### PR TITLE
Add claude-rank — SEO/GEO/AEO audit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Marketing Growth
 - [app-store-optimizer](./plugins/app-store-optimizer)
+- [claude-rank](https://github.com/Houseofmvps/claude-rank) - SEO/GEO/AEO audit with 170+ rules, auto-fix for robots.txt/sitemap.xml/llms.txt/JSON-LD
 - [content-creator](./plugins/content-creator)
 - [growth-hacker](./plugins/growth-hacker)
 - [instagram-curator](./plugins/instagram-curator)


### PR DESCRIPTION
Adds [claude-rank](https://github.com/Houseofmvps/claude-rank) to the Marketing Growth category.

**What it does:** Claude Code plugin that tells you why your site won't get cited by AI — and fixes the discoverability files automatically.

- 170+ rules across 10 scanners (SEO, GEO, AEO, AI Citability, Content, Keywords, Performance + Mobile, Vertical SEO, Security, Content Brief)
- Auto-generates robots.txt, sitemap.xml, llms.txt, and JSON-LD
- URL + directory scanning — audit any live site
- Free, MIT licensed, single dependency (htmlparser2)

**npm**: `@houseofmvps/claude-rank`