### PR TITLE
feat: add image-gen to Media & Image Generation category

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
     - [Documentation](#documentation)
     - [Git Workflow](#git-workflow)
     - [Marketing Growth](#marketing-growth)
+    - [Media & Image Generation](#media--image-generation)
     - [Project & Product Management](#project--product-management)
     - [Security, Compliance, & Legal](#security-compliance--legal)
 * [Tutorials](#tutorials)
@@ -167,6 +168,9 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
 - [twitter-engager](./plugins/twitter-engager)
+
+### Media & Image Generation
+- [image-gen](https://github.com/shipdeckai/claude-skills) - AI image generation with 10 providers (OpenAI DALL-E, BFL FLUX, Stability AI, Ideogram, Google Gemini, FAL, Leonardo, Recraft, Replicate, ClipDrop). Intelligent provider selection and automatic fallbacks.
 
 ### Project & Product Management
 - [discuss](./plugins/discuss)


### PR DESCRIPTION
## Summary

Added **image-gen** plugin to a new **Media & Image Generation** category.

### Plugin Details
- **Repository**: https://github.com/shipdeckai/claude-skills
- **Website**: https://shipdeckai.github.io/image-gen

### Features
- Unified AI image generation interface supporting **10 providers**:
  - OpenAI DALL-E 3
  - BFL FLUX.2 (up to 4K resolution)
  - Stability AI SDXL
  - Ideogram v3 (best for typography)
  - Google Gemini Imagen
  - FAL, Leonardo, Recraft, Replicate, ClipDrop
- **Intelligent provider selection** - Claude automatically picks the best provider for each prompt
- **Automatic fallbacks** - If one provider fails, it tries the next

### Installation
\`\`\`
/plugin marketplace add shipdeckai/claude-skills
/plugin install image-gen@shipdeckai/claude-skills
\`\`\`

### Why a new category?
Image generation is a distinct use case that doesn't fit well into existing categories. This opens the door for other media generation plugins (video, audio, etc.) in the future.