### PR TITLE
Add autoresearch — autonomous skill optimizer plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [technical-sales-engineer](./plugins/technical-sales-engineer)
 
 ### Code Quality Testing
+- [autoresearch](./plugins/autoresearch)
 - [api-tester](./plugins/api-tester)
 - [bug-detective](./plugins/bug-detective)
 - [code-review](./plugins/code-review)

--- a/plugins/autoresearch/.claude-plugin/plugin.json
+++ b/plugins/autoresearch/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "autoresearch",
+  "description": "Autonomous skill optimizer using Karpathy's autoresearch methodology. Scores outputs 0-100, mutates prompts, keeps improvements. Includes auto-screenshot and stop-gate hooks.",
+  "version": "1.1.1",
+  "license": "MIT",
+  "author": {
+    "name": "Tony Davis",
+    "url": "https://github.com/lendtrain"
+  },
+  "homepage": "https://github.com/lendtrain/autoresearch-for-skills"
+}


### PR DESCRIPTION
Adds the autoresearch plugin — autonomously optimizes Claude Code skill prompts.

- Based on Karpathy's autoresearch methodology
- Scores outputs 0-100.00 with weighted eval criteria
- Mutates one thing at a time, keeps improvements
- Git branching for safety, HTML dashboard for results
- PostToolUse hook (auto-screenshots) + Stop hook (completion gate)

**GitHub:** https://github.com/lendtrain/autoresearch-for-skills
**License:** MIT