### PR TITLE
Add newsmcp — Real-time world news plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
+- [newsmcp](https://github.com/pranciskus/newsmcp) — Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [trend-researcher](./plugins/trend-researcher)
 
 ### Design UX


### PR DESCRIPTION
## Summary

- Adds [newsmcp](https://github.com/pranciskus/newsmcp) to the **Data Analytics** section
- newsmcp is a Claude Code plugin that provides real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance
- Free to use, no API key required

## Install

```bash
/plugin marketplace add pranciskus/newsmcp
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)