### PR TITLE
Add nano-banana: Google Gemini image generation plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [brand-guardian](./plugins/brand-guardian)
 - [joker](./plugins/joker)
 - [mobile-ux-optimizer](./plugins/mobile-ux-optimizer)
+- [nano-banana](https://github.com/Ibrahim-3d/nano-banana-claude-plugin) - Google Gemini image generation plugin. Text-to-image, text-guided image editing, style transfer, 4K output, search grounding, and multi-reference composition via `/genimage`. Uses `gemini-2.5-flash-image` (fast) and `gemini-3-pro-image-preview` (4K/search).
 - [onomastophes](./plugins/onomastophes)
 - [ui-designer](./plugins/ui-designer)
 - [ux-researcher](./plugins/ux-researcher)


### PR DESCRIPTION
## Plugin: Nano Banana

**Repository:** https://github.com/Ibrahim-3d/nano-banana-claude-plugin

**What it does:**
Nano Banana brings Google Gemini's native image generation capabilities into Claude Code through a single `/genimage` slash command, an autonomous AI agent, and 8 Python scripts covering every Gemini image mode.

**Capabilities:**
- `/genimage` slash command with smart routing — agent picks the right script automatically
- Text-to-image via `gemini-2.5-flash-image`
- Text-guided image editing: inpainting, add/remove objects, background replacement, bring sketches to life
- Style transfer between two images
- Multi-image composition (up to 14 reference images)
- 4K resolution generation (up to 4096×4096) via `gemini-3-pro-image-preview`
- Google Search grounded generation (real-time data)
- Multi-turn iterative editing with memory

**Quick demo after install:**
```
/genimage a watercolor painting of a lighthouse during a storm, dramatic sky, 16:9
```

**Install:**
```bash
/plugin marketplace add Ibrahim-3d/nano-banana-claude-plugin
/plugin install nano-banana@nano-banana
```

**Links:**
- GitHub: https://github.com/Ibrahim-3d/nano-banana-claude-plugin
- License: MIT