### PR TITLE
Add cc-inspect plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -56,6 +56,7 @@
 
 ### 工作流编排
 - [angelos-symbo](./plugins/angelos-symbo)
+- [cc-inspect](./plugins/cc-inspect)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Workflow Orchestration
 - [angelos-symbo](./plugins/angelos-symbo)
+- [cc-inspect](./plugins/cc-inspect)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)

--- a/plugins/cc-inspect/commands/cc-inspect.md
+++ b/plugins/cc-inspect/commands/cc-inspect.md
@@ -1,0 +1,25 @@
+---
+allowed-tools: Bash(bash:*), Bash(python3:*), Bash(open:*)
+description: Show all installed skills, plugins, MCP servers, commands, and hooks in a browser dashboard
+---
+
+## Your Task
+
+Inspect the current Claude Code environment and display a browser-based dashboard showing all installed components.
+
+The dashboard is scope-aware (user / project / local) and covers:
+- **Skills** — installed slash-command skills
+- **Plugins** — active Claude Code plugins
+- **MCP Servers** — configured Model Context Protocol servers
+- **Commands** — registered slash commands
+- **Hooks** — configured lifecycle hooks
+
+### How It Works
+
+1. Scan `~/.claude/` and project-level `.claude/` directories
+2. Generate a self-contained HTML dashboard (no external dependencies)
+3. Open it in the default browser
+
+### Source
+
+GitHub: [howardpen9/cc-inspect](https://github.com/howardpen9/cc-inspect)


### PR DESCRIPTION
## Summary

- Adds [cc-inspect](https://github.com/howardpen9/cc-inspect) to the Workflow Orchestration section
- Claude Code environment inspector that shows all installed skills, plugins, MCP servers, commands, and hooks in a browser dashboard
- Scope-aware (user/project/local), zero external dependencies, generates self-contained HTML