### PR TITLE
Add launch-swarm to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [launch-swarm](https://github.com/harshmoney123/launch-swarm) - 6-agent Claude Code swarm with strict role separation, dual-gate merge pipeline, and prompt health anti-rot
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)


### PR DESCRIPTION
Adds [launch-swarm](https://github.com/harshmoney123/launch-swarm) to the **Workflow Orchestration** section.

**launch-swarm** is a 6-agent Claude Code swarm with strict role separation, dual-gate merge pipeline, and prompt health anti-rot.

- Placed in alphabetical order between `claude-desktop-extension` and `lyra`
- Follows the existing entry format