### PR TITLE
Add slack-message-formatter plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1785,6 +1785,25 @@
         "hooks",
         "skill"
       ]
+    },
+    {
+      "name": "slack-message-formatter",
+      "source": "./plugins/slack-message-formatter",
+      "description": "Format Markdown for Slack. Rich HTML copy-paste plus mrkdwn API output.",
+      "version": "1.0.0",
+      "author": {
+        "name": "karanb192",
+        "url": "https://github.com/karanb192"
+      },
+      "category": "Communication & Integrations",
+      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/slack-message-formatter",
+      "keywords": [
+        "slack",
+        "markdown",
+        "mrkdwn",
+        "formatting",
+        "messaging"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -130,6 +130,7 @@
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
 - [react-native-dev](./plugins/react-native-dev)
+- [slack-message-formatter](./plugins/slack-message-formatter)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
 - [react-native-dev](./plugins/react-native-dev)
+- [slack-message-formatter](./plugins/slack-message-formatter)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [think-first](https://github.com/ofershap/think-first) - Plan-before-code behavior modifier for agents
 
 ### Communication & Integrations
+- [slack-message-formatter](./plugins/slack-message-formatter) - Format Markdown for Slack: rich HTML copy-paste plus mrkdwn API output.
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.
 
 ### Data Analytics

--- a/plugins/slack-message-formatter/.claude-plugin/plugin.json
+++ b/plugins/slack-message-formatter/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "slack-message-formatter",
+  "description": "Format Markdown for Slack. Rich HTML copy-paste + mrkdwn API output.",
+  "version": "1.0.0",
+  "author": {
+    "name": "karanb192",
+    "url": "https://github.com/karanb192"
+  },
+  "homepage": "https://github.com/karanb192/slack-message-formatter"
+}

--- a/plugins/slack-message-formatter/commands/slack-message-formatter.md
+++ b/plugins/slack-message-formatter/commands/slack-message-formatter.md
@@ -1,0 +1,31 @@
+---
+description: Format Markdown for Slack. Rich HTML copy-paste + mrkdwn API output.
+author: karanb192
+author-url: https://github.com/karanb192
+version: 1.0.0
+---
+
+# Slack Message Formatter
+
+This slash command formats messages for Slack with pixel-perfect accuracy. It converts standard Markdown to Slack-compatible output with two delivery paths:
+
+1. **Copy-paste** — Rich HTML that preserves formatting when pasted into Slack's compose box
+2. **API/Webhook** — Slack mrkdwn syntax for bots, automation, and CI/CD
+
+## Key Features
+
+- Converts bold, italic, strikethrough, code, links, headings, tables, task lists, and more
+- Handles Slack mentions (`<@U...>`, `<#C...>`, `<!here>`) as pass-through
+- Generates a Slack-themed browser preview page
+- Copies rich HTML to clipboard for instant paste into Slack
+- Supports direct webhook sending via `CCH_SLA_WEBHOOK` environment variable
+- Converts 150+ emoji shortcodes to native Unicode
+
+## Usage
+
+```
+/slack-message-formatter preview
+/slack-message-formatter send
+```
+
+Write your message in standard Markdown, and the formatter handles conversion to Slack's mrkdwn syntax and rich HTML automatically.


### PR DESCRIPTION
## Summary

- Adds **slack-message-formatter** plugin under Development Engineering
- Converts Markdown to Slack-compatible output via two paths: rich HTML (copy-paste) and mrkdwn (API/webhook)
- Includes `plugin.json`, slash command definition, and entries in both `README.md` and `README-zh.md`

**Plugin repo:** https://github.com/karanb192/slack-message-formatter

### Features

- Rich HTML clipboard copy for pixel-perfect Slack paste
- Slack mrkdwn conversion for bots, webhooks, and CI/CD
- 150+ emoji shortcode-to-Unicode mappings
- Table, task list, blockquote, and nested list support
- Slack mention pass-through (`<@U...>`, `<#C...>`, `<!here>`)
- Browser preview with Slack-themed styling

## Test plan

- [ ] Verify plugin directory structure matches repo conventions (`plugin.json` + `commands/*.md`)
- [ ] Confirm alphabetical ordering in README plugin lists
- [ ] Check that both README.md and README-zh.md are updated consistently