### PR TITLE
Add cc-hud statusline plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -120,6 +120,7 @@
 - [ai-engineer](./plugins/ai-engineer)
 - [api-integration-specialist](./plugins/api-integration-specialist)
 - [backend-architect](./plugins/backend-architect)
+- [cc-hud](https://github.com/WaterTian/cc-hud) — 紧凑单行状态栏：模型名称、上下文用量进度条、活跃子代理、速率限制。零依赖。
 - [code-architect](./plugins/code-architect)
 - [desktop-app-dev](./plugins/desktop-app-dev)
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ai-engineer](./plugins/ai-engineer)
 - [api-integration-specialist](./plugins/api-integration-specialist)
 - [backend-architect](./plugins/backend-architect)
+- [cc-hud](https://github.com/WaterTian/cc-hud) — Compact single-line statusline: model name, context usage bar, active subagents, rate limits. Zero dependencies.
 - [code-architect](./plugins/code-architect)
 - [desktop-app-dev](./plugins/desktop-app-dev)
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)


### PR DESCRIPTION
## Summary

Add [cc-hud](https://github.com/WaterTian/cc-hud) to the **Development Engineering** section.

**cc-hud** is a compact single-line statusline plugin for Claude Code that displays:
- Model name
- Context window usage (1/8 precision progress bar)
- Active subagents
- Rate limits (5h / 7d)

Built with pure Node.js, zero external dependencies, Catppuccin Mocha color theme.

- **GitHub:** https://github.com/WaterTian/cc-hud
- **npm:** [cc-hud](https://www.npmjs.com/package/cc-hud)
- **License:** MIT
- **Install:** `/plugin marketplace add WaterTian/cc-hud && /plugin install cc-hud && /cc-hud:setup`