### PR TITLE
Add vara-skills — Gear/Vara Sails development plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
 - [react-native-dev](./plugins/react-native-dev)
+- [vara-skills](./plugins/vara-skills)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 

--- a/plugins/vara-skills/README.md
+++ b/plugins/vara-skills/README.md
@@ -1,0 +1,7 @@
+# vara-skills
+
+A portable skill pack that turns AI coding agents into Gear/Vara Sails smart contract developers. 20 workflow skills covering the full lifecycle — spec, architecture, implementation, gtest verification, and deployment.
+
+- **Source**: https://github.com/gear-foundation/vara-skills
+- **Install**: Listed on the Claude Code plugin marketplace, or `npx vara-skills add`
+- **Packaging**: Claude Code plugin (`.claude-plugin/`), Codex (`AGENTS.md`), OpenClaw


### PR DESCRIPTION
Adds vara-skills, a Claude Code plugin with 20 workflow skills for Gear/Vara Sails smart contract development.

Built by the Gear Foundation. Ships as a Claude Code plugin with `.claude-plugin/` manifest.