### PR TITLE
Add plannotator to Project & Product Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [explore](./plugins/explore)
 - [plan](./plugins/plan)
 - [planning-prd-agent](./plugins/planning-prd-agent)
+- [plannotator](https://github.com/backnotprop/plannotator) - Interactive plan review UI with visual annotation (install via `/plugin marketplace add backnotprop/plannotator`)
 - [prd-specialist](./plugins/prd-specialist)
 - [project-shipper](./plugins/project-shipper)
 - [sprint-prioritizer](./plugins/sprint-prioritizer)


### PR DESCRIPTION
## Summary

Adding [plannotator](https://github.com/backnotprop/plannotator) to the Project & Product Management section.

## About Plannotator

Plannotator is a Claude Code plugin that provides an interactive plan review UI:

- Intercepts `ExitPlanMode` via hooks to provide visual review interface
- Visual annotation with comments, deletions, and replacements
- Offline URL sharing with compression
- Obsidian and Bear integration
- Configurable plan saving

**Install:** `/plugin marketplace add backnotprop/plannotator`

Note: This is an external marketplace plugin rather than a local plugin directory. Included install command in the listing for clarity.