### PR TITLE
Add Product Org OS

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1208,8 +1208,8 @@
     {
       "name": "product-org-os",
       "source": "./plugins/product-org-os",
-      "description": "An entire product organization as AI agents. 13 role-based agents, 133 skills, and 2 gateways covering product management, strategy, GTM, competitive intelligence, and more. Built on the Agent Skills open standard.",
-      "version": "3.2.0",
+      "description": "An entire product organization as AI agents. 12 role-based agents, 150+ skills, 38 knowledge packs, and 2 gateways covering product management, strategy, GTM, competitive intelligence, and more. Built on the Agent Skills open standard.",
+      "version": "4.0.0",
       "author": {
         "name": "Yohay Etsion",
         "url": "https://github.com/yohayetsion"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1206,6 +1206,25 @@
       ]
     },
     {
+      "name": "product-org-os",
+      "source": "./plugins/product-org-os",
+      "description": "An entire product organization as AI agents. 13 role-based agents, 133 skills, and 2 gateways covering product management, strategy, GTM, competitive intelligence, and more. Built on the Agent Skills open standard.",
+      "version": "3.2.0",
+      "author": {
+        "name": "Yohay Etsion",
+        "url": "https://github.com/yohayetsion"
+      },
+      "category": "Project & Product Management",
+      "homepage": "https://github.com/yohayetsion/product-org-os",
+      "keywords": [
+        "subagent",
+        "product-management",
+        "strategy",
+        "gtm",
+        "competitive-intelligence"
+      ]
+    },
+    {
       "name": "pricing-packaging-specialist",
       "source": "./plugins/pricing-packaging-specialist",
       "description": "Use this agent when you need to optimize B2B pricing strategies, packaging models, and revenue optimization for enterprise sales. This agent specializes in value-based pricing, usage-based billing, enterprise contract negotiations, and competitive pricing analysis for SaaS platforms. Examples:",

--- a/README-zh.md
+++ b/README-zh.md
@@ -174,6 +174,7 @@
 - [plan](./plugins/plan)
 - [planning-prd-agent](./plugins/planning-prd-agent)
 - [prd-specialist](./plugins/prd-specialist)
+- [product-org-os](./plugins/product-org-os)
 - [project-shipper](./plugins/project-shipper)
 - [sprint-prioritizer](./plugins/sprint-prioritizer)
 - [studio-producer](./plugins/studio-producer)

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [plan](./plugins/plan)
 - [planning-prd-agent](./plugins/planning-prd-agent)
 - [prd-specialist](./plugins/prd-specialist)
+- [product-org-os](./plugins/product-org-os)
 - [project-shipper](./plugins/project-shipper)
 - [sprint-prioritizer](./plugins/sprint-prioritizer)
 - [studio-producer](./plugins/studio-producer)

--- a/plugins/product-org-os/agents/product-org-os.md
+++ b/plugins/product-org-os/agents/product-org-os.md
@@ -1,0 +1,61 @@
+---
+name: product-org-os
+description: "An entire product organization as AI agents. 13 role-based agents, 133 skills, and 2 gateways covering product management, strategy, GTM, competitive intelligence, and more. Built on the Agent Skills open standard. Install the full system: github:yohayetsion/product-org-os"
+model: opus
+color: blue
+---
+
+# Product Org OS
+
+An entire product organization as AI agents — 13 role-based specialists, 133 skills, and 2 gateways structured around a 6-phase methodology: Strategic Foundation, Strategic Decisions, Strategic Commitments, Coordinated Execution, Business & Customer Outcomes, and Learning & Adaptation.
+
+## Full Installation
+
+This agent is a preview. Install the complete system for all 13 agents, 133 skills, rules, and knowledge packs:
+
+```bash
+claude plugins install github:yohayetsion/product-org-os
+```
+
+Also compatible with Cursor, GitHub Copilot, Gemini CLI, and other Agent Skills-standard tools.
+
+- **Repository**: https://github.com/yohayetsion/product-org-os
+- **Homepage**: https://yohayetsion.github.io/product-org-os/
+- **Agent Guide**: https://github.com/yohayetsion/product-org-os/blob/main/product-org-plugin/agent-guide.md
+
+## Agents
+
+| Agent | Role |
+|-------|------|
+| CPO | Executive product strategy, organization design |
+| VP Product | Product vision, strategic bets, portfolio direction, pricing |
+| Director PM | Roadmap governance, requirements standards, team scaling |
+| Director PMM | GTM strategy, positioning, competitive response |
+| Product Manager | Feature specs, user stories, delivery planning |
+| PMM | Campaign execution, collateral creation, customer research |
+| Product Mentor | Career coaching, professional development |
+| BizOps | Business cases, financial analysis, KPI tracking |
+| BizDev | Partnership strategy, market expansion, deal structuring |
+| Competitive Intelligence | Competitor analysis, win/loss, market landscape |
+| Product Operations | Process optimization, launch coordination, tooling |
+| Value Realization | Success metrics, adoption tracking, customer outcomes |
+| UX Lead | User research, design specs, usability testing |
+
+## Gateways
+
+- **Product Gateway** (`@product`) — Routes requests to the right agent(s) automatically
+- **Product Leadership Team** (`@plt`) — Multi-stakeholder meeting mode for portfolio tradeoffs and strategic decisions
+
+## Key Skills
+
+PRD, feature spec, user story, business case, competitive landscape, GTM strategy, product roadmap, launch plan, pricing strategy, strategic bet, positioning statement, campaign brief, and 120+ more.
+
+## How It Works
+
+Describe what you need in natural language. The gateway analyzes your request and routes it to the right specialist agent(s). Each agent has a distinct role, voice, and domain expertise.
+
+**Examples:**
+- "Write a PRD for user authentication" → Product Manager
+- "Analyze our competitive landscape" → Competitive Intelligence
+- "Plan the GTM for our new feature" → Director PMM
+- "Review our portfolio priorities" → Product Leadership Team

--- a/plugins/product-org-os/agents/product-org-os.md
+++ b/plugins/product-org-os/agents/product-org-os.md
@@ -1,17 +1,17 @@
 ---
 name: product-org-os
-description: "An entire product organization as AI agents. 13 role-based agents, 133 skills, and 2 gateways covering product management, strategy, GTM, competitive intelligence, and more. Built on the Agent Skills open standard. Install the full system: github:yohayetsion/product-org-os"
+description: "An entire product organization as AI agents. 12 role-based agents, 150+ skills, 38 knowledge packs, and 2 gateways covering product management, strategy, GTM, competitive intelligence, and more. Built on the Agent Skills open standard. Install the full system: github:yohayetsion/product-org-os"
 model: opus
 color: blue
 ---
 
 # Product Org OS
 
-An entire product organization as AI agents — 13 role-based specialists, 133 skills, and 2 gateways structured around a 6-phase methodology: Strategic Foundation, Strategic Decisions, Strategic Commitments, Coordinated Execution, Business & Customer Outcomes, and Learning & Adaptation.
+An entire product organization as AI agents — 12 role-based specialists, 150+ skills, 38 knowledge packs, and 2 gateways structured around a 6-phase methodology: Strategic Foundation, Strategic Decisions, Strategic Commitments, Coordinated Execution, Business & Customer Outcomes, and Learning & Adaptation.
 
 ## Full Installation
 
-This agent is a preview. Install the complete system for all 13 agents, 133 skills, rules, and knowledge packs:
+This agent is a preview. Install the complete system for all 12 agents, 150+ skills, rules, and 38 knowledge packs:
 
 ```bash
 claude plugins install github:yohayetsion/product-org-os
@@ -39,7 +39,6 @@ Also compatible with Cursor, GitHub Copilot, Gemini CLI, and other Agent Skills-
 | Competitive Intelligence | Competitor analysis, win/loss, market landscape |
 | Product Operations | Process optimization, launch coordination, tooling |
 | Value Realization | Success metrics, adoption tracking, customer outcomes |
-| UX Lead | User research, design specs, usability testing |
 
 ## Gateways
 


### PR DESCRIPTION
## Product Org OS

An entire product organization as AI agents — 13 role-based agents, 133 skills, and 2 gateways.

- **Repository**: https://github.com/yohayetsion/product-org-os
- **Homepage**: https://yohayetsion.github.io/product-org-os/
- **License**: MIT
- **Agent Guide**: https://github.com/yohayetsion/product-org-os/blob/main/product-org-plugin/agent-guide.md

Agents cover CPO, VP Product, Directors, PMs, PMMs, BizOps, Competitive Intelligence, Product Operations, Value Realization, UX Lead, and more. Each has a distinct role, voice, and domain expertise.

Built on the Agent Skills open standard — works with Claude Code, Cursor, Copilot, Gemini CLI, and other compatible tools.