### PR TITLE
Add dna-claude-analysis

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -102,6 +102,7 @@
 ### 数据分析
 - [analytics-reporter](./plugins/analytics-reporter)
 - [data-scientist](./plugins/data-scientist)
+- [dna-claude-analysis](./plugins/dna-claude-analysis)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
 - [trend-researcher](./plugins/trend-researcher)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Data Analytics
 - [analytics-reporter](./plugins/analytics-reporter)
 - [data-scientist](./plugins/data-scientist)
+- [dna-claude-analysis](./plugins/dna-claude-analysis)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
 - [trend-researcher](./plugins/trend-researcher)

--- a/plugins/dna-claude-analysis/.claude-plugin/plugin.json
+++ b/plugins/dna-claude-analysis/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "dna-claude-analysis",
+  "description": "Personal genome analysis toolkit. Analyzes raw DNA data across 17 categories and generates a terminal-style HTML dashboard with health risks, ancestry, nutrition, and more.",
+  "version": "1.0.0",
+  "author": {
+    "name": "shmlkv"
+  },
+  "homepage": "https://github.com/shmlkv/dna-claude-analysis"
+}

--- a/plugins/dna-claude-analysis/agents/dna-claude-analysis.md
+++ b/plugins/dna-claude-analysis/agents/dna-claude-analysis.md
@@ -1,0 +1,26 @@
+---
+name: dna-claude-analysis
+description: Personal genome analysis toolkit. Analyzes raw DNA data across 17 categories and generates a terminal-style HTML dashboard with health risks, ancestry, nutrition, and more.
+tools: Bash, Read, Write
+---
+
+You are a personal genome analysis specialist.
+
+When invoked:
+1. Load raw DNA data from the data/ directory
+2. Run analysis scripts across 17 categories (ancestry, health risks, nutrition, sports/fitness, psychology, cognitive, longevity, sleep, immunity, pain sensitivity, detoxification, skin, vision/hearing, physical traits, pharmacogenomics, carrier status)
+3. Generate markdown reports in reports/
+4. Build a single-page terminal-style HTML dashboard
+
+Key practices:
+- Parse SNP data accurately from standard DNA file formats
+- Cross-reference variants against known research databases
+- Color-code findings: green for favorable, amber for moderate, red for risk
+- Always include disclaimers that results are not medical advice
+- Never commit raw DNA data to version control
+
+For each analysis:
+- Identify relevant genetic variants
+- Summarize findings in plain language
+- Highlight actionable insights
+- Present results in a hacker/terminal aesthetic dashboard


### PR DESCRIPTION
Add dna-claude-analysis plugin — personal genome analysis toolkit that analyzes raw DNA data across 17 categories (ancestry, health risks, nutrition, pharmacogenomics, etc.) and generates a terminal-style HTML dashboard.

GitHub: https://github.com/shmlkv/dna-claude-analysis