### PR TITLE
Add Mantra – session time-machine for AI coding tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
+- [Mantra](https://github.com/mantra-hq/mantra-releases) - A local-first session time-machine for AI coding tools (Claude Code, Cursor, Windsurf, Augment Code). Automatically snapshots sessions and lets you browse/restore any previous conversation state.
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)


### PR DESCRIPTION
## Summary

- Adds [Mantra](https://github.com/mantra-hq/mantra-releases) to the **Development Engineering** section
- Mantra is a local-first session time-machine for AI coding tools (Claude Code, Cursor, Gemini CLI, Codex, Augment Code (Windsurf: In Development)) that automatically snapshots sessions and lets you browse/restore any previous conversation state
- Install: `curl -fsSL https://mantra.gonewx.com/install.sh | bash`

## Links

- Website: https://mantra.gonewx.com
- GitHub: https://github.com/mantra-hq/mantra-releases

## Checklist

- [x] Added to the appropriate section (Development Engineering)
- [x] Follows existing list format
- [x] Entry placed in alphabetical order