### PR TITLE
Add The Pragmatic PM — product management toolkit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [project-shipper](./plugins/project-shipper)
 - [sprint-prioritizer](./plugins/sprint-prioritizer)
 - [studio-producer](./plugins/studio-producer)
+- [the-pragmatic-pm](https://github.com/marfoerst/the-pragmatic-pm) - PM leadership toolkit with 43 skills, 5 orchestrator agents, and 4 multi-stage workflows. PRD generation, OKR lifecycle, pricing, AI pricing, battlecards, sales enablement, quarterly planning, and more.
 - [tool-evaluator](./plugins/tool-evaluator)
 - [workflow-optimizer](./plugins/workflow-optimizer)
 


### PR DESCRIPTION
## Add The Pragmatic PM plugin

PM leadership toolkit with 43 skills, 5 agents, and 4 multi-stage workflows.

**Plugin structure:**
```
the-pragmatic-pm/
├── .claude-plugin/plugin.json
├── domain-context.md
├── agents/ (5 orchestrator agents)
└── skills/ (43 skills + 4 workflows)
```

**Install:**
```
/plugin marketplace add marfoerst/the-pragmatic-pm
/plugin install pm-toolkit@the-pragmatic-pm
```

Covers: PRD generation, OKR lifecycle, SaaS pricing, AI pricing, positioning (Dunford), battlecards, sales enablement, quarterly planning, competitive intelligence, and more.

**Repository:** https://github.com/marfoerst/the-pragmatic-pm