### PR TITLE
Add agent-manager-skill plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -91,6 +91,26 @@
       ]
     },
     {
+      "name": "agent-manager-skill",
+      "source": "./plugins/agent-manager-skill",
+      "description": "Orchestrate multiple local CLI agents via tmux using agent-manager-skill (start/stop/monitor/assign + cron-friendly scheduling).",
+      "version": "0.1.0",
+      "author": {
+        "name": "fractalmind-ai",
+        "url": "https://github.com/fractalmind-ai"
+      },
+      "category": "Workflow Orchestration",
+      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/agent-manager-skill",
+      "keywords": [
+        "workflow",
+        "orchestration",
+        "tmux",
+        "agents",
+        "monitoring",
+        "scheduling"
+      ]
+    },
+    {
       "name": "code-review",
       "source": "./plugins/code-review",
       "description": "Perform a comprehensive code review of recent changes",

--- a/README-zh.md
+++ b/README-zh.md
@@ -56,6 +56,7 @@
 
 ### 工作流编排
 - [angelos-symbo](./plugins/angelos-symbo)
+- [agent-manager-skill](./plugins/agent-manager-skill)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Workflow Orchestration
 - [angelos-symbo](./plugins/angelos-symbo)
+- [agent-manager-skill](./plugins/agent-manager-skill)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)

--- a/plugins/agent-manager-skill/.claude-plugin/plugin.json
+++ b/plugins/agent-manager-skill/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "agent-manager-skill",
+  "description": "Orchestrate multiple local CLI agents via tmux using agent-manager-skill (start/stop/monitor/assign + cron-friendly scheduling).",
+  "version": "0.1.0",
+  "author": {
+    "name": "fractalmind-ai",
+    "url": "https://github.com/fractalmind-ai"
+  },
+  "homepage": "https://github.com/fractalmind-ai/agent-manager-skill"
+}

--- a/plugins/agent-manager-skill/commands/agent-manager-skill.md
+++ b/plugins/agent-manager-skill/commands/agent-manager-skill.md
@@ -1,0 +1,48 @@
+---
+description: Use /agent-manager-skill to orchestrate multiple local CLI agents via tmux using agent-manager-skill (start/stop/monitor/assign + cron-friendly scheduling).
+author: fractalmind-ai
+version: 0.1.0
+---
+
+## Usage
+
+`/agent-manager-skill <TASK>`
+
+## Goal
+
+Help the user run and coordinate multiple local agents in parallel using `tmux`.
+
+## Instructions
+
+1. Ask the user where `agent-manager-skill` is installed (or have them clone it):
+
+   ```bash
+   git clone https://github.com/fractalmind-ai/agent-manager-skill.git
+   ```
+
+2. Run a quick environment check:
+
+   ```bash
+   python3 agent-manager/scripts/main.py doctor
+   ```
+
+3. List configured agents:
+
+   ```bash
+   python3 agent-manager/scripts/main.py list
+   ```
+
+4. Based on the user task ($ARGUMENTS), start/assign/monitor agents:
+
+   ```bash
+   python3 agent-manager/scripts/main.py start EMP_0001
+   python3 agent-manager/scripts/main.py assign EMP_0001 <<'EOF'
+   $ARGUMENTS
+   EOF
+   python3 agent-manager/scripts/main.py monitor EMP_0001 --follow
+   ```
+
+## Output
+
+- Summarize which agents were started and what they are doing.
+- Provide the exact commands to reproduce.


### PR DESCRIPTION
Adds agent-manager-skill as a Workflow Orchestration plugin entry, including a plugin folder and marketplace metadata.