### PR TITLE
Add SkillFlow - AI Skills Marketplace Discovery MCP Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
 - **Subagents** — Purpose-built agents for specialized dev tasks
 - **MCP Servers** — Integrations to tools and data sources via the Model Context Protocol
 - **Hooks** — Extensions that modify Claude Code’s behavior at key workflow points
+* [SkillFlow](https://github.com/rafsilva85/skillflow-mcp-server) - AI Skills Marketplace discovery server. Search, compare, and get installation instructions for curated MCP servers and AI agent tools.
 
 Install or disable them dynamically with the `/plugin` command — enabling you to keep your system context focused and lightweight.
 


### PR DESCRIPTION
## Add SkillFlow MCP Server

**SkillFlow** is a curated AI Skills Marketplace that helps developers discover, compare, and integrate AI agent tools.

### Details
- **npm:** [`skillflow-mcp-server`](https://www.npmjs.com/package/skillflow-mcp-server) (v1.0.2)
- **GitHub:** [rafsilva85/skillflow-mcp-server](https://github.com/rafsilva85/skillflow-mcp-server)
- Published on the Official Anthropic MCP Registry and npm

### Installation
```bash
npx skillflow-mcp-server
```