### PR TITLE
Add dotforge: configuration factory for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
+- [claude-kit](https://github.com/luiseiman/claude-kit) - Configuration factory for Claude Code — bootstrap, audit, sync. 13 stacks, 6 agents, practices pipeline.
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
-- [claude-kit](https://github.com/luiseiman/claude-kit) - Configuration factory for Claude Code — bootstrap, audit, sync. 13 stacks, 6 agents, practices pipeline.
+- [dotforge](https://github.com/luiseiman/dotforge) - Configuration factory for Claude Code — 17 skills, 7 agents, 15 stacks, audit scoring (0-10), practices pipeline.
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)


### PR DESCRIPTION
## dotforge

Configuration factory for Claude Code that manages the full .claude/ lifecycle.

**Key features:**
- 17 skills installed as ~/.claude/skills/ symlinks
- 15 composable technology stacks (auto-detected and additive)
- 7 specialized subagents with orchestration protocol
- Audit scoring (0-10) with security cap
- Template sync (updates managed sections, preserves customizations)
- Practices pipeline with effectiveness tracking
- Config validation: measures if rules are actually effective, not just present
- MCP server templates (github, postgres, supabase, redis, slack)
- Export to Cursor, Codex, Windsurf, OpenClaw

**Install:** `/install luiseiman/dotforge`

**Links:** [GitHub](https://github.com/luiseiman/dotforge) | [Usage Guide](https://github.com/luiseiman/dotforge/blob/main/docs/guia-uso.md)