### PR TITLE
Add context-memory plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,25 @@
   },
   "plugins": [
     {
+      "name": "context-memory",
+      "source": "./plugins/context-memory",
+      "description": "Persistent, searchable context storage across Claude Code sessions using SQLite + FTS5.",
+      "version": "1.3.1",
+      "author": {
+        "name": "ErebusEnigma",
+        "url": "https://github.com/ErebusEnigma"
+      },
+      "category": "Development Engineering",
+      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/context-memory",
+      "keywords": [
+        "memory",
+        "context",
+        "search",
+        "sessions",
+        "persistence"
+      ]
+    },
+    {
       "name": "documentation-generator",
       "source": "./plugins/documentation-generator",
       "description": "Create comprehensive documentation for code, APIs, and projects.",

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [api-integration-specialist](./plugins/api-integration-specialist)
 - [backend-architect](./plugins/backend-architect)
 - [code-architect](./plugins/code-architect)
+- [context-memory](./plugins/context-memory)
 - [desktop-app-dev](./plugins/desktop-app-dev)
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)

--- a/plugins/context-memory/.claude-plugin/plugin.json
+++ b/plugins/context-memory/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "context-memory",
+  "description": "Persistent, searchable context storage across Claude Code sessions using SQLite + FTS5",
+  "version": "1.3.1",
+  "author": {
+    "name": "ErebusEnigma",
+    "url": "https://github.com/ErebusEnigma"
+  },
+  "repository": "https://github.com/ErebusEnigma/context-memory",
+  "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/context-memory",
+  "keywords": [
+    "memory",
+    "context",
+    "sqlite",
+    "fts5",
+    "search",
+    "sessions",
+    "persistence"
+  ]
+}

--- a/plugins/context-memory/commands/remember.md
+++ b/plugins/context-memory/commands/remember.md
@@ -1,0 +1,110 @@
+---
+allowed-tools: Bash(python:*)
+description: "Save the current session to persistent context memory"
+argument-hint: "[note]"
+---
+
+# /remember Command
+
+Save the current session to context memory with an optional annotation.
+
+## Usage
+
+```
+/remember [note]
+```
+
+**Arguments:**
+- `note` (optional): A personal annotation or tag to help find this session later
+
+## Examples
+
+```
+/remember
+/remember "Fixed the auth bug with refresh tokens"
+/remember "Important: OAuth2 implementation details"
+```
+
+## Workflow
+
+When the user runs `/remember`:
+
+1. **Generate Session Summary**
+
+   Analyze the current conversation and create:
+
+   - **brief**: A single sentence summarizing what was accomplished
+   - **detailed**: 2-3 paragraphs with full context of what happened
+   - **key_decisions**: List of important decisions made during the session
+   - **problems_solved**: List of problems that were resolved
+   - **technologies**: List of technologies, frameworks, or tools discussed
+   - **outcome**: One of: `success`, `partial`, `abandoned`
+
+2. **Extract Topics**
+
+   Identify 3-8 relevant topics from the conversation. Use lowercase, common terms like:
+   - Technology names: `react`, `python`, `sqlite`
+   - Concepts: `authentication`, `debugging`, `refactoring`
+   - Domains: `api`, `frontend`, `database`
+
+3. **Identify Key Code**
+
+   If significant code was written or discussed, extract important snippets with:
+   - The code itself
+   - The programming language
+   - A brief description of what it does
+   - The file path if applicable
+
+4. **Extract Key Messages**
+
+   Select 5-15 important messages from the conversation that capture:
+   - The initial request/problem statement
+   - Key decisions and their reasoning
+   - Solution descriptions
+   - Important caveats or warnings
+
+5. **Pipe JSON via Stdin and Save to Database**
+
+   Pipe JSON directly via `--json -` (stdin):
+
+   ```bash
+   python "~/.claude/skills/context-memory/scripts/db_save.py" --json - << 'ENDJSON'
+   {
+     "session_id": "<UNIQUE_ID>",
+     "project_path": "<PROJECT_PATH>",
+     "messages": [
+       {"role": "user", "content": "The initial question or request"},
+       {"role": "assistant", "content": "The response or solution"}
+     ],
+     "summary": {
+       "brief": "One-line summary of what was accomplished",
+       "detailed": "2-3 paragraphs with full context...",
+       "key_decisions": ["Decision 1", "Decision 2"],
+       "problems_solved": ["Problem 1", "Problem 2"],
+       "technologies": ["python", "sqlite", "fts5"],
+       "outcome": "success"
+     },
+     "topics": ["topic1", "topic2", "topic3"],
+     "code_snippets": [
+       {
+         "code": "def example(): pass",
+         "language": "python",
+         "description": "What this code does",
+         "file_path": "src/example.py"
+       }
+     ],
+     "user_note": "User's note if provided, or null"
+   }
+   ENDJSON
+   ```
+
+6. **Confirm to User**
+
+   Report back: confirmation, brief summary, topics, message/snippet counts, user note.
+
+## Notes
+
+- Requires the full context-memory plugin: https://github.com/ErebusEnigma/context-memory
+- Install with: `git clone https://github.com/ErebusEnigma/context-memory && cd context-memory && python install.py`
+- Sessions are stored globally and can be searched across all projects
+- Use `/recall` to search past sessions

--- a/plugins/context-memory/skills/context-memory/SKILL.md
+++ b/plugins/context-memory/skills/context-memory/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: "context-memory"
+description: >
+  Saves and searches past Claude Code sessions so context, decisions, and
+  code persist across conversations. Use when user says 'remember this',
+  'save this session', 'recall', 'search past sessions', 'what did we
+  discuss about', or 'find previous work on'. Do NOT use for general file
+  storage, note-taking, or bookmark management.
+license: "MIT"
+compatibility: "Requires Python >= 3.8 with sqlite3 FTS5 support (included in standard library). MCP server requires Python >= 3.10. Claude Code CLI only."
+allowed-tools: "Bash(python:*)"
+metadata:
+  author: "ErebusEnigma"
+  version: "1.3.1"
+---
+
+# Context Memory Skill
+
+Saves and searches past Claude Code sessions so context, decisions, and code persist across conversations.
+
+## Trigger Phrases
+
+Activate this skill when the user says:
+- "remember this" / "save this session" / "store this for later"
+- "recall" / "search past sessions"
+- "what did we discuss about..."
+- "find previous work on..."
+- "look up past decisions about..."
+- "context memory"
+
+## Features
+
+- **Cross-session memory** - Save and recall past work across Claude Code sessions
+- **Structured AI summaries** - Rich summaries with decisions, problems solved, technologies, outcome
+- **Full-text search** - FTS5 with Porter stemming for fast, fuzzy search
+- **Two-tier retrieval** - Summary-ranked search (<10ms) + deep content fetch (<50ms)
+- **Auto-save on exit** - Stop hook captures session context automatically
+- **Pre-compact checkpoints** - Saves full conversation before context compaction
+- **Web dashboard** - Full SPA with analytics (optional, requires flask)
+- **MCP server** - Six tools for programmatic access (optional, requires Python >= 3.10)
+
+## Installation
+
+```bash
+git clone https://github.com/ErebusEnigma/context-memory.git
+cd context-memory
+python install.py
+```
+
+## Commands
+
+### /remember [note]
+Save the current session with an optional annotation.
+
+### /recall <query> [options]
+Search past sessions.
+- `--project`: Limit to current project
+- `--detailed`: Include full message content and code snippets
+- `--limit N`: Maximum results (default: 10)
+
+## Source Repository
+
+https://github.com/ErebusEnigma/context-memory


### PR DESCRIPTION
## Summary

Adds the **context-memory** plugin — persistent, searchable context storage across Claude Code sessions using SQLite + FTS5.

**Source repository:** https://github.com/ErebusEnigma/context-memory

### What it does

- `/remember` saves sessions with AI-generated structured summaries, topics, and code snippets
- `/recall` searches past sessions with two-tier FTS5 full-text search (<50ms)
- Auto-save hook captures context on exit; pre-compact hook preserves full conversation before compaction
- Optional web dashboard with analytics, and MCP server for programmatic access
- 364 tests, zero core dependencies, cross-platform (Windows/macOS/Linux)

### Changes

- Added `plugins/context-memory/` with plugin.json, commands, and skill definition
- Added entry in README under Development Engineering
- Added entry in marketplace.json