### PR TITLE
Add wondelai/skills marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
 - [twitter-engager](./plugins/twitter-engager)
+- [wondelai-skills](https://github.com/wondelai/skills)
 
 ### Project & Product Management
 - [discuss](./plugins/discuss)


### PR DESCRIPTION
Adds [wondelai/skills](https://github.com/wondelai/skills) to Marketing Growth — a marketplace of 25 agent skills for UX design, marketing/CRO, sales, product strategy, and growth. Install: `npx skills add wondelai/skills`. License: MIT.