### PR TITLE
Add AuraKit — all-in-one Claude Code skill (46 modes, 23 agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,9 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
 
 
+### Skills & Frameworks
+- [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 33 modes, 6-layer security, 23 hooks, 8 languages, 75% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
+
 ## Tutorials
 
 You can host and share your own curated plugin marketplace using a simple Git repository with a `.claude-plugin/marketplace.json` file.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 
 ### Skills & Frameworks
-- [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 33 modes, 6-layer security, 23 hooks, 8 languages, 75% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
+- [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
 
 ## Tutorials
 


### PR DESCRIPTION
## Summary
- Adds [AuraKit](https://github.com/smorky850612/Aurakit) v6.3.1
- All-in-one Claude Code skill: **36 modes**, 6-layer security, 23 hooks, 8 languages, ~55% token savings
- Cross-platform: Claude Code · OpenAI Codex CLI · Cursor · Manus · Windsurf
- Install: `npx @smorky85/aurakit` or `bash install.sh`

## What's New in v6.3.1
- **36 modes**: BUILD · FIX · CLEAN · DEPLOY · REVIEW · TDD · DEBUG · QA:E2E · ORCHESTRATE · STATUS:HEALTH + 26 more
- **install.sh v2.0**: Auto-installs jq (winget/scoop/choco/brew/apt/dnf/yum/apk/pacman), cross-platform OS detection
- **23 hooks / 16 Claude Code events**: Full automation pipeline (pre-session → build-verify → instinct-auto-save → compact/restore)
- **DNA Identity**: 8 core principles — FAST · FLASHY · SECURE · THRIFTY · IMMORTAL · EVOLVING · UNIVERSAL · TOP-TIER

## Why AuraKit

| Feature | Detail |
|---------|--------|
| Security | 6-layer (L1 roles → L6 npm audit), SEC-01~15 OWASP rules |
| Token savings | ~55% via Tiered Model (haiku Scout + sonnet Builder) |
| Memory | Instinct engine learns patterns per project — gets smarter every session |
| Recovery | Compact-proof — snapshots survive context loss |
| Languages | TypeScript · Python · Go · Java · Rust · Kotlin · C++ · Swift (10 reviewers) |