### PR TITLE
Add Maestro Orchestrate to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
 - [studio-coach](./plugins/studio-coach)
 - [ultrathink](./plugins/ultrathink)
+- [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) — Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, least-privilege security tiers, and standalone commands for code review, debugging, security audit, and more. Runs on Gemini CLI, Claude Code, and Codex.
 
 ### Automation DevOps
 - [deployment-engineer](./plugins/deployment-engineer)

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
 - [studio-coach](./plugins/studio-coach)
+- [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate)
 - [ultrathink](./plugins/ultrathink)
-- [maestro-orchestrate](https://github.com/josstei/maestro-orchestrate) — Multi-agent development orchestration coordinating 22 specialized subagents through 4-phase workflows with native parallel execution, persistent sessions, least-privilege security tiers, and standalone commands for code review, debugging, security audit, and more. Runs on Gemini CLI, Claude Code, and Codex.
 
 ### Automation DevOps
 - [deployment-engineer](./plugins/deployment-engineer)


### PR DESCRIPTION
Adds [Maestro Orchestrate](https://github.com/josstei/maestro-orchestrate) to the Workflow Orchestration section.

Maestro Orchestrate is a multi-agent development orchestration plugin for Claude Code. It coordinates 22 specialized subagents through 4-phase workflows with:

- Native parallel subagent execution
- MCP server with 12 tools
- Persistent session state
- Least-privilege security tiers
- Slash commands, subagents, hooks, and MCP server
- Also runs on Gemini CLI and Codex from the same codebase