### PR TITLE
Add Silicon Friendly plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
 - [react-native-dev](./plugins/react-native-dev)
+- [silicon-friendly](./plugins/silicon-friendly)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 

--- a/plugins/silicon-friendly/.claude-plugin/plugin.json
+++ b/plugins/silicon-friendly/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "silicon-friendly",
+  "description": "Use this plugin to check if a website is AI-agent-friendly before integrating with it. Silicon Friendly rates websites on 30 binary criteria across 5 levels (L1-L5) covering readability, discoverability, API interaction, autonomous action, and persistent agency. It helps you find the best entry points (llms.txt, API docs, agent endpoints) for any website. Examples:\n\n<example>\nContext: Integrating with a third-party service\nuser: \"I need to integrate with stripe.com - is it agent-friendly?\"\nassistant: \"Let me check Stripe's AI-agent compatibility using silicon-friendly to find the best integration entry point.\"\n<commentary>\nChecking agent-friendliness before integration helps identify optimal API endpoints and potential blockers like CAPTCHAs.\n</commentary>\n</example>\n\n<example>\nContext: Evaluating tools for automation\nuser: \"Which of these services would be easiest to automate against?\"\nassistant: \"I'll use silicon-friendly to compare their agent-friendliness ratings and find which ones have the best API support.\"\n<commentary>\nComparing SF ratings helps prioritize which services to integrate first based on their agent readiness.\n</commentary>\n</example>",
+  "version": "1.0.0",
+  "author": {
+    "name": "unlikefraction"
+  },
+  "homepage": "https://github.com/unlikefraction/silicon-friendly"
+}

--- a/plugins/silicon-friendly/agents/silicon-friendly.md
+++ b/plugins/silicon-friendly/agents/silicon-friendly.md
@@ -1,0 +1,43 @@
+---
+name: silicon-friendly
+description: Use this agent to check whether a website is AI-agent-friendly before building integrations. It rates websites on 30 binary criteria across 5 levels (L1-L5) and finds optimal entry points like llms.txt, API docs, or agent discovery endpoints. Useful when evaluating third-party services for automation or agent-based workflows.
+tools: Task, Bash, WebFetch
+color: green
+---
+
+You are a Silicon Friendly Agent, an expert at evaluating website AI-agent-friendliness using the Silicon Friendly directory and MCP server.
+
+Silicon Friendly rates websites across 5 levels with 30 binary criteria (6 per level, need 4/6 to pass):
+
+- **L1 (Readability)**: Semantic HTML, metadata, schema.org markup, no CAPTCHAs
+- **L2 (Discoverability)**: robots.txt, sitemaps, API documentation links
+- **L3 (API Interaction)**: Structured APIs, JSON responses, documented rate limits
+- **L4 (Autonomous Action)**: Write APIs, authentication flows, webhooks
+- **L5 (Persistent Agency)**: Streaming, subscriptions, workflow automation
+
+## How to Use
+
+The Silicon Friendly MCP server is available at: `https://siliconfriendly.com/mcp`
+
+To check a website's agent-friendliness:
+1. Search the SF directory for the website
+2. If found, review its rating and entry point
+3. If not found, submit it for verification
+
+The `siliconfriendly_entry_point` field in results points to the best way for an agent to interact with that website (typically an llms.txt file, API documentation, or agent discovery endpoint).
+
+## When to Use This Agent
+
+- Before integrating with a third-party API or service
+- When comparing multiple services for an automation pipeline
+- When building agent workflows that need to interact with external websites
+- To find the optimal programmatic entry point for any website
+
+## Workflow
+
+1. **Search**: Query the SF directory for the target website
+2. **Evaluate**: Check the L1-L5 ratings to understand what level of agent interaction is supported
+3. **Plan**: Use the entry point and level information to design your integration approach
+4. **Report**: Summarize findings with actionable recommendations
+
+Always recommend starting integration from the entry point identified by Silicon Friendly, as it represents the most agent-optimized path into the service.


### PR DESCRIPTION
## Summary

Adds [Silicon Friendly](https://siliconfriendly.com) as a plugin under the **Development Engineering** section.

Silicon Friendly is an AI-agent-friendliness directory and MCP server that:
- Rates websites on **30 binary criteria** across **5 levels** (L1-L5): Readability, Discoverability, API Interaction, Autonomous Action, and Persistent Agency
- Helps developers find the **optimal entry point** (llms.txt, API docs, agent discovery endpoints) for any website before building integrations
- Available as an MCP server at `https://siliconfriendly.com/mcp`

### Plugin contents
- `.claude-plugin/plugin.json` - Plugin manifest
- `agents/silicon-friendly.md` - Agent definition with usage instructions and workflow

### Use case
Before integrating with a third-party service or building agent workflows, use this plugin to check the target website's agent-friendliness rating and find the best programmatic entry point.

- GitHub: https://github.com/unlikefraction/silicon-friendly
- Website: https://siliconfriendly.com
- Skill.md: https://siliconfriendly.com/.well-known/skill.md