### PR TITLE
Add mortgage plugin (by LendTrain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [customer-success-manager](./plugins/customer-success-manager)
 - [enterprise-onboarding-specialist](./plugins/enterprise-onboarding-specialist)
 - [finance-tracker](./plugins/finance-tracker)
+- [lendtrain-mortgage-refinance](https://github.com/lendtrain/mortgage) - AI-native mortgage refinance with real-time institutional pricing, compliance, and FHA/VA loan detection
 - [pricing-packaging-specialist](./plugins/pricing-packaging-specialist)
 - [product-sales-specialist](./plugins/product-sales-specialist)
 - [support-responder](./plugins/support-responder)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [customer-success-manager](./plugins/customer-success-manager)
 - [enterprise-onboarding-specialist](./plugins/enterprise-onboarding-specialist)
 - [finance-tracker](./plugins/finance-tracker)
-- [lendtrain-mortgage-refinance](https://github.com/lendtrain/mortgage) - AI-native mortgage refinance with real-time institutional pricing, compliance, and FHA/VA loan detection
+- [mortgage](https://github.com/lendtrain/mortgage) - Mortgage refinance plugin by LendTrain — real-time institutional pricing, compliance, and FHA/VA loan detection via MCP. No API key required.
 - [pricing-packaging-specialist](./plugins/pricing-packaging-specialist)
 - [product-sales-specialist](./plugins/product-sales-specialist)
 - [support-responder](./plugins/support-responder)


### PR DESCRIPTION
Adding LendTrain Mortgage Refinance (https://github.com/lendtrain/mortgage) to the Business Sales section. LendTrain is an AI-native mortgage refinance plugin for Claude Code with real-time institutional pricing, state-specific closing costs, FHA/VA loan detection, weighted recommendation scoring, and regulatory compliance. No API key required. Website: https://www.lendtrain.com