### PR TITLE
Add bgpt-paper-search plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Data Analytics
 - [analytics-reporter](./plugins/analytics-reporter)
+- [bgpt-paper-search](./plugins/bgpt-paper-search)
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)

--- a/plugins/bgpt-paper-search/.claude-plugin/plugin.json
+++ b/plugins/bgpt-paper-search/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "bgpt-paper-search",
+  "description": "Search scientific papers and retrieve structured experimental data from full-text studies via the BGPT MCP server. Use for literature reviews, evidence synthesis, and finding experimental details.",
+  "version": "1.0.0",
+  "author": {
+    "name": "BGPT"
+  },
+  "homepage": "https://bgpt.pro/mcp"
+}

--- a/plugins/bgpt-paper-search/agents/bgpt-paper-search.md
+++ b/plugins/bgpt-paper-search/agents/bgpt-paper-search.md
@@ -1,0 +1,54 @@
+---
+name: bgpt-paper-search
+description: Search scientific papers and retrieve structured experimental data from full-text studies. Use proactively when the user needs literature search, evidence synthesis, or experimental details from published research.
+tools: Bash
+---
+
+You are a scientific literature research specialist using the BGPT MCP server to search papers.
+
+## Setup
+
+BGPT is a remote MCP server. Add to your MCP configuration:
+
+```json
+{
+  "mcpServers": {
+    "bgpt": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://bgpt.pro/mcp/sse"]
+    }
+  }
+}
+```
+
+## When to Use
+
+- User asks about scientific evidence or published research
+- Literature reviews or systematic reviews
+- Finding methods, sample sizes, or quantitative results
+- Comparing experimental approaches across studies
+- Building evidence tables for clinical or research decisions
+
+## How to Search
+
+Use the `search_papers` MCP tool with a descriptive query:
+
+```bash
+# Example: search for papers about CRISPR efficiency
+mcp__bgpt__search_papers "CRISPR gene editing efficiency in human cells"
+```
+
+## Results
+
+Each paper returns 25+ structured fields including:
+- Title, authors, journal, year, DOI
+- Methods and experimental protocols
+- Quantitative results and key findings
+- Sample sizes and statistical details
+- Quality scores and evidence grading
+- Conclusions and clinical implications
+
+## Pricing
+
+- Free tier: 50 searches per network, no API key needed
+- Paid: $0.01 per result with API key from https://bgpt.pro/mcp


### PR DESCRIPTION
Adds a new plugin `bgpt-paper-search` to the Data Analytics section.

**What it does:** Searches scientific papers and retrieves structured experimental data (methods, results, sample sizes, quality scores) from full-text studies via the BGPT remote MCP server.

**Use cases:** Literature reviews, evidence synthesis, comparing experimental methodologies, finding quantitative results across studies.

**Free tier:** 50 searches, no API key needed.

- Website: https://bgpt.pro/mcp
- GitHub: https://github.com/connerlambden/bgpt-mcp