### PR TITLE
Add PUIUX Pilot to Automation DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ultrathink](./plugins/ultrathink)
 
 ### Automation DevOps
+- [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) - Auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types, selects from 28+ hooks, scores quality (0-100, A-F). `npm i -g puiux-pilot`
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)


### PR DESCRIPTION
## Summary
Adds [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) to the Automation DevOps section.

PUIUX Pilot is an open-source CLI that auto-configures Claude Code hooks, MCPs, and skills for any project. It scans 95+ project types, selects relevant hooks, configures MCP servers based on dependencies, and scores quality (0-100). Safe by default: dry-run mode, atomic writes, backup + rollback, and clean eject.

- **Install:** `npm i -g puiux-pilot`
- **License:** Apache 2.0
- **GitHub:** https://github.com/PUIUX-Cloud/puiux-pilot