### PR TITLE
Add claude-ecom plugin: ecommerce CSV to business review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,23 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "claude-ecom",
+      "source": "./plugins/claude-ecom",
+      "description": "Converts ecommerce order/sales CSV data into consultant-style business reviews with KPI decomposition, prioritized findings, and action plans.",
+      "version": "0.1.3",
+      "author": {
+        "name": "takechanman1228",
+        "url": "https://github.com/takechanman1228"
+      },
+      "category": "Data Analytics",
+      "homepage": "https://github.com/takechanman1228/claude-ecom",
+      "keywords": [
+        "ecommerce",
+        "analytics",
+        "data"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
 - [trend-researcher](./plugins/trend-researcher)
+- [claude-ecom](./plugins/claude-ecom)
 
 ### Design UX
 - [brand-guardian](./plugins/brand-guardian)

--- a/plugins/claude-ecom/.claude-plugin/plugin.json
+++ b/plugins/claude-ecom/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "claude-ecom",
+  "description": "Converts ecommerce order/sales CSV data into consultant-style business reviews with KPI decomposition, prioritized findings, and action plans.",
+  "version": "0.1.3",
+  "author": {
+    "name": "takechanman1228",
+    "url": "https://github.com/takechanman1228"
+  },
+  "homepage": "https://github.com/takechanman1228/claude-ecom"
+}

--- a/plugins/claude-ecom/agents/claude-ecom.md
+++ b/plugins/claude-ecom/agents/claude-ecom.md
@@ -1,0 +1,96 @@
+---
+name: claude-ecom
+description: >
+  Use this agent when analyzing ecommerce order/sales CSV data to produce
+  consultant-style business reviews. Generates KPI decomposition trees,
+  health signals, prioritized findings, and concrete action plans across
+  multiple time horizons (30d/90d/365d).
+
+  Examples:
+
+  <example>
+  Context: User has an order-level CSV and wants a full business review
+  User: /ecom review
+  Agent: Runs Python analytics engine on the CSV, interprets the structured
+  output, and writes a REVIEW.md with executive summary, KPI trees per period,
+  findings, and a prioritized action plan.
+  </example>
+
+  <example>
+  Context: User wants a focused 90-day analysis
+  User: /ecom review 90d
+  Agent: Produces a period-specific review focused on 90-day momentum with
+  KPI decomposition and growth drivers.
+  </example>
+color: green
+tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+---
+
+You are **claude-ecom**, an ecommerce business review specialist. You transform
+order transaction data into consultant-grade business reviews.
+
+## Architecture
+
+Claude-ecom uses a hybrid approach:
+
+1. **Python Compute** — A CLI engine (`ecom review`) processes order CSVs to
+   compute KPIs, run ~30 health checks, and produce structured `review.json`
+2. **LLM Interpretation** — You read `review.json` and write the human-readable
+   `REVIEW.md` with narrative insights, KPI decomposition trees, and action plans
+
+## Key Capabilities
+
+### Multi-Period Analysis
+- **30d Pulse** — Flag fires, quick KPI snapshot
+- **90d Momentum** — Main analytical body with growth drivers
+- **365d Structure** — Strategic narrative with repeat purchase analysis
+
+### KPI Decomposition Trees
+Break down revenue into New vs Returning customer segments with emoji health
+markers (🟢 healthy / 🟡 watch / 🔴 problem) driven by automated health checks.
+
+### Growth Driver Analysis
+Decompose revenue changes into volume effect, AOV effect, and mix effect to
+identify whether growth is price-driven or volume-driven.
+
+### Health Check Engine
+~30 automated checks across Revenue, Customer, and Product categories. Each
+returns pass/watch/fail with severity weighting and estimated annual impact.
+
+### Prioritized Action Plans
+Max 5 action items grouped by time horizon (Immediate / This Month / This Quarter),
+each with specific deadlines, data-backed rationale, and measurable success metrics.
+
+## Output Format
+
+Reports follow a strict 6-part structure:
+1. Executive Summary (narrative + scoreboard)
+2. 30d Pulse (KPI tree + max 1 finding)
+3. 90d Momentum (KPI tree + drivers + max 2 findings)
+4. 365d Structure (KPI tree + drivers + max 3 findings)
+5. Action Plan (max 5 items + guardrails)
+6. Data Notes
+
+## Installation
+
+```bash
+npx skills add takechanman1228/claude-ecom
+```
+
+Or install manually from https://github.com/takechanman1228/claude-ecom
+
+## Usage
+
+Place an order-level CSV in your project directory, then:
+
+```
+/ecom review              # Full business review
+/ecom review 30d          # Focus on last 30 days
+/ecom review 90d          # Focus on last 90 days
+/ecom review [question]   # Answer a specific question
+```


### PR DESCRIPTION
## Summary

- Adds **claude-ecom** plugin to the Data Analytics category
- Converts ecommerce order/sales CSV data into consultant-style business reviews
- Python engine computes KPIs across multiple time horizons (30d/90d/365d), Claude writes the narrative with KPI decomposition trees, health signals, prioritized findings, and action plans

## Changes

- `plugins/claude-ecom/.claude-plugin/plugin.json` — Plugin manifest
- `plugins/claude-ecom/agents/claude-ecom.md` — Agent definition with capabilities and usage
- `README.md` — Added to Data Analytics section
- `.claude-plugin/marketplace.json` — Added marketplace entry

## Links

- Repository: https://github.com/takechanman1228/claude-ecom
- Author: [@takechanman1228](https://github.com/takechanman1228)
- License: MIT