### PR TITLE
Add Knowledge Graph to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
+- [knowledge-graph](https://github.com/hilyfux/knowledge-graph) - Built on Anthropic internal engineering practices and Karpathy's AutoResearch methodology. A zero-dependency, git-native memory layer for Claude Code that persists learned context across sessions. Pure bash, ~3ms/event, privacy-first.
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)


### PR DESCRIPTION
## Summary
- add Knowledge Graph to the Development Engineering plugin list
- describe it as a persistent memory layer for Claude Code
- highlight its zero-dependency, git-native approach

## Why it fits
Knowledge Graph is a Claude Code-focused plugin/tool that helps preserve learned context across sessions. It is built on Anthropic internal engineering practices and Karpathy's AutoResearch methodology, while staying pure bash, privacy-first, and lightweight.