### PR TITLE
Add Reporecall — local codebase memory with hooks + MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
+- [reporecall](https://github.com/proofofwork-agency/reporecall) - Local codebase memory for Claude Code. AST indexing (22 languages), call graphs, hybrid search. Injects context via hooks (~5ms). Also an MCP server.
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)


### PR DESCRIPTION
## What it does

[Reporecall](https://github.com/proofofwork-agency/reporecall) gives Claude Code a codebase memory so it stops wasting tokens rediscovering your code.

**The problem:** Claude Code spends its first moves grepping and reading files to understand a codebase it's already seen. On large repos this burns through context window and token budget before real work starts.

**The solution:** Reporecall pre-indexes your codebase using Tree-sitter AST parsing (22 languages), builds call graphs, and injects relevant context via a hook in ~5ms — before Claude starts thinking. No grep chains, no exploration loops.

- Hybrid keyword + vector search
- Call graph traversal (callers + callees)
- Also works as an MCP server
- 3-8x reduction in token usage for context gathering

npm: `@proofofwork-agency/reporecall`