### PR TITLE
Add ClawSec and ClawSearch security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Security, Compliance, & Legal
 - [ai-ethics-governance-specialist](./plugins/ai-ethics-governance-specialist)
 - [audit](./plugins/audit)
+- [clawsec](./plugins/clawsec)
+- [clawsearch](./plugins/clawsearch)
 - [compliance-automation-specialist](./plugins/compliance-automation-specialist)
 - [data-privacy-engineer](./plugins/data-privacy-engineer)
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)

--- a/plugins/clawsearch/.claude-plugin/plugin.json
+++ b/plugins/clawsearch/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "clawsearch",
+  "description": "Security-first skill discovery engine. Search and evaluate AI agent skills with Trust Score ratings, knowledge graph analysis, and security assessments before installation.",
+  "version": "1.0.0",
+  "author": {
+    "name": "ClawSearch"
+  },
+  "homepage": "https://clawsearch.cc"
+}

--- a/plugins/clawsearch/commands/clawsearch.md
+++ b/plugins/clawsearch/commands/clawsearch.md
@@ -1,0 +1,23 @@
+---
+allowed-tools: Bash(curl:*), Bash(jq:*), Bash(npm:*)
+description: Search for AI agent skills with security-first discovery via ClawSearch
+---
+
+## Context
+
+- ClawSearch API: https://api.clawsearch.cc
+- Trust Score ratings across four dimensions
+- Pre-install guard available: `npm install -g clawsearch-guard`
+
+## Your task
+
+Search for AI agent skills using ClawSearch and evaluate their security posture.
+
+1. **Search skills**: `curl -s "https://api.clawsearch.cc/api/search?q=$ARGUMENTS" | jq .`
+2. **Evaluate Trust Scores**: Review the four-dimension trust score for each result
+3. **Check related skills**: Look at knowledge graph connections for similar/alternative skills
+4. **Recommend**: Suggest the safest options based on audit status and trust scores
+
+Target: $ARGUMENTS
+
+Provide ranked results with Trust Scores and security recommendations.

--- a/plugins/clawsec/.claude-plugin/plugin.json
+++ b/plugins/clawsec/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "clawsec",
+  "description": "Security audit tool for AI agent skills. Queries the ClawSec API to check skill security assessments, vulnerability reports, and audit scores before installing or using skills in your projects.",
+  "version": "1.0.0",
+  "author": {
+    "name": "ClawSec"
+  },
+  "homepage": "https://clawsec.cc"
+}

--- a/plugins/clawsec/commands/clawsec.md
+++ b/plugins/clawsec/commands/clawsec.md
@@ -1,0 +1,21 @@
+---
+allowed-tools: Bash(curl:*), Bash(jq:*)
+description: Check security audit status of an AI agent skill via ClawSec
+---
+
+## Context
+
+- ClawSec API: https://api.clawsec.cc
+- Audits 33,000+ skills with a 5-tier assessment engine
+
+## Your task
+
+Query the ClawSec API to check the security audit status of the specified skill.
+
+1. **Lookup skill**: `curl -s "https://api.clawsec.cc/api/skills/search?q=$ARGUMENTS" | jq .`
+2. **Review findings**: Check the audit score, risk level, and any flagged vulnerabilities
+3. **Summarize**: Present the security assessment with actionable recommendations
+
+Target: $ARGUMENTS
+
+Provide a clear security summary with pass/fail status and any remediation steps.


### PR DESCRIPTION
## Summary

- Adds **clawsec** plugin — slash command that queries the ClawSec API to check security audit status of AI agent skills
- Adds **clawsearch** plugin — slash command that searches for skills via ClawSearch with Trust Score ratings and security recommendations

Both plugins are added alphabetically to the **Security, Compliance, & Legal** section with full plugin structure (plugin.json + command markdown).

## What's included

Each plugin provides:
- `.claude-plugin/plugin.json` — plugin metadata
- `commands/*.md` — slash command that queries the respective API to evaluate skill security

## Why these plugins belong here

ClawSec and ClawSearch help Claude Code users evaluate the security posture of skills and plugins before installation, fitting naturally in the Security, Compliance, & Legal category.