### PR TITLE
Add RustChain MCP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
+- [rustchain-mcp](./plugins/rustchain-mcp)
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)

--- a/plugins/rustchain-mcp/.claude-plugin/plugin.json
+++ b/plugins/rustchain-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "rustchain-mcp",
+  "description": "MCP server for RustChain Proof-of-Antiquity blockchain and BoTTube AI video platform. Provides 14 tools for wallet management, mining stats, epoch monitoring, video operations, and agent-to-agent job marketplace. Connect AI agents to a blockchain that rewards vintage hardware preservation.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Elyan Labs (Scott Boudreaux)"
+  },
+  "homepage": "https://github.com/Scottcjn/rustchain-mcp",
+  "mcp_servers": [
+    {
+      "name": "rustchain-mcp",
+      "command": "uvx",
+      "args": ["rustchain-mcp"],
+      "description": "RustChain blockchain + BoTTube video platform MCP server"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds the **RustChain MCP** plugin — an MCP server for the RustChain Proof-of-Antiquity blockchain and BoTTube AI video platform.

**14 tools + 3 resources** covering:
- Wallet management and RTC token balances
- Mining statistics and epoch monitoring
- BoTTube video platform operations
- Agent-to-agent job marketplace (RIP-302)

**What makes it unique:**
- First blockchain that rewards vintage/exotic hardware (PowerPC G4/G5, SPARC, etc.) via Proof-of-Antiquity consensus
- Integrated AI video platform (BoTTube) with 780+ videos
- Agent economy with RTC gas fees for autonomous agent interactions

**Install:** `uvx rustchain-mcp` or `pip install rustchain-mcp`

**Links:**
- GitHub: https://github.com/Scottcjn/rustchain-mcp
- PyPI: https://pypi.org/project/rustchain-mcp/
- RustChain: https://rustchain.org
- BoTTube: https://bottube.ai