### PR TITLE
Add AgentStore marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Example:
 /plugin install analyze-codebase
 ```
 
+## Marketplaces
+
+- [AgentStore](https://github.com/techgangboss/agentstore) - Open-source plugin marketplace with gasless USDC payments. Install via `/plugin marketplace add techgangboss/agentstore`. Publishers earn 80% of sales. Agent-first API for zero-auth publishing.
+
 ## Contributing
 
 Contributions are welcome!


### PR DESCRIPTION
## AgentStore

[AgentStore](https://github.com/techgangboss/agentstore) is an open-source marketplace for Claude Code plugins with gasless USDC payments.

**Install as a marketplace:**
```
/plugin marketplace add techgangboss/agentstore
```

**For publishers — publish in 2 HTTP calls, zero auth for free agents:**
```bash
curl -X POST https://api.agentstore.tools/api/publishers \
  -H "Content-Type: application/json" \
  -d '{"name":"my-publisher","display_name":"My Publisher"}'

curl -X POST https://api.agentstore.tools/api/publishers/agents/simple \
  -H "Content-Type: application/json" \
  -d '{"publisher_id":"my-publisher","name":"My Agent","description":"What it does"}'
```

- License: MIT
- Website: https://agentstore.tools
- npm: https://www.npmjs.com/package/agentstore