### PR TITLE
Add prompt-chime notification plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ultrathink](./plugins/ultrathink)
 
 ### Automation DevOps
+- [prompt-chime](https://github.com/pick/prompt-chime) - Cross-platform notification plugin with meme sound presets, toast notifications, profiles, quiet hours, and per-project overrides.
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)


### PR DESCRIPTION
Adds **prompt-chime** to the Automation DevOps section.

Cross-platform notification plugin that plays sounds and toast notifications when Claude finishes responding. Ships with 11 chiptune meme sound presets, profiles, quiet hours, per-project overrides, and a `/notification-toolkit` skill.

https://github.com/pick/prompt-chime