### PR TITLE
Add founder-toolkit to Business Sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [product-sales-specialist](./plugins/product-sales-specialist)
 - [support-responder](./plugins/support-responder)
 - [technical-sales-engineer](./plugins/technical-sales-engineer)
+- [founder-toolkit](https://github.com/mooster/founder-toolkit) - 4 skills for startup founders: investor update writer (YC/a16z format), pitch deck reviewer (10-dimension VC scoring), SaaS metrics dashboard with benchmarks, and outreach lead scorer (ICP-first, tested on 300+ companies). Built by Mu Chen, CEO of Canopy Cloud ($120B+ AUM).
 
 ### Code Quality Testing
 - [api-tester](./plugins/api-tester)


### PR DESCRIPTION
## Plugin: founder-toolkit

**Repo**: https://github.com/mooster/founder-toolkit
**Category**: Business Sales

4 production-ready skills for startup founders:
- **investor-update** — Generate investor updates following YC/a16z best practices (EN/中文)
- **pitch-reviewer** — 10-dimension pitch deck scoring from a VC perspective
- **startup-metrics** — Full SaaS metric suite (ARR, NRR, LTV:CAC, burn multiple, runway) with stage benchmarks
- **lead-scorer** — ICP-first lead scoring, tested on 300+ companies, with 3-layer email verification

**Author**: Mu Chen, CEO of Canopy Cloud ($120B+ AUM, 60+ institutional clients)
**License**: MIT