### PR TITLE
Add Claudebin to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Example:
 /plugin install analyze-codebase
 ```
 
+## Resources
+
+- [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.
+
 ## Contributing
 
 Contributions are welcome!


### PR DESCRIPTION
Adding [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - a minimalistic tool for publishing and sharing Claude coding sessions.