### PR TITLE
Add WhichModel MCP server

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,6 +21,7 @@
     - [市场营销与增长](#市场营销与增长)
     - [项目与产品管理](#项目与产品管理)
     - [安全、合规与法律](#安全、合规与法律)
+    - [MCP 服务器](#mcp-服务器)
 * [使用教程](#使用教程)
 * [如何贡献](#如何贡献)
 
@@ -188,6 +189,9 @@
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+
+### MCP 服务器
+- [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — 面向 Claude Code 的 AI 模型定价与推荐 MCP 服务器，帮助为每项任务选择最合适、性价比最高的模型。数据经交叉验证，每 4 小时更新一次。MCP 端点：`https://whichmodel.dev/mcp`
 
 
 ## 使用教程

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
     - [Marketing Growth](#marketing-growth)
     - [Project & Product Management](#project--product-management)
     - [Security, Compliance, & Legal](#security-compliance--legal)
+    - [MCP Servers](#mcp-servers)
 * [Tutorials](#tutorials)
 * [Contributing](#contributing)
 
@@ -188,6 +189,9 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+
+### MCP Servers
+- [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 
 
 ## Tutorials


### PR DESCRIPTION
## Summary

- Adds [WhichModel](https://github.com/Which-Model/whichmodel-mcp) to both the English and Chinese READMEs
- Creates a new **MCP Servers** section to properly categorize external MCP server integrations
- WhichModel is an AI model pricing & recommendation MCP server for Claude Code that helps choose the right model for every task at the best price, with cross-verified data updated every 4 hours

**Product details:**
- Website: https://whichmodel.dev
- GitHub: https://github.com/Which-Model/whichmodel-mcp
- MCP Endpoint: `https://whichmodel.dev/mcp`

## Test plan

- [ ] Verify links in README.md resolve correctly
- [ ] Verify links in README-zh.md resolve correctly
- [ ] Confirm new MCP Servers section appears in table of contents for both READMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)