### PR TITLE
Add Plan-Build-Run — context-engineered workflow orchestration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
+- [plan-build-run](./plugins/plan-build-run)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
 - [studio-coach](./plugins/studio-coach)
 - [ultrathink](./plugins/ultrathink)

--- a/plugins/plan-build-run/.claude-plugin/plugin.json
+++ b/plugins/plan-build-run/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "pbr",
+  "description": "Plan-Build-Run — Context-engineered development workflow for Claude Code. Solves context rot through subagent delegation, structured planning, atomic execution, and goal-backward verification.",
+  "version": "2.0.0",
+  "author": {
+    "name": "SienkLogic",
+    "email": "dave@sienklogic.com"
+  },
+  "homepage": "https://github.com/SienkLogic/plan-build-run",
+  "repository": "https://github.com/SienkLogic/plan-build-run",
+  "license": "MIT",
+  "keywords": [
+    "claude-code",
+    "context-engineering",
+    "development-workflow",
+    "subagent-delegation"
+  ]
+}

--- a/plugins/plan-build-run/README.md
+++ b/plugins/plan-build-run/README.md
@@ -1,0 +1,25 @@
+# Plan-Build-Run
+
+Context-engineered development workflow for Claude Code. Solves context rot through disciplined subagent delegation, structured planning, atomic execution, and goal-backward verification.
+
+## Features
+
+- Keeps orchestrator at ~15% context by delegating to fresh 200k-token subagent windows
+- 21 `/pbr:*` slash commands covering the full development lifecycle
+- 10 specialized agents (researcher, planner, executor, verifier, etc.)
+- 15 lifecycle hooks enforcing commit format, context budget, plan compliance
+- Wave-based parallel execution with atomic commits
+- Goal-backward verification (checks codebase against must-haves, not just task completion)
+- Kill-safe: all state lives on disk in `.planning/`
+
+## Install
+
+```bash
+claude plugin marketplace add SienkLogic/plan-build-run
+claude plugin install pbr@plan-build-run
+```
+
+## Links
+
+- **Repository**: https://github.com/SienkLogic/plan-build-run
+- **License**: MIT


### PR DESCRIPTION
## Add Plan-Build-Run

**Category**: Workflow Orchestration

Plan-Build-Run is a Claude Code plugin that solves context rot — quality degradation as
the context window fills during long sessions. It keeps the main orchestrator lean
(~15% context) by delegating work to fresh subagent contexts.

### What's included
- `plugins/plan-build-run/.claude-plugin/plugin.json` — plugin metadata
- `plugins/plan-build-run/README.md` — plugin description and install instructions
- `README.md` — entry added to Workflow Orchestration section

### Key features
- 21 `/pbr:*` slash commands covering the full dev lifecycle
- 10 specialized agents with configurable model profiles
- 15 lifecycle hooks enforcing discipline at zero token cost
- Wave-based parallel execution with atomic commits
- Goal-backward verification
- Kill-safe file-based state
- 780+ tests, CI on Node 18/20/22 x Windows/macOS/Linux

**Repo**: https://github.com/SienkLogic/plan-build-run