### PR TITLE
Add claude-recap: per-topic session memory plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -57,6 +57,7 @@
 ### 工作流编排
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
+- [claude-recap](https://github.com/hatawong/claude-recap) — 基于话题的会话记忆插件，使用 Shell hooks 将每个对话话题归档为独立的 Markdown 摘要。两个 hooks，bash + Node.js，100% 本地运行。
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Workflow Orchestration
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
+- [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)


### PR DESCRIPTION
## Summary

- Adds [claude-recap](https://github.com/hatawong/claude-recap) to the **Workflow Orchestration** section in both `README.md` and `README-zh.md`
- claude-recap is a per-topic session memory plugin for Claude Code — it archives each conversation topic as a separate Markdown summary using Shell hooks (bash + Node.js), running 100% locally
- Entry placed in alphabetical order within the section

## About claude-recap

Claude Code's filesystem memory — two Shell hooks + prompt templates that let the Agent automatically remember work progress, decisions, and lessons learned across sessions.

**Key features:**
- Per-topic archiving: each conversation topic gets its own Markdown summary file
- Pure Shell hooks architecture (SessionStart + Stop hooks)
- bash + Node.js, no external services, 100% local
- Supports cold-read summarization for compacted sessions
- Background archiving of missed sessions via `archive-pending`

**Repo:** https://github.com/hatawong/claude-recap

## Test plan

- [x] Entry follows existing list format (markdown link + description)
- [x] Alphabetically ordered within the Workflow Orchestration section
- [x] Both README.md and README-zh.md updated consistently
- [x] Link points to valid GitHub repository