### PR TITLE
Add mcp-openapi: OpenAPI/Swagger to MCP tools converter

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -125,6 +125,7 @@
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
+- [mcp-openapi](./plugins/mcp-openapi)
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
+- [mcp-openapi](./plugins/mcp-openapi)
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)

--- a/plugins/mcp-openapi/.claude-plugin/plugin.json
+++ b/plugins/mcp-openapi/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "name": "mcp-openapi",
+  "description": "Turn any OpenAPI/Swagger spec into MCP tools for Claude. Supports OpenAPI 3.x and Swagger 2.0 with auto-auth, flat parameter schemas, and smart response truncation. One command: npx mcp-openapi --spec <url>",
+  "version": "0.2.2",
+  "author": {
+    "name": "Docat0209"
+  },
+  "homepage": "https://github.com/Docat0209/mcp-openapi",
+  "mcp_servers": [
+    {
+      "name": "mcp-openapi",
+      "command": "npx",
+      "args": ["-y", "mcp-openapi", "--spec", "<openapi-spec-url>"],
+      "description": "Convert any OpenAPI/Swagger spec into MCP tools. Replace <openapi-spec-url> with the URL or path to your OpenAPI spec."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds **mcp-openapi** plugin — turn any OpenAPI/Swagger spec into MCP tools for Claude with a single command
- Supports OpenAPI 3.x and Swagger 2.0, auto-auth (Bearer, API Key, Basic), flat parameter schemas, and smart response truncation
- Usage: `npx mcp-openapi --spec <url>`
- npm: [mcp-openapi](https://www.npmjs.com/package/mcp-openapi) | GitHub: [Docat0209/mcp-openapi](https://github.com/Docat0209/mcp-openapi)

## Changes

- `plugins/mcp-openapi/.claude-plugin/plugin.json` — plugin definition with `mcp_servers` config
- `README.md` — added to Development Engineering section (alphabetical order)
- `README-zh.md` — same

## Test plan

- [ ] `npx mcp-openapi --spec https://petstore3.swagger.io/api/v3/openapi.json` runs and exposes MCP tools
- [ ] Plugin installs correctly via `/plugin install mcp-openapi`