### PR TITLE
feat: add openclaw-setup plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,25 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "openclaw-setup",
+      "description": "One command to install and secure OpenClaw AI Assistant. Generates security tokens, applies hardened configs, blocks dangerous tools.",
+      "version": "1.0.0",
+      "author": {
+        "name": "cathy-kim",
+        "url": "https://github.com/cathy-kim"
+      },
+      "source": "./plugins/openclaw-setup",
+      "category": "Security, Compliance, & Legal",
+      "homepage": "https://github.com/cathy-kim/openclaw-plugin",
+      "keywords": [
+        "security",
+        "setup",
+        "automation",
+        "openclaw",
+        "ai-assistant"
+      ]
     }
   ]
 }

--- a/plugins/openclaw-setup/.claude-plugin/plugin.json
+++ b/plugins/openclaw-setup/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "openclaw-setup",
+  "displayName": "OpenClaw Setup",
+  "description": "One command to install and secure OpenClaw AI Assistant. Generates security tokens, applies hardened configs, blocks dangerous tools.",
+  "version": "1.0.0",
+  "author": {
+    "name": "cathy-kim",
+    "url": "https://github.com/cathy-kim"
+  },
+  "license": "MIT",
+  "repository": "https://github.com/cathy-kim/openclaw-plugin",
+  "homepage": "https://github.com/cathy-kim/openclaw-plugin",
+  "keywords": [
+    "openclaw",
+    "security",
+    "setup",
+    "ai-assistant",
+    "automation"
+  ]
+}

--- a/plugins/openclaw-setup/skills/openclaw-setup/SKILL.md
+++ b/plugins/openclaw-setup/skills/openclaw-setup/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: openclaw-setup
+description: |
+  Install and secure OpenClaw AI Assistant in one command.
+  Generates 32-byte security token, applies hardened config, blocks dangerous tools.
+  Use when: "openclaw", "clawbot", "install", "security setup"
+userInvocable: true
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - Edit
+version: "1.0.0"
+---
+
+# OpenClaw Setup
+
+> **One command. Full security.**
+
+Install and configure [OpenClaw](https://openclaw.ai) AI Assistant with paranoid-level security defaults.
+
+## Usage
+
+```bash
+/openclaw-setup              # Full install + security
+/openclaw-setup install      # Install only
+/openclaw-setup security     # Security config only
+/openclaw-setup audit        # Security audit only
+```
+
+## What It Does
+
+### Phase 1: Installation
+```bash
+which openclaw || curl -fsSL https://openclaw.ai/install.sh | bash
+openclaw --version
+```
+
+### Phase 2: Generate Security Token
+```bash
+openssl rand -base64 32
+```
+
+### Phase 3: Create Secure Config
+
+Creates `~/.openclaw/openclaw.json` with:
+
+| Setting | Value | Effect |
+|---------|-------|--------|
+| Gateway | `loopback` | Local access only |
+| Auth | `token` | 32-byte token required |
+| DM Policy | `pairing` | Pairing code required |
+| Sandbox | `mode: all` | All tools sandboxed |
+| Workspace | `ro` | Read-only |
+| Dangerous tools | `deny` | exec, write, browser blocked |
+
+### Phase 4: Harden Permissions
+```bash
+chmod 700 ~/.openclaw
+chmod 600 ~/.openclaw/openclaw.json
+```
+
+### Phase 5: Run Audit
+```bash
+openclaw security audit
+```
+
+## Blocked Tools
+- `exec` - Shell execution
+- `write` / `edit` - File modification
+- `browser` - Browser automation
+- `process` - Process control
+- `apply_patch` - Code patches
+
+## Allowed Tools
+- `read` - File reading
+- `search` - Code search
+- `web_search` / `web_fetch` - Web access
+
+## After Setup
+
+```bash
+openclaw onboard                      # Complete setup
+openclaw channels login whatsapp      # Connect WhatsApp
+openclaw status                       # Verify
+```
+
+## Links
+
+- [OpenClaw Docs](https://docs.openclaw.ai)
+- [Security Guide](https://docs.openclaw.ai/security)
+- [Plugin Repository](https://github.com/cathy-kim/openclaw-plugin)
+
+---
+
+**Version**: 1.0.0


### PR DESCRIPTION
## Summary

Add **openclaw-setup** plugin to the marketplace.

**One command to install and secure OpenClaw AI Assistant:**

```bash
/openclaw-setup
```

## Features

- 32-byte cryptographic token generation
- Hardened config with loopback-only gateway binding
- Sandbox mode enabled by default
- Dangerous tools blocked (exec, write, browser, apply_patch)
- File permissions hardened (700/600)
- Security audit integration

## Before/After

| Before | After |
|--------|-------|
| Gateway exposed to network | Loopback only |
| No authentication | 32-byte token required |
| Anyone can DM your bot | Pairing code required |
| Full tool access | Dangerous tools blocked |

## Category

Security, Compliance, & Legal

## Links

- [Plugin Repository](https://github.com/cathy-kim/openclaw-plugin)
- [OpenClaw Docs](https://docs.openclaw.ai)