### PR TITLE
Add Onepilot to Companion Apps & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
     - [Marketing Growth](#marketing-growth)
     - [Project & Product Management](#project--product-management)
     - [Security, Compliance, & Legal](#security-compliance--legal)
+* [Companion Apps & Tools](#companion-apps--tools)
 * [Tutorials](#tutorials)
 * [Contributing](#contributing)
 
@@ -189,6 +190,10 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
 
+
+## Companion Apps & Tools
+
+- [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
 
 ## Tutorials
 


### PR DESCRIPTION
Adds a new **Companion Apps & Tools** section with [Onepilot](https://onepilotapp.com) — an iOS app for SSHing into remote servers and running Claude Code from your phone. Since this is an external companion tool rather than a Claude Code plugin, I created a separate section to keep it distinct from the plugin listings. Happy to adjust placement if you prefer it elsewhere.