### PR TITLE
Add agentkits-memory and agentkits-marketing plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [whimsy-injector](./plugins/whimsy-injector)
 
 ### Development Engineering
+- [agentkits-memory](./plugins/agentkits-memory)
 - [ai-engineer](./plugins/ai-engineer)
 - [api-integration-specialist](./plugins/api-integration-specialist)
 - [backend-architect](./plugins/backend-architect)
@@ -160,6 +161,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [update-branch-name](./plugins/update-branch-name)
 
 ### Marketing Growth
+- [agentkits-marketing](./plugins/agentkits-marketing)
 - [app-store-optimizer](./plugins/app-store-optimizer)
 - [content-creator](./plugins/content-creator)
 - [growth-hacker](./plugins/growth-hacker)

--- a/plugins/agentkits-marketing/.claude-plugin/plugin.json
+++ b/plugins/agentkits-marketing/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "agentkits-marketing",
+  "description": "Complete AI marketing toolkit with 18 specialized agents, 93 slash commands, 28 skills, and 19 training modules",
+  "version": "1.4.0",
+  "author": {
+    "name": "AityTech"
+  },
+  "homepage": "https://github.com/aitytech/agentkits-marketing",
+  "repository": "https://github.com/aitytech/agentkits-marketing",
+  "license": "MIT",
+  "keywords": ["marketing", "agents", "seo", "cro", "copywriting", "email"]
+}

--- a/plugins/agentkits-marketing/README.md
+++ b/plugins/agentkits-marketing/README.md
@@ -1,0 +1,27 @@
+# AgentKits Marketing
+
+Complete AI marketing toolkit — 18 specialized agents, 93 slash commands, 28 marketing skills, and 19 training modules in 11 languages.
+
+## Features
+
+- **18 Agents** covering the full customer lifecycle (attraction, conversion, retention, expansion)
+- **93 Slash Commands** across 22 categories (campaigns, content, SEO, CRO, email, social, competitive analysis)
+- **28 Marketing Skills** — deep knowledge bases including Marketing Psychology (70+ mental models), CRO Stack (7 frameworks), Programmatic SEO, Launch Strategy
+- **19 Training Modules** in 11 languages — interactive marketing education inside your IDE
+- **Quality Reviewers** — brand voice guardian, data analyst, and marketing strategist agents
+
+## Install
+
+```bash
+# Via Claude Code Plugin Marketplace
+/plugin marketplace add agentkits-marketing
+/plugin install agentkits-marketing@agentkits-marketing
+
+# Or via npm
+npx @aitytech/agentkits-marketing install
+```
+
+## Links
+
+- **GitHub:** https://github.com/aitytech/agentkits-marketing
+- **Homepage:** https://www.agentkits.net/marketing

--- a/plugins/agentkits-memory/.claude-plugin/plugin.json
+++ b/plugins/agentkits-memory/.claude-plugin/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "agentkits-memory",
+  "description": "Persistent memory system for AI coding assistants with hybrid search, session tracking, and web viewer",
+  "version": "2.2.0",
+  "author": {
+    "name": "AityTech"
+  },
+  "homepage": "https://github.com/aitytech/agentkits-memory",
+  "repository": "https://github.com/aitytech/agentkits-memory",
+  "license": "MIT",
+  "keywords": ["memory", "context", "persistence", "mcp", "sessions"]
+}

--- a/plugins/agentkits-memory/README.md
+++ b/plugins/agentkits-memory/README.md
@@ -1,0 +1,29 @@
+# AgentKits Memory
+
+Persistent memory system for AI coding assistants — saves decisions, patterns, errors, and context across sessions via MCP.
+
+## Features
+
+- **MCP Server** with 8 tools: `memory_save`, `memory_search`, `memory_timeline`, `memory_details`, `memory_recall`, `memory_list`, `memory_update`, `memory_delete`
+- **Hybrid Search** combining SQLite FTS5 full-text search with vector embeddings
+- **Session Management** with automatic summarization
+- **Context Hooks** for SessionStart, UserPromptSubmit, PostToolUse, and Stop events
+- **Web Viewer** for browsing memories visually
+- **No Daemon** — single SQLite file, zero infrastructure
+
+## Install
+
+```bash
+# Via Claude Code Plugin Marketplace
+/plugin marketplace add agentkits-memory
+/plugin install agentkits-memory@agentkits-memory
+
+# Or via npm
+npx @aitytech/agentkits-memory install
+```
+
+## Links
+
+- **GitHub:** https://github.com/aitytech/agentkits-memory
+- **npm:** https://www.npmjs.com/package/@aitytech/agentkits-memory
+- **Homepage:** https://www.agentkits.net/memory


### PR DESCRIPTION
## Summary

Adding two plugins from the AgentKits suite:

### agentkits-memory (Development Engineering)
Persistent memory system for AI coding assistants with:
- MCP server with 8 tools (save, search, timeline, details, recall, list, update, delete)
- Hybrid search (SQLite FTS5 + vector embeddings)
- Session tracking with automatic summarization
- Context hooks for SessionStart, UserPromptSubmit, PostToolUse, Stop
- Web viewer for browsing memories
- No daemon — single SQLite file

**GitHub:** https://github.com/aitytech/agentkits-memory
**npm:** https://www.npmjs.com/package/@aitytech/agentkits-memory

### agentkits-marketing (Marketing Growth)
Complete AI marketing toolkit with:
- 18 specialized agents (attraction, conversion, retention, expansion)
- 93 slash commands across 22 categories
- 28 marketing skills (Marketing Psychology, CRO Stack, SEO, etc.)
- 19 training modules in 11 languages

**GitHub:** https://github.com/aitytech/agentkits-marketing

Both are MIT licensed and available via Claude Code Plugin Marketplace.