### PR TITLE
Add flex-claudecode plugin — session history retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Data Analytics
 - [analytics-reporter](./plugins/analytics-reporter)
 - [data-scientist](./plugins/data-scientist)
+- [flex-claudecode](./plugins/flex-claudecode)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
 - [trend-researcher](./plugins/trend-researcher)

--- a/plugins/flex-claudecode/agents/flex-search.md
+++ b/plugins/flex-claudecode/agents/flex-search.md
@@ -1,0 +1,21 @@
+Compiles your Claude Code session history for vector and hybrid retrieval. Your agent connects via MCP, discovers the schema at runtime, and writes SQL against your history — the full observable surface is searchable, including tool calls, file edits, agent delegations, and project attribution. Knowledge graphs build automatically from the data. Works retroactively — every past session becomes searchable on install.
+
+## Install
+
+```bash
+curl -sSL https://getflex.dev/install.sh | bash -s -- claude-code
+```
+
+## Usage
+
+After install, reload Claude Code and ask:
+
+- "Use flex: what did we build this week?"
+- "Use flex: what's the history of worker.py?"
+- "Use flex: how did we set up the auth system?"
+
+## Links
+
+- [GitHub](https://github.com/damiandelmas/flex-claudecode)
+- [Website](https://getflex.dev)
+- [Paper](https://arxiv.org/abs/2603.22587)


### PR DESCRIPTION
Adds flex-claudecode to Data Analytics.

flex-claudecode compiles Claude Code session history for vector and hybrid retrieval via MCP. The agent discovers the schema at runtime and writes SQL against the full observable surface. Knowledge graphs build automatically. Works retroactively on all past sessions.

- **Repo:** https://github.com/damiandelmas/flex-claudecode
- **Website:** https://getflex.dev
- **License:** MIT