### PR TITLE
Add claude-memory-manager — Web UI for Claude Code memory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
-- [claude-memory-manager](https://github.com/WhymustIhaveaname/claude-memory-manager) - Web UI for managing Claude Code's native MEMORY.md memory system. Three-panel interface for browsing, editing, and organizing cross-session memories with full operation reversibility.
+- [claude-memory-manager](https://github.com/WhymustIhaveaname/claude-memory-manager) - Global memory tier for Claude Code. Stores cross-project memories in ~/.claude/memory/, injects them via SessionStart hook. Includes a web UI for managing all memory files without digging through directories.
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [claude-memory-manager](https://github.com/WhymustIhaveaname/claude-memory-manager) - Web UI for managing Claude Code's native MEMORY.md memory system. Three-panel interface for browsing, editing, and organizing cross-session memories with full operation reversibility.
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)


### PR DESCRIPTION
## What is claude-memory-manager?

Claude Code memories are per-project only. Teach Claude something in one repo and it forgets in the next. This plugin adds a global memory tier — stores cross-project memories in `~/.claude/memory/` and injects them at session start via hook.

Also ships a web UI for managing all memory files (global + per-project) without digging through `~/.claude/` by hand.

### Key bits
- SessionStart hook for global memory injection
- Skill for mid-session memory read/write
- Three-panel web UI: folders → memory index → content editor
- Export/import as zip for multi-machine setups

### Screenshots

<table>
<tr>
<td width="50%" align="center"><strong>Global memories injected at session start</strong></td>
<td width="50%" align="center"><strong>Web UI for browsing and editing memories</strong></td>
</tr>
<tr>
<td><img src="https://raw.githubusercontent.com/WhymustIhaveaname/claude-memory-manager/main/docs/terminal.png" width="100%"></td>
<td><img src="https://raw.githubusercontent.com/WhymustIhaveaname/claude-memory-manager/main/docs/webui.png" width="100%"></td>
</tr>
</table>

### Links
- GitHub: https://github.com/WhymustIhaveaname/claude-memory-manager
- License: MIT

### Category
Workflow Orchestration