### PR TITLE
Add Context Mode — sandbox large outputs, return only summaries

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -58,6 +58,7 @@
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [context-mode](./plugins/context-mode)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [context-mode](./plugins/context-mode)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/plugins/context-mode/.claude-plugin/plugin.json
+++ b/plugins/context-mode/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "context-mode",
+  "description": "MCP server that processes large outputs in sandboxed subprocesses and returns concise summaries instead of dumping raw data into the context window. Reduces token usage by up to 98%.",
+  "version": "1.0.0",
+  "author": {
+    "name": "mksglu"
+  },
+  "homepage": "https://github.com/mksglu/claude-context-mode"
+}

--- a/plugins/context-mode/agents/context-mode.md
+++ b/plugins/context-mode/agents/context-mode.md
@@ -1,0 +1,47 @@
+# Context Mode
+
+An MCP server that processes large outputs in sandboxed subprocesses instead of dumping raw data into the context window. Returns only concise summaries — same analysis, up to 98% less context usage.
+
+## Problem
+
+Large command outputs (logs, API responses, Playwright snapshots, git history) flood the context window with hundreds of kilobytes of raw data, burning tokens and degrading session quality.
+
+## Solution
+
+Context Mode intercepts these outputs, processes them in isolated subprocesses with 10 language runtimes, and returns structured summaries. A SQLite FTS5 knowledge base with BM25 ranking stores indexed content for later retrieval.
+
+## Performance
+
+| Operation | Raw Output | With Context Mode | Savings |
+|---|---|---|---|
+| Playwright snapshot | 56.2 KB | 299 B | 99% |
+| GitHub Issues (20) | 58.9 KB | 1.1 KB | 98% |
+| Access log (500 req) | 45.1 KB | 155 B | 100% |
+| Git log (153 commits) | 11.6 KB | 107 B | 99% |
+
+## MCP Tools
+
+- `execute` — Run code in a sandboxed subprocess and return a summary
+- `execute_file` — Execute a file in a sandboxed subprocess
+- `index` — Index content into the SQLite FTS5 knowledge base
+- `search` — Search indexed content with BM25 ranking
+- `fetch_and_index` — Fetch a URL, process it, and index the result
+
+## Supported Runtimes
+
+JavaScript, TypeScript, Python, Ruby, PHP, Perl, Lua, R, jq, Shell (bash/zsh)
+
+## Authenticated CLI Passthrough
+
+Supports `gh`, `aws`, `gcloud`, `kubectl`, `docker`, and other CLI tools with credential passthrough.
+
+## Install
+
+```bash
+claude mcp add context-mode -- npx -y context-mode
+```
+
+## Links
+
+- GitHub: https://github.com/mksglu/claude-context-mode
+- npm: https://www.npmjs.com/package/context-mode


### PR DESCRIPTION
## Context Mode

A Claude Code plugin that processes large outputs in sandboxed subprocesses instead of dumping raw data into the context window.

**Without Context Mode:** 315 KB of raw data burns ~80K tokens per session  
**With Context Mode:** 5.4 KB of clean summaries — same analysis, 98% less context

| Operation | Raw Output | With Context Mode | Savings |
|---|---|---|---|
| Playwright snapshot | 56.2 KB | 299 B | 99% |
| GitHub Issues (20) | 58.9 KB | 1.1 KB | 98% |
| Access log (500 req) | 45.1 KB | 155 B | 100% |
| Git log (153 commits) | 11.6 KB | 107 B | 99% |

## Features

- 5 MCP tools: `execute`, `execute_file`, `index`, `search`, `fetch_and_index`
- 10 language runtimes
- SQLite FTS5 knowledge base with BM25 ranking
- Authenticated CLI passthrough (gh, aws, gcloud, kubectl, docker)

## Install

```bash
claude mcp add context-mode -- npx -y context-mode
```

- GitHub: https://github.com/mksglu/claude-context-mode
- npm: https://www.npmjs.com/package/context-mode