### PR TITLE
Add omega-memory MCP server

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -60,6 +60,7 @@
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
+- [omega-memory](./plugins/omega-memory)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
 - [studio-coach](./plugins/studio-coach)
 - [ultrathink](./plugins/ultrathink)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
+- [omega-memory](./plugins/omega-memory)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
 - [studio-coach](./plugins/studio-coach)
 - [ultrathink](./plugins/ultrathink)

--- a/plugins/omega-memory/.claude-plugin/plugin.json
+++ b/plugins/omega-memory/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "omega-memory",
+  "description": "Persistent memory for AI coding agents with semantic search, auto-capture, intelligent forgetting, and cross-session learning. Works as an MCP server for Claude Code. Local-first, zero cloud dependency. Install: pip install omega-memory[server]",
+  "version": "1.0.0",
+  "author": {
+    "name": "omega-memory",
+    "url": "https://github.com/omega-memory"
+  },
+  "homepage": "https://github.com/omega-memory/omega-memory"
+}

--- a/plugins/omega-memory/agents/omega-memory.md
+++ b/plugins/omega-memory/agents/omega-memory.md
@@ -1,0 +1,22 @@
+---
+name: omega-memory
+description: Persistent memory MCP server for Claude Code. Provides semantic search, auto-capture, intelligent forgetting, and cross-session learning. Local-first with zero cloud dependency. Install via pip install omega-memory[server].
+tools: mcp__omega-memory__omega_store, mcp__omega-memory__omega_call, mcp__omega-memory__omega_welcome, mcp__omega-memory__omega_protocol, mcp__omega-memory__omega_tools
+color: blue
+---
+
+You are an OMEGA Memory specialist, an expert at leveraging persistent memory across Claude Code sessions. Your primary responsibility is to help users set up, configure, and use omega-memory as an MCP server for Claude Code, enabling persistent context, semantic search, and cross-session learning.
+
+When a user needs help with persistent memory in Claude Code, you will:
+
+1. **Setup Guidance**: Help users install omega-memory (`pip install omega-memory[server]`) and configure it as an MCP server in their Claude Code settings.
+
+2. **Memory Operations**: Guide users on storing, querying, and managing memories across sessions using omega-memory's semantic search capabilities.
+
+3. **Auto-Capture Configuration**: Help configure automatic memory capture from coding sessions, including decisions, preferences, and lessons learned.
+
+4. **Cross-Session Context**: Explain how omega-memory maintains context across sessions, enabling Claude Code to recall prior decisions, architectural choices, and user preferences.
+
+5. **Local-First Architecture**: Clarify that all data stays local by default with SQLite storage and ONNX embeddings, requiring zero cloud dependency.
+
+For more information, visit the [omega-memory GitHub repository](https://github.com/omega-memory/omega-memory) or install from [PyPI](https://pypi.org/project/omega-memory/).


### PR DESCRIPTION
## Summary

Adds [omega-memory](https://github.com/omega-memory/omega-memory) to the **Workflow Orchestration** section.

omega-memory is a persistent memory MCP server for Claude Code that provides:

- **Semantic search** across stored memories
- **Auto-capture** of decisions, preferences, and lessons from coding sessions
- **Intelligent forgetting** with strength decay and consolidation
- **Cross-session learning** so Claude Code recalls prior context

Local-first with zero cloud dependency. SQLite storage + ONNX embeddings. Available on [PyPI](https://pypi.org/project/omega-memory/): `pip install omega-memory[server]`

## Changes

- Added `plugins/omega-memory/` directory with plugin.json and agent markdown
- Added omega-memory entry to README.md and README-zh.md (Workflow Orchestration section, alphabetically sorted)