### PR TITLE
Add fractal — recursive project management plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
 - **Slash Commands** — Custom shortcuts for frequent operations
 - **Subagents** — Purpose-built agents for specialized dev tasks
 - **MCP Servers** — Integrations to tools and data sources via the Model Context Protocol
-- **Hooks** — Extensions that modify Claude Code’s behavior at key workflow points
+- **Hooks** — Extensions that modify Claude Code's behavior at key workflow points
 
 Install or disable them dynamically with the `/plugin` command — enabling you to keep your system context focused and lightweight.
 
@@ -171,6 +171,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Project & Product Management
 - [discuss](./plugins/discuss)
 - [explore](./plugins/explore)
+- [fractal](https://github.com/rmolines/fractal) - Recursive project management plugin. Decomposes any goal into verifiable predicates, works on the riskiest unknown first. Features `/fractal:run` (idempotent state machine), `/fractal:init`, `/fractal:patch`, dry run mode, and incremental decomposition with re-evaluation.
 - [plan](./plugins/plan)
 - [planning-prd-agent](./plugins/planning-prd-agent)
 - [prd-specialist](./plugins/prd-specialist)
@@ -200,7 +201,7 @@ You can host and share your own curated plugin marketplace using a simple Git re
 /plugin marketplace add user-or-org/repo-name
 ```
 
-Then browse and install plugins from within Claude Code’s `/plugin` menu.
+Then browse and install plugins from within Claude Code's `/plugin` menu.
 
 Example:
 


### PR DESCRIPTION
## Summary

Adds [fractal](https://github.com/rmolines/fractal) to the **Project & Product Management** section.

**What it does:** Recursive project management for Claude Code. One primitive that decomposes any goal into verifiable predicates, works on the riskiest unknown first. The filesystem is the state — no database, no JSON.

**Key features:**
- `/fractal:run` — idempotent state machine, call repeatedly to advance the tree
- `/fractal:init` — bootstrap any goal into a predicate tree
- `/fractal:patch` — fast path for trivial leaf predicates
- Full sprint cycle: planning → delivery → review → ship
- Dry run mode — builds the full decomposition tree without executing
- Incremental decomposition with re-evaluation at each node

**Repo:** https://github.com/rmolines/fractal