### PR TITLE
Add Blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ai-engineer](./plugins/ai-engineer)
 - [api-integration-specialist](./plugins/api-integration-specialist)
 - [backend-architect](./plugins/backend-architect)
-- [blueprint](https://github.com/JuliusBrussee/blueprint) by [@JuliusBrussee](https://github.com/JuliusBrussee) — Specification-driven development system that transforms requirements into structured blueprints, then orchestrates automated parallel builds with validation and adversarial review
+- [blueprint](https://github.com/JuliusBrussee/blueprint)
 - [code-architect](./plugins/code-architect)
 - [desktop-app-dev](./plugins/desktop-app-dev)
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ai-engineer](./plugins/ai-engineer)
 - [api-integration-specialist](./plugins/api-integration-specialist)
 - [backend-architect](./plugins/backend-architect)
+- [blueprint](https://github.com/JuliusBrussee/blueprint) by [@JuliusBrussee](https://github.com/JuliusBrussee) — Specification-driven development system that transforms requirements into structured blueprints, then orchestrates automated parallel builds with validation and adversarial review
 - [code-architect](./plugins/code-architect)
 - [desktop-app-dev](./plugins/desktop-app-dev)
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)


### PR DESCRIPTION
## What is Blueprint?

[Blueprint](https://github.com/JuliusBrussee/blueprint) is a specification-driven development plugin for Claude Code by [@JuliusBrussee](https://github.com/JuliusBrussee).

It transforms natural language requirements into structured, numbered blueprints and then orchestrates automated parallel builds with validation and adversarial review — bridging the gap between high-level intent and production-ready code.

## Key features

- **Five-phase workflow** — Research, Draft, Architect, Build, and Inspect phases via slash commands
- **Blueprint-first approach** — decomposes requirements into numbered, testable domain specs before any code is written
- **Parallel execution** — groups independent tasks and dispatches them concurrently across dependency tiers
- **Dual-model adversarial review** — integrates OpenAI Codex as a second reviewer to catch flaws single-model self-review misses
- **Automated validation loops** — each build task runs against acceptance criteria with fix-and-retry cycles
- **Full traceability** — every line of code traces back to a specific blueprint requirement

## Placement

Added under **Development Engineering**, alphabetically between `backend-architect` and `code-architect`.