### PR TITLE
Add Raysurfer Code Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
+- [raysurfer-code-caching](https://github.com/rayxc-org/raysurfer-code-caching-tool) - Automatic code caching plugin. Checks cache before generation and uploads successful results.
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)


### PR DESCRIPTION
## Summary
- Adds [raysurfer-code-caching](https://github.com/rayxc-org/raysurfer-code-caching-tool) to the **Development Engineering** section

Raysurfer is an automatic code caching plugin for Claude Code that checks cache before generation and uploads successful results.

## Test plan
- [ ] Verify entry appears in the Development Engineering section
- [ ] Verify link resolves to a valid GitHub repository
- [ ] Verify entry format matches existing entries in the section