### PR TITLE
Add Speech AI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [studio-coach](./plugins/studio-coach)
 - [ultrathink](./plugins/ultrathink)
 
+### AI & Speech
+- [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.
+
 ### Automation DevOps
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)


### PR DESCRIPTION
## Summary

Adds **Speech AI** plugin under a new **AI & Speech** category.

Speech AI is a Claude Code plugin providing:
- **Pronunciation assessment** with phoneme-level scoring (17MB model, <300ms latency)
- **Text-to-speech** synthesis
- **Speech-to-text** transcription
- 8 MCP tools for language learning, accessibility, and voice applications

This enables Claude Code users to add speech capabilities to their AI agents and applications.

## Checklist
- [x] New category added for AI & Speech tools (none existed)
- [x] Entry follows the existing format
- [x] Link points to a public GitHub repository with documentation