### PR TITLE
Add cc-aws-keepalive plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1785,6 +1785,29 @@
         "hooks",
         "skill"
       ]
+    },
+    {
+      "name": "cc-aws-keepalive",
+      "source": "./plugins/cc-aws-keepalive",
+      "description": "Proactive AWS credential expiry detection, session-surviving credential refresh, and optional statusline timer for Claude Code on Bedrock.",
+      "version": "0.5.1-ccplugins.1",
+      "author": {
+        "name": "GeiserX",
+        "url": "https://github.com/GeiserX"
+      },
+      "category": "Automation DevOps",
+      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/cc-aws-keepalive",
+      "repository": "https://github.com/GeiserX/cc-aws-keepalive",
+      "license": "GPL-3.0",
+      "keywords": [
+        "aws",
+        "bedrock",
+        "credentials",
+        "sso",
+        "saml",
+        "keepalive",
+        "hooks"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -65,6 +65,7 @@
 - [ultrathink](./plugins/ultrathink)
 
 ### 自动化运维
+- [cc-aws-keepalive](./plugins/cc-aws-keepalive)
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)

--- a/README-zh.md
+++ b/README-zh.md
@@ -67,6 +67,7 @@
 - [ultrathink](./plugins/ultrathink)
 
 ### 自动化运维
+- [cc-aws-keepalive](./plugins/cc-aws-keepalive)
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ultrathink](./plugins/ultrathink)
 
 ### Automation DevOps
+- [cc-aws-keepalive](./plugins/cc-aws-keepalive)
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Automation DevOps
 - [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) - Auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types, selects from 28+ hooks, scores quality (0-100, A-F). `npm i -g puiux-pilot`
+- [cc-aws-keepalive](./plugins/cc-aws-keepalive)
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [MyVibe](https://www.myvibe.so) - Instant deployment with `/myvibe:publish`

--- a/plugins/cc-aws-keepalive/.claude-plugin/plugin.json
+++ b/plugins/cc-aws-keepalive/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "cc-aws-keepalive",
+  "description": "Keep Claude Code sessions alive through AWS credential expiration. Hooks into UserPromptSubmit to proactively detect expiring AWS credentials and refresh them before they break your Bedrock-powered session. Features proactive warnings, credential refresh bypass, and optional statusline timer.",
+  "version": "0.1.0",
+  "author": {
+    "name": "GeiserX"
+  },
+  "homepage": "https://github.com/GeiserX/cc-aws-keepalive"
+}

--- a/plugins/cc-aws-keepalive/.claude-plugin/plugin.json
+++ b/plugins/cc-aws-keepalive/.claude-plugin/plugin.json
@@ -1,9 +1,12 @@
 {
   "name": "cc-aws-keepalive",
-  "description": "Keep Claude Code sessions alive through AWS credential expiration. Hooks into UserPromptSubmit to proactively detect expiring AWS credentials and refresh them before they break your Bedrock-powered session. Features proactive warnings, credential refresh bypass, and optional statusline timer.",
-  "version": "0.1.0",
+  "description": "Keep Claude Code sessions alive through AWS credential expiration",
+  "version": "0.5.1-ccplugins.1",
   "author": {
-    "name": "GeiserX"
+    "name": "GeiserX",
+    "email": "9169332+GeiserX@users.noreply.github.com"
   },
+  "repository": "https://github.com/GeiserX/cc-aws-keepalive",
+  "license": "GPL-3.0",
   "homepage": "https://github.com/GeiserX/cc-aws-keepalive"
 }

--- a/plugins/cc-aws-keepalive/DOWNSTREAM-CHANGES.md
+++ b/plugins/cc-aws-keepalive/DOWNSTREAM-CHANGES.md
@@ -1,0 +1,21 @@
+# Downstream modification notice
+
+This package is a modified derivative of
+[`GeiserX/cc-aws-keepalive` 0.5.0](https://github.com/GeiserX/cc-aws-keepalive/tree/v0.5.0),
+distributed by the Awesome Claude Code Plugins marketplace as
+`0.5.1-ccplugins.1` under GPL-3.0.
+
+Changes made on 2026-08-12:
+
+- emit proactive credential warnings through Claude Code's documented
+  `systemMessage` hook response instead of successful-hook stderr;
+- verify reactive auto-login through STS when no expiration field is configured;
+- require verified SSH host keys by default, make trust-on-first-use explicit,
+  and remove plaintext SSH-password support;
+- support version-path updates from any Claude Code marketplace cache;
+- document the aggregate-marketplace installation path and external Node.js 18+
+  prerequisite; and
+- add regression tests for these downstream integrations and security fixes.
+
+The original copyright notices and GPL-3.0 license are retained in
+[LICENSE](LICENSE).

--- a/plugins/cc-aws-keepalive/LICENSE
+++ b/plugins/cc-aws-keepalive/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/plugins/cc-aws-keepalive/README.md
+++ b/plugins/cc-aws-keepalive/README.md
@@ -1,0 +1,526 @@
+<p align="center">
+  <img src="docs/images/banner.svg" alt="cc-aws-keepalive banner" width="900"/>
+</p>
+
+<p align="center">
+  <a href="https://codecov.io/gh/GeiserX/cc-aws-keepalive"><img src="https://codecov.io/gh/GeiserX/cc-aws-keepalive/graph/badge.svg" alt="codecov"></a>
+</p>
+
+# cc-aws-keepalive
+
+Keep Claude Code sessions alive through AWS credential expiration. No more restarting terminal tabs every time your SSO/SAML session expires.
+
+> This marketplace distributes `0.5.1-ccplugins.1`, a security-hardened
+> derivative of upstream 0.5.0. See [DOWNSTREAM-CHANGES.md](DOWNSTREAM-CHANGES.md)
+> for the dated modification notice.
+
+## Problem
+
+When using Claude Code with AWS Bedrock, the AWS SDK caches credentials in memory. After your SSO/SAML session expires (typically every 1-12 hours), all Claude Code sessions become unresponsive and must be restarted — often corrupting conversations and losing context.
+
+## Solution
+
+Four Node.js scripts (cross-platform: macOS, Linux, Windows) that hook into Claude Code's credential lifecycle:
+
+| Script | Purpose | CC Setting |
+|--------|---------|------------|
+| `aws-cred-export.mjs` | Reads fresh creds from `~/.aws/credentials`, bypassing SDK in-memory cache | `awsCredentialExport` |
+| `aws-auth-refresh.mjs` | On auth failure, checks if you already re-authed in another terminal | `awsAuthRefresh` |
+| `aws-cred-check.mjs` | Proactive check before each prompt — warns if expired or nearing expiry | `hooks.UserPromptSubmit` |
+| `aws-statusline.mjs` | Optional persistent timer in the status bar (e.g., `AWS: 4h23m`) | `statusLine` |
+
+### How it works
+
+**Before expiry (proactive):**
+
+1. You submit a prompt in Claude Code
+2. The `UserPromptSubmit` hook checks credential expiration
+3. If nearing expiry and `autoLoginCmd` is configured: fires it in the background (you get a notification, approve MFA, session renews silently)
+4. If nearing expiry without `autoLoginCmd`: inline warning with re-auth command
+5. If expired: warns inline — the prompt proceeds and `awsAuthRefresh` handles recovery
+
+**After expiry (reactive):**
+
+1. Claude Code hits a Bedrock 403
+2. `awsAuthRefresh` runs — checks if you already re-authed in another terminal
+3. If still expired and `autoLoginCmd` is configured, runs it synchronously (waits up to 3 minutes for password + MFA)
+4. `awsCredentialExport` reads fresh creds from disk (bypassing SDK memory cache)
+5. Claude Code retries the API call — session continues without restart
+
+### The key insight
+
+Claude Code's AWS SDK caches credentials in memory and doesn't re-read `~/.aws/credentials` after expiry ([known issue](https://github.com/anthropics/claude-code/issues/41064)). The `awsCredentialExport` setting forces Claude Code to call our script instead, which always reads the latest credentials from disk.
+
+## Install
+
+Requires Node.js 18 or newer. Install Node.js separately if it is not already
+available on your `PATH`; native Claude Code installations do not provide a
+standalone `node` executable.
+
+### Option A: As a Claude Code plugin (recommended)
+
+```bash
+/plugin marketplace add ccplugins/awesome-claude-code-plugins
+/plugin install cc-aws-keepalive@awesome-claude-code-plugins
+```
+
+The plugin auto-registers the `UserPromptSubmit` hook. You still need to add `awsCredentialExport` and `awsAuthRefresh` to `~/.claude/settings.json` — point them at the cached plugin path:
+
+```json
+{
+  "awsCredentialExport": "node ~/.claude/plugins/cache/awesome-claude-code-plugins/cc-aws-keepalive/<version>/aws-cred-export.mjs",
+  "awsAuthRefresh": "node ~/.claude/plugins/cache/awesome-claude-code-plugins/cc-aws-keepalive/<version>/aws-auth-refresh.mjs"
+}
+```
+
+Replace `<version>` with the installed version (for this snapshot,
+`0.5.1-ccplugins.1`),
+then run the cached installer. It creates the protected config file and prints
+the exact settings paths for this installation:
+
+```bash
+node ~/.claude/plugins/cache/awesome-claude-code-plugins/cc-aws-keepalive/<version>/install.mjs
+```
+
+Edit the created `~/.config/cc-aws-keepalive/config.json` before using the
+plugin.
+
+### Option B: Manual (no plugin system)
+
+```bash
+git clone https://github.com/GeiserX/cc-aws-keepalive.git
+cd cc-aws-keepalive
+node install.mjs
+```
+
+The installer creates a config and prints all settings to add to `~/.claude/settings.json`.
+
+### Upgrading
+
+After upgrading, re-run the installer to update paths:
+
+- **Plugin**: `node ~/.claude/plugins/cache/awesome-claude-code-plugins/cc-aws-keepalive/<version>/install.mjs`
+- **Manual**: `git pull && node install.mjs`
+
+The installer automatically:
+
+1. **OMC HUD wrapper**: Cleans up any legacy timer patch from `omc-hud.mjs` and updates the `aws-hud-wrapper.mjs` with the current path
+2. **settings.json paths**: Updates `awsCredentialExport` and `awsAuthRefresh` to point to the new version directory (preserves any custom wrapper commands)
+
+## Configure
+
+Edit `~/.config/cc-aws-keepalive/config.json`:
+
+```json
+{
+  "profile": "my-bedrock-profile",
+  "expirationField": "x_security_token_expires",
+  "loginCmd": "saml2aws login --profile my-bedrock-profile",
+  "autoLoginCmd": "",
+  "autoLoginMinutes": 30,
+  "warnMinutes": 30,
+  "timerWarnMinutes": 60,
+  "statusLineCmd": ""
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `profile` | AWS profile name in `~/.aws/credentials` |
+| `expirationField` | Field storing session expiration as unix timestamp. Leave empty to fall back to `aws sts get-caller-identity` (slower, can only detect expired vs. valid — not time remaining) |
+| `loginCmd` | Command to re-authenticate (shown in warnings so you can copy-paste it) |
+| `autoLoginCmd` | Command for fully automated re-authentication. Must work without a TTY — see [Auto-login setup](#auto-login-setup) below |
+| `autoLoginMinutes` | Auto-run `autoLoginCmd` when session has fewer than this many minutes left (0 = disabled). Requires `expirationField`. Rate-limited to once per 5 minutes |
+| `warnMinutes` | Minutes before expiry to start showing warnings |
+| `timerWarnMinutes` | Minutes before expiry to turn the statusline timer red |
+| `statusLineCmd` | Existing status line command to compose with (leave empty for standalone) |
+
+**Environment variables:**
+
+| Variable | Description |
+|----------|-------------|
+| `CC_KEEPALIVE_PROFILE` | Overrides `profile` from config. Useful for multi-account setups where different terminals use different AWS accounts |
+
+**Common `expirationField` values by provider:**
+
+| Provider | `expirationField` value |
+|----------|------------------------|
+| saml2aws | `x_security_token_expires` |
+| gimme-aws-creds | `x_security_token_expires` |
+| awsmyid | `awsmyid_session_expiration` |
+| aws-google-auth | `x_security_token_expires` |
+
+Check your `~/.aws/credentials` after authenticating to find the field name for your provider.
+
+## Auto-login setup
+
+The `autoLoginCmd` feature lets cc-aws-keepalive re-authenticate automatically — no manual terminal switching needed. This section walks through setting it up end-to-end.
+
+### How it triggers
+
+- **Proactive** (before expiry): When you submit a prompt and your session has fewer than `autoLoginMinutes` left, the command fires **in the background**. You keep working while it runs. Rate-limited to once per 5 minutes to avoid spamming.
+- **Reactive** (after expiry): When Claude Code hits a Bedrock 403, the command runs **synchronously** with up to 3 minutes for completion. Since you're blocked waiting for credentials anyway, this is fine.
+
+### Requirements
+
+Your `autoLoginCmd` must:
+
+1. **Run without a TTY** — Claude Code hooks have no terminal attached. Interactive prompts hang forever.
+2. **Handle password input** — pull it from a keychain/vault, not stdin.
+3. **Handle MFA** — either trigger a push notification you approve on your phone, or use a TOTP generator.
+4. **Suppress spinner/progress output** — ANSI escape codes from progress bars break pattern matching in expect scripts. Most CLI tools have a `--no-progress` or `--spinner=false` flag.
+5. **Pre-select the IAM role** — if your tool shows an interactive role chooser, use a CLI flag to filter or pre-select the role. Otherwise, characters from the password prompt can spill into the role selector.
+
+### Step 1: Store your password securely
+
+Never put passwords in config files or environment variables. Use your OS keychain.
+
+**macOS** (Keychain):
+```bash
+security add-generic-password -s cc-aws-keepalive -a mylogin -w 'YourPassword123!'
+# Verify it works:
+security find-generic-password -s cc-aws-keepalive -a mylogin -w
+```
+
+**Linux** (libsecret / GNOME Keyring):
+```bash
+secret-tool store --label="cc-aws-keepalive" service cc-aws-keepalive account mylogin <<< 'YourPassword123!'
+# Verify:
+secret-tool lookup service cc-aws-keepalive account mylogin
+```
+
+**Windows** (Credential Manager via PowerShell):
+```powershell
+# Store
+cmdkey /add:cc-aws-keepalive /user:mylogin /pass:YourPassword123!
+# Retrieve (in your automation script)
+(New-Object System.Net.NetworkCredential((cmdkey /list:cc-aws-keepalive))).Password
+```
+
+Replace `mylogin` with a label that identifies your credential provider account (e.g., `saml2aws`, `awsmyid`).
+
+### Step 2: Write an expect script
+
+[`expect`](https://core.tcl-lang.org/expect/index) drives interactive CLI tools by matching output patterns and sending responses. Install it with `brew install expect` (macOS) or `apt install expect` (Linux).
+
+Here's a template — adapt it to your login tool:
+
+```expect
+#!/usr/bin/env expect
+# Auto-login script for cc-aws-keepalive
+# Adapt the spawn command, password retrieval, and success pattern to your tool.
+
+set timeout 180
+log_user 0
+set notified 0
+
+# --- Password retrieval ---
+# macOS Keychain:
+set password [exec security find-generic-password -s cc-aws-keepalive -a mylogin -w]
+# Linux libsecret:
+# set password [exec secret-tool lookup service cc-aws-keepalive account mylogin]
+
+# --- CLI arguments (optional, for flexibility) ---
+set profile [lindex $argv 0]
+if {$profile eq ""} { set profile "default" }
+
+# --- Spawn your login tool ---
+# Key flags:
+#   --spinner=false / --no-progress : suppress ANSI output that breaks expect
+#   -r / --role-filter              : skip interactive role chooser
+#   -f push / --mfa-mode push       : use push MFA instead of TOTP prompt
+#
+# Examples:
+#   saml2aws:  spawn saml2aws login --profile $profile --skip-prompt --disable-keychain
+#   awsmyid:   spawn awsmyid login -p $profile -r bedrock -f push --spinner=false
+#   gimme:     spawn gimme-aws-creds --profile $profile
+spawn your-login-tool login --profile $profile --spinner=false
+
+expect {
+    -re {[Pp]assword} {
+        sleep 0.5
+        send -- "$password\r"
+        exp_continue
+    }
+    -re {MFA Number:\s*(\d+)} {
+        # Okta number matching challenge — show the code in a desktop notification
+        # Guard: only notify once per login (tools may retry and output multiple numbers)
+        if {!$notified} {
+            set notified 1
+            set mfa_number $expect_out(1,string)
+            # macOS:
+            exec osascript -e "display notification \"Enter $mfa_number on your phone\" with title \"AWS MFA\" subtitle \"Number: $mfa_number\" sound name \"Ping\""
+            # Linux alternative (requires notify-send):
+            # exec notify-send "AWS MFA" "Enter $mfa_number on your phone"
+        }
+        exp_continue
+    }
+    -re {push notification|Waiting.*approval|verify.*identity|Please Approve} {
+        # Simple push MFA (no number) — just remind to approve
+        if {!$notified} {
+            set notified 1
+            # macOS:
+            exec osascript -e {display notification "Check your authenticator app" with title "AWS Login" subtitle "MFA push sent" sound name "Ping"}
+            # Linux alternative:
+            # exec notify-send "AWS Login" "MFA push sent — check your authenticator app"
+        }
+        exp_continue
+    }
+    -re {hoose.*role|Select.*role} {
+        # Fallback if role filter didn't work — accept first match
+        send "\r"
+        exp_continue
+    }
+    -re {Credentials will expire|Success|Logged in} {
+        puts "Auto-login succeeded"
+    }
+    eof {}
+    timeout {
+        puts stderr "auto-login timed out after 180s"
+        exit 1
+    }
+}
+
+set result [wait]
+exit [lindex $result 3]
+```
+
+Save it to `~/.config/cc-aws-keepalive/auto-login.exp` and make it executable:
+
+```bash
+chmod +x ~/.config/cc-aws-keepalive/auto-login.exp
+```
+
+**Test it manually first:**
+
+```bash
+# This should complete the full login without any manual input
+expect ~/.config/cc-aws-keepalive/auto-login.exp my-profile
+```
+
+If it hangs, run with `log_user 1` (change line 4) to see what the tool is outputting — often it's an unexpected prompt or ANSI escape codes breaking the pattern match.
+
+### Step 3: Configure cc-aws-keepalive
+
+Update your `~/.config/cc-aws-keepalive/config.json`:
+
+```json
+{
+  "profile": "my-bedrock-profile",
+  "expirationField": "x_security_token_expires",
+  "loginCmd": "saml2aws login --profile my-bedrock-profile",
+  "autoLoginCmd": "expect ~/.config/cc-aws-keepalive/auto-login.exp my-bedrock-profile",
+  "autoLoginMinutes": 30,
+  "warnMinutes": 30,
+  "timerWarnMinutes": 60,
+  "statusLineCmd": ""
+}
+```
+
+Key points:
+- `autoLoginCmd` is the full command — it must work when run as `sh -c "your command"` with no TTY
+- `autoLoginMinutes` controls how early the proactive trigger fires (30 = re-auth when 30 minutes remain)
+- `loginCmd` is still shown in manual warnings as a fallback — it's never run automatically
+
+### Common pitfalls
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Script hangs at password prompt | ANSI spinner output breaks the `Password` pattern match | Add `--spinner=false` or `--no-progress` to your spawn command |
+| Wrong IAM role selected | Password characters leak into interactive role chooser | Use a role filter flag (`-r`, `--role`, `--role-filter`) to pre-select |
+| Password not found | Keychain service/account name mismatch | Run the `security find-generic-password` command manually to verify |
+| Times out after 180s | MFA push not approved, or success pattern doesn't match | Set `log_user 1` and run manually to see what the tool outputs after login |
+| MFA number not showing | Number matching pattern doesn't match your tool's output | Set `log_user 1`, run manually, and look for the line containing the number. Update the `-re {MFA Number:\s*(\d+)}` pattern to match |
+| `spawn: command not found` | `expect` not installed | `brew install expect` (macOS) or `apt install expect` (Linux) |
+| Works manually but not from cc-aws-keepalive | PATH differs when run from Claude Code | Use full path to your login tool in the spawn command (e.g., `/usr/local/bin/saml2aws`) |
+
+### Windows alternative
+
+Windows doesn't have `expect`. Use a PowerShell script instead:
+
+```powershell
+# auto-login.ps1
+$password = (cmdkey /list:cc-aws-keepalive | Select-String "Password").ToString().Split("=")[1].Trim()
+echo $password | your-login-tool login --profile $args[0] --stdin-password
+```
+
+Set `autoLoginCmd` to: `powershell -File %USERPROFILE%\.config\cc-aws-keepalive\auto-login.ps1 my-profile`
+
+## Status line timer
+
+The optional `aws-statusline.mjs` shows a persistent countdown in the Claude Code status bar:
+
+- Normal: `AWS: 4h23m`
+- Warning (< `timerWarnMinutes`): yellow `AWS: 45m`
+- Expired: red `AWS: EXPIRED`
+
+**[oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) users:** The installer creates an `aws-hud-wrapper.mjs` that intercepts OMC's HUD output and appends the timer inline (e.g., `aws:5h23m`). It automatically updates the `statusLine` setting to use the wrapper. This approach survives OMC updates — the wrapper lives outside `omc-hud.mjs` and delegates to it.
+
+For other status line plugins, set `statusLineCmd` in config.json to your existing command — the timer will be appended.
+
+## Credential providers
+
+Works with any tool that **materializes temporary credentials** (`aws_access_key_id`, `aws_secret_access_key`, `aws_session_token`) into `~/.aws/credentials`:
+
+- **saml2aws**
+- **gimme-aws-creds** (Okta)
+- **aws-google-auth**
+- **onelogin-aws-cli**
+- Any corporate SAML/OIDC CLI that writes to `~/.aws/credentials`
+
+> **Note:** Plain `aws sso login` stores tokens in `~/.aws/sso/cache/`, not in `~/.aws/credentials`. If you use AWS SSO, you need a tool that exports the session to the credentials file, or use `aws configure export-credentials --profile myprofile --format process`.
+
+## Requirements
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) with `CLAUDE_CODE_USE_BEDROCK=1`
+- Node.js 18 or newer, installed separately and available on `PATH`
+- Any AWS credential provider that writes to `~/.aws/credentials`
+
+## Platform notes
+
+The core scripts (credential export, auth refresh, cred check, statusline) work on **macOS, Linux, and Windows**. The `autoLoginCmd` feature runs your command via the platform's native shell (`/bin/sh` on Unix, `cmd.exe` on Windows). On Windows, use a PowerShell script instead of `expect` — see [Windows alternative](#windows-alternative).
+
+## Credential sync
+
+Optionally sync credentials to remote machines after every successful login. Useful when you develop on multiple machines that share the same AWS profile.
+
+Sync fires automatically:
+- **Proactive**: On each prompt submission when credentials are fresh (debounced by `syncCooldownSeconds`)
+- **Reactive**: After a successful `autoLoginCmd` re-authentication
+
+### Configuration
+
+Add a `syncTargets` array to your `~/.config/cc-aws-keepalive/config.json`:
+
+```json
+{
+  "profile": "my-bedrock-profile",
+  "expirationField": "x_security_token_expires",
+  "syncTargets": [
+    {
+      "type": "ssh",
+      "host": "my-remote-machine.local",
+      "user": "myuser"
+    }
+  ],
+  "syncTimeoutSeconds": 15,
+  "syncCooldownSeconds": 60
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `syncTargets` | Array of sync targets (empty = disabled) |
+| `syncTimeoutSeconds` | Timeout per sync operation in seconds (default: 15). Uses seconds (not minutes) because sync operations complete in seconds, unlike session lifetimes |
+| `syncCooldownSeconds` | Minimum seconds between syncs (default: 60) |
+
+### Sync types
+
+#### SSH
+
+Copies credentials to a remote `~/.aws/credentials` file via SSH. Uses key-based auth by default.
+
+```json
+{
+  "type": "ssh",
+  "host": "remote-machine.local",
+  "user": "remoteuser",
+  "remoteProfile": "default",
+  "remotePath": "~/.aws/credentials",
+  "sshArgs": "-p 2222"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `host` | Remote hostname (required) |
+| `user` | SSH username (optional — uses SSH config default) |
+| `remoteProfile` | Profile name on the remote file (default: same as local `profile`) |
+| `remotePath` | Remote credentials file path (default: `~/.aws/credentials`) |
+| `sshArgs` | Additional SSH arguments as a string or array (optional). Use array form for paths with spaces: `["-i", "/path/to/key"]` |
+| `acceptNewHostKey` | Set to `true` only to opt into trust-on-first-use. The secure default requires a previously verified host key in `known_hosts` |
+
+The remote write is atomic (write to `.tmp` then `mv`). Credentials are piped via stdin — never in command arguments or environment variables. Password authentication is intentionally unsupported; use an SSH key or agent and verify the host key before enabling sync.
+
+#### Webhook
+
+Posts credentials to an HTTPS endpoint. Refuses non-HTTPS URLs.
+
+```json
+{
+  "type": "webhook",
+  "url": "https://my-service.example.com/aws-creds",
+  "method": "POST",
+  "headers": {
+    "Authorization": "Bearer ${MY_SECRET_TOKEN}"
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `url` | HTTPS endpoint (required — HTTP refused) |
+| `method` | HTTP method (default: `POST`) |
+| `headers` | Custom headers; supports `${ENV_VAR}` interpolation (optional) |
+| `remoteProfile` | Profile name in the JSON payload (default: same as local `profile`) |
+
+Payload format:
+```json
+{
+  "profile": "my-profile",
+  "credentials": {
+    "aws_access_key_id": "...",
+    "aws_secret_access_key": "...",
+    "aws_session_token": "..."
+  },
+  "timestamp": 1716000000000
+}
+```
+
+#### Command
+
+Runs a custom command and pipes credential JSON to its stdin.
+
+```json
+{
+  "type": "command",
+  "command": "/path/to/my-sync-script.sh"
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `command` | Shell command to execute (required) |
+| `remoteProfile` | Profile name in the JSON payload (default: same as local `profile`) |
+
+Stdin JSON format:
+```json
+{
+  "profile": "my-profile",
+  "credentials": {
+    "aws_access_key_id": "...",
+    "aws_secret_access_key": "...",
+    "aws_session_token": "..."
+  },
+  "expiration": "2024-01-01T12:00:00Z",
+  "timestamp": 1716000000000
+}
+```
+
+### Security
+
+- **Session tokens only**: Sync is refused if no `aws_session_token` is present (will never sync long-lived IAM keys)
+- **HTTPS enforced**: Webhook targets must use `https://`; also refuses if `NODE_TLS_REJECT_UNAUTHORIZED=0`
+- **Stdin transport**: Credentials are piped via stdin, never passed as CLI arguments or environment variables
+- **Atomic writes**: SSH sync writes to a `.tmp` file then atomically renames — no partial reads on the remote
+- **Verified SSH hosts by default**: SSH uses `StrictHostKeyChecking=yes`, so credentials are never sent to an unknown host. Pre-populate `~/.ssh/known_hosts` after verifying the fingerprint. Trust-on-first-use requires the explicit `acceptNewHostKey: true` opt-in and can expose credentials if the first connection is intercepted
+- **Fire-and-forget**: Sync runs in the background and never blocks your Claude Code session
+
+## Limitations
+
+- **Proactive time-remaining warnings** require `expirationField`. Without it, the STS fallback can only detect valid vs. expired — not "expires in 20 minutes".
+- **Fully automated re-authentication** requires an `autoLoginCmd` that can drive your login tool non-interactively. See [Auto-login setup](#auto-login-setup) for a complete walkthrough.
+
+## License
+
+[GPL-3.0](LICENSE)

--- a/plugins/cc-aws-keepalive/aws-auth-refresh.mjs
+++ b/plugins/cc-aws-keepalive/aws-auth-refresh.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Called by Claude Code (awsAuthRefresh) when Bedrock auth fails.
+// Tries auto-login if configured, otherwise prompts user to re-auth manually.
+import { execSync, execFileSync } from "node:child_process";
+import { loadConfig, getRemaining, formatTime, tryAcquireAutoLoginLock, releaseAutoLoginLock, sleepSync } from "./lib.mjs";
+
+const config = loadConfig();
+
+// Check if a background auto-login (from cred-check) already refreshed creds
+const info = getRemaining(config);
+if (info && info.remaining > 0) {
+  console.log(
+    `Credentials refreshed (valid for ${formatTime(info.remaining)}). Retrying...`
+  );
+  process.exit(0);
+}
+
+// No expiration field — fall back to STS
+if (!info) {
+  try {
+    execFileSync("aws", ["sts", "get-caller-identity", "--profile", config.profile], {
+      stdio: "ignore",
+      timeout: 15_000,
+      shell: process.platform === "win32",
+    });
+    console.log("Credentials valid. Retrying...");
+    process.exit(0);
+  } catch {
+    // Creds expired
+  }
+}
+
+// Try auto-login synchronously (user is blocked anyway — CC waits for this script)
+// Only use autoLoginCmd — loginCmd may be interactive and hang without a TTY
+const autoCmd = config.autoLoginCmd;
+if (autoCmd) {
+  if (!tryAcquireAutoLoginLock()) {
+    // Another session is already running auto-login — wait for it
+    console.log("Another session is already re-authenticating. Waiting...");
+    const waitStart = Date.now();
+    while (Date.now() - waitStart < 180_000) {
+      const check = getRemaining(config);
+      if (check && check.remaining > 0) {
+        console.log(
+          `Credentials refreshed by another session (valid for ${formatTime(check.remaining)}). Retrying...`
+        );
+        process.exit(0);
+      }
+      if (!check) {
+        try {
+          execFileSync("aws", ["sts", "get-caller-identity", "--profile", config.profile], {
+            stdio: "ignore",
+            timeout: 15_000,
+            shell: process.platform === "win32",
+          });
+          console.log("Credentials refreshed by another session. Retrying...");
+          process.exit(0);
+        } catch { /* still invalid */ }
+      }
+      sleepSync(3000);
+    }
+    console.log("Timed out waiting for the other session to complete re-authentication.");
+  } else {
+    console.log("AWS credentials expired. Running auto-login...");
+    try {
+      execSync(autoCmd, { stdio: "inherit", timeout: 180_000 });
+      releaseAutoLoginLock();
+      const refreshed = getRemaining(config);
+      let refreshedOk = Boolean(refreshed && refreshed.remaining > 0);
+      if (!refreshed) {
+        try {
+          execFileSync("aws", ["sts", "get-caller-identity", "--profile", config.profile], {
+            stdio: "ignore",
+            timeout: 15_000,
+            shell: process.platform === "win32",
+          });
+          refreshedOk = true;
+        } catch { /* still invalid */ }
+      }
+      if (refreshedOk) {
+        await import("./credential-sync.mjs").then(m => m.syncCredentials(config)).catch(e => {
+          process.stderr.write(`cc-aws-keepalive: sync failed: ${e.message}\n`);
+        });
+        const validity = refreshed ? ` (valid for ${formatTime(refreshed.remaining)})` : "";
+        console.log(`Auto-login succeeded${validity}. Retrying...`);
+        await new Promise(resolve => setTimeout(resolve, 500));
+        process.exit(0);
+      }
+    } catch {
+      releaseAutoLoginLock();
+      console.log("Auto-login failed.");
+    }
+  }
+}
+
+console.log("");
+console.log("AWS credentials expired.");
+if (config.loginCmd) {
+  console.log(`Run in another terminal:  ${config.loginCmd}`);
+} else {
+  console.log("Re-authenticate in another terminal.");
+}
+console.log(
+  "Then come back here - CC will retry automatically on your next message."
+);
+console.log("");
+process.exit(1);

--- a/plugins/cc-aws-keepalive/aws-auth-refresh.test.mjs
+++ b/plugins/cc-aws-keepalive/aws-auth-refresh.test.mjs
@@ -1,0 +1,46 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { delimiter, join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const homes = [];
+
+afterEach(() => {
+  for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+describe("reactive auto-login verification", { skip: process.platform === "win32" }, () => {
+  it("falls back to STS after login when expirationField is empty", () => {
+    const home = mkdtempSync(join(tmpdir(), "cc-refresh-"));
+    homes.push(home);
+    const bin = join(home, "bin");
+    const configDir = join(home, ".config", "cc-aws-keepalive");
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(configDir, { recursive: true });
+
+    const marker = join(home, ".aws-valid");
+    const aws = join(bin, "aws");
+    const login = join(bin, "login");
+    writeFileSync(aws, `#!/bin/sh\ntest -f '${marker}'\n`);
+    writeFileSync(login, `#!/bin/sh\ntouch '${marker}'\n`);
+    chmodSync(aws, 0o755);
+    chmodSync(login, 0o755);
+    writeFileSync(join(configDir, "config.json"), JSON.stringify({
+      profile: "default",
+      expirationField: "",
+      autoLoginCmd: login,
+    }));
+
+    const result = spawnSync(process.execPath, ["aws-auth-refresh.mjs"], {
+      cwd: new URL(".", import.meta.url),
+      env: { ...process.env, HOME: home, USERPROFILE: home, PATH: `${bin}${delimiter}${process.env.PATH}` },
+      encoding: "utf8",
+      timeout: 10_000,
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.match(result.stdout, /Auto-login succeeded\. Retrying/);
+  });
+});

--- a/plugins/cc-aws-keepalive/aws-cred-check.mjs
+++ b/plugins/cc-aws-keepalive/aws-cred-check.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// UserPromptSubmit hook: proactive AWS credential expiry check.
+// Warns via the hook JSON protocol if expired or nearing expiry (never blocks).
+// Optionally auto-renews credentials when within autoLoginMinutes window.
+import { execFileSync, spawn } from "node:child_process";
+import { loadConfig, getRemaining, formatTime, tryAcquireAutoLoginLock, releaseAutoLoginLock } from "./lib.mjs";
+
+const config = loadConfig();
+const warnSeconds = config.warnMinutes * 60;
+const autoLoginSeconds = (config.autoLoginMinutes || 0) * 60;
+let remaining = null;
+const notices = [];
+
+const info = getRemaining(config);
+if (info) {
+  remaining = info.remaining;
+  if (remaining > 0 && config.syncTargets?.length) {
+    import("./credential-sync.mjs").then(m => m.syncCredentials(config)).catch(e => {
+      process.stderr.write(`cc-aws-keepalive: sync failed: ${e.message}\n`);
+    });
+  }
+} else {
+  // No expiration field, or field configured but unresolvable — fall back to STS
+  try {
+    execFileSync("aws", ["sts", "get-caller-identity", "--profile", config.profile], {
+      stdio: "ignore",
+      timeout: 10_000,
+      shell: process.platform === "win32",
+    });
+    process.exit(0); // Valid, can't determine remaining time
+  } catch {
+    remaining = -1;
+  }
+}
+
+// Auto-login: re-authenticate when within the configured window
+// Only use autoLoginCmd (designed for non-interactive use), never loginCmd (may need a TTY)
+const autoCmd = config.autoLoginCmd;
+if (autoLoginSeconds > 0 && autoCmd && remaining > 0 && remaining <= autoLoginSeconds) {
+  if (tryAcquireAutoLoginLock()) {
+    try {
+      const child = spawn(autoCmd, {
+        shell: true,
+        detached: true,
+        stdio: "ignore",
+      });
+      child.unref();
+      notices.push(`AWS auto-login started in background (${formatTime(remaining)} remaining).`);
+    } catch {
+      releaseAutoLoginLock();
+      notices.push(`Auto-login failed. Run manually: ${config.loginCmd}`);
+    }
+  }
+}
+
+if (remaining <= 0) {
+  const action = config.loginCmd
+    ? `Run: ${config.loginCmd}`
+    : "Re-authenticate";
+  notices.push(`⚠ AWS credentials EXPIRED. ${action} in another terminal — CC will auto-retry via awsAuthRefresh.`);
+} else if (remaining <= warnSeconds) {
+  const hint = config.loginCmd ? ` Run soon: ${config.loginCmd}` : " Re-authenticate soon.";
+  notices.push(`AWS session expires in ${formatTime(remaining)}.${hint}`);
+}
+
+if (notices.length) {
+  process.stdout.write(`${JSON.stringify({ systemMessage: notices.join("\n") })}\n`);
+}

--- a/plugins/cc-aws-keepalive/aws-cred-check.test.mjs
+++ b/plugins/cc-aws-keepalive/aws-cred-check.test.mjs
@@ -1,0 +1,61 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { spawnSync } from "node:child_process";
+
+const homes = [];
+
+function configuredHome(expiration) {
+  const home = mkdtempSync(join(tmpdir(), "cc-hook-"));
+  homes.push(home);
+  mkdirSync(join(home, ".aws"), { recursive: true });
+  mkdirSync(join(home, ".config", "cc-aws-keepalive"), { recursive: true });
+  writeFileSync(join(home, ".aws", "credentials"), [
+    "[default]",
+    "aws_access_key_id = AKID",
+    "aws_secret_access_key = SECRET",
+    "aws_session_token = TOKEN",
+    `x_security_token_expires = ${expiration}`,
+  ].join("\n"));
+  writeFileSync(join(home, ".config", "cc-aws-keepalive", "config.json"), JSON.stringify({
+    profile: "default",
+    expirationField: "x_security_token_expires",
+    warnMinutes: 30,
+  }));
+  return home;
+}
+
+afterEach(() => {
+  for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+describe("UserPromptSubmit output", () => {
+  it("emits an expired warning as non-blocking hook JSON", () => {
+    const home = configuredHome(Math.floor(Date.now() / 1000) - 60);
+    const result = spawnSync(process.execPath, ["aws-cred-check.mjs"], {
+      cwd: new URL(".", import.meta.url),
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.match(output.systemMessage, /credentials EXPIRED/);
+    assert.equal(output.decision, undefined);
+  });
+
+  it("emits a near-expiry warning as hook JSON", () => {
+    const home = configuredHome(Math.floor(Date.now() / 1000) + 10 * 60);
+    const result = spawnSync(process.execPath, ["aws-cred-check.mjs"], {
+      cwd: new URL(".", import.meta.url),
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    assert.match(output.systemMessage, /session expires in/);
+  });
+});

--- a/plugins/cc-aws-keepalive/aws-cred-export.mjs
+++ b/plugins/cc-aws-keepalive/aws-cred-export.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// Reads current AWS credentials from ~/.aws/credentials for the configured profile.
+// Used by Claude Code's awsCredentialExport to bypass in-memory SDK cache.
+import { loadConfig, parseCredentials } from "./lib.mjs";
+
+if (process.stdout.isTTY) {
+  process.stderr.write("WARNING: Writing credentials to terminal. This script is meant for awsCredentialExport only.\n");
+}
+
+const config = loadConfig();
+const creds = parseCredentials(config.profile);
+
+if (!creds || !creds.aws_access_key_id || !creds.aws_secret_access_key) {
+  process.stderr.write(`No credentials found for profile [${config.profile}]\n`);
+  process.exit(1);
+}
+
+const output = {
+  Credentials: {
+    AccessKeyId: creds.aws_access_key_id,
+    SecretAccessKey: creds.aws_secret_access_key,
+    SessionToken: creds.aws_session_token || "",
+  },
+};
+
+process.stdout.write(JSON.stringify(output) + "\n");

--- a/plugins/cc-aws-keepalive/aws-cred-export.test.mjs
+++ b/plugins/cc-aws-keepalive/aws-cred-export.test.mjs
@@ -1,0 +1,95 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "aws-cred-export.mjs");
+
+function makeTmpHome() {
+  return mkdtempSync(join(tmpdir(), "cckeep-export-"));
+}
+
+function writeCredentials(home, content) {
+  const awsDir = join(home, ".aws");
+  mkdirSync(awsDir, { recursive: true });
+  writeFileSync(join(awsDir, "credentials"), content, "utf8");
+}
+
+// ============================================================================
+// aws-cred-export.mjs -- spawned as a subprocess
+// ============================================================================
+
+describe("aws-cred-export.mjs", () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("outputs valid JSON with all 3 credential fields", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = AKIAEXAMPLE",
+        "aws_secret_access_key = SECRET123",
+        "aws_session_token = TOKEN456==",
+      ].join("\n")
+    );
+
+    const stdout = execFileSync("node", [SCRIPT], {
+      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+      encoding: "utf8",
+    });
+
+    const parsed = JSON.parse(stdout.trim());
+    assert.equal(parsed.Credentials.AccessKeyId, "AKIAEXAMPLE");
+    assert.equal(parsed.Credentials.SecretAccessKey, "SECRET123");
+    assert.equal(parsed.Credentials.SessionToken, "TOKEN456==");
+  });
+
+  it("exits with code 1 when no credentials exist", () => {
+    // tmpHome has no .aws directory
+    try {
+      execFileSync("node", [SCRIPT], {
+        env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+        encoding: "utf8",
+      });
+      assert.fail("expected script to exit with code 1");
+    } catch (err) {
+      assert.equal(err.status, 1);
+      assert.ok(
+        err.stderr.includes("No credentials found"),
+        `expected stderr to mention missing credentials, got: ${err.stderr}`
+      );
+    }
+  });
+
+  it("outputs empty SessionToken when aws_session_token is missing", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = AKIANOSSN",
+        "aws_secret_access_key = SECRETNOSSN",
+      ].join("\n")
+    );
+
+    const stdout = execFileSync("node", [SCRIPT], {
+      env: { ...process.env, HOME: tmpHome, USERPROFILE: tmpHome },
+      encoding: "utf8",
+    });
+
+    const parsed = JSON.parse(stdout.trim());
+    assert.equal(parsed.Credentials.AccessKeyId, "AKIANOSSN");
+    assert.equal(parsed.Credentials.SecretAccessKey, "SECRETNOSSN");
+    assert.equal(parsed.Credentials.SessionToken, "");
+  });
+});

--- a/plugins/cc-aws-keepalive/aws-statusline.mjs
+++ b/plugins/cc-aws-keepalive/aws-statusline.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Status line: shows AWS session time remaining with color warning.
+// Composes with any existing status line command via config.statusLineCmd.
+import { execSync } from "node:child_process";
+import { loadConfig, getRemaining, formatTime } from "./lib.mjs";
+
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const RESET = "\x1b[0m";
+
+const config = loadConfig();
+
+// Run existing status line command if configured
+let original = "";
+if (config.statusLineCmd) {
+  try {
+    original = execSync(config.statusLineCmd, {
+      encoding: "utf8",
+      timeout: 5000,
+    }).trim();
+  } catch {
+    // Existing statusline failed — continue with just the timer
+  }
+}
+
+// Build AWS timer
+let timer = "";
+const info = getRemaining(config);
+if (info) {
+  const warnSeconds = config.timerWarnMinutes * 60;
+  const text = `AWS: ${formatTime(info.remaining)}`;
+
+  if (info.remaining <= 0) {
+    timer = `${RED}${text}${RESET}`;
+  } else if (info.remaining <= warnSeconds) {
+    timer = `${YELLOW}${text}${RESET}`;
+  } else {
+    timer = text;
+  }
+}
+
+// Compose
+if (original && timer) {
+  process.stdout.write(`${original} | ${timer}\n`);
+} else {
+  process.stdout.write(`${original || timer}\n`);
+}

--- a/plugins/cc-aws-keepalive/config.example.json
+++ b/plugins/cc-aws-keepalive/config.example.json
@@ -1,0 +1,13 @@
+{
+  "profile": "default",
+  "expirationField": "",
+  "loginCmd": "saml2aws login --profile default",
+  "autoLoginCmd": "",
+  "autoLoginMinutes": 0,
+  "warnMinutes": 30,
+  "timerWarnMinutes": 60,
+  "statusLineCmd": "",
+  "syncTargets": [],
+  "syncTimeoutSeconds": 15,
+  "syncCooldownSeconds": 60
+}

--- a/plugins/cc-aws-keepalive/credential-sync.mjs
+++ b/plugins/cc-aws-keepalive/credential-sync.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { parseCredentials, STATE_DIR } from "./lib.mjs";
+
+const SYNC_STATE_FILE = join(STATE_DIR, ".last-sync");
+const SAFE_PATH_RE = /^~?\/[a-zA-Z0-9_./-]+$/;
+const MAX_STDERR = 8192;
+
+export function getSshHostKeyPolicy(target) {
+  return target.acceptNewHostKey === true ? "accept-new" : "yes";
+}
+
+function shouldSync(config) {
+  const cooldown = (config.syncCooldownSeconds ?? 60) * 1000;
+  try {
+    const last = parseInt(readFileSync(SYNC_STATE_FILE, "utf8"), 10);
+    if (!isNaN(last) && Date.now() - last < cooldown) return false;
+  } catch { /* no state file — proceed */ }
+  return true;
+}
+
+function markSynced() {
+  try {
+    mkdirSync(STATE_DIR, { recursive: true });
+    writeFileSync(SYNC_STATE_FILE, String(Date.now()), { mode: 0o600 });
+  } catch { /* best effort */ }
+}
+
+function buildIniBlock(profile, creds, expirationField) {
+  let ini = `[${profile}]\n`;
+  ini += `aws_access_key_id = ${creds.aws_access_key_id}\n`;
+  ini += `aws_secret_access_key = ${creds.aws_secret_access_key}\n`;
+  if (creds.aws_session_token) {
+    ini += `aws_session_token = ${creds.aws_session_token}\n`;
+  }
+  if (expirationField && creds[expirationField]) {
+    ini += `${expirationField} = ${creds[expirationField]}\n`;
+  }
+  return ini;
+}
+
+function syncSsh(target, ini, config) {
+  const timeout = (config.syncTimeoutSeconds ?? 15) * 1000;
+  const remotePath = target.remotePath || "~/.aws/credentials";
+
+  if (!SAFE_PATH_RE.test(remotePath)) {
+    process.stderr.write(`cc-aws-keepalive: invalid remotePath "${remotePath}" — must be a simple file path\n`);
+    return;
+  }
+
+  const remoteCmd = `mkdir -p ~/.aws && chmod 700 ~/.aws && cat > ${remotePath}.tmp && chmod 600 ${remotePath}.tmp && mv ${remotePath}.tmp ${remotePath}`;
+
+  const sshBinary = "ssh";
+  const sshArgs = [];
+  const hostKeyPolicy = getSshHostKeyPolicy(target);
+
+  sshArgs.push(
+    "-o", `StrictHostKeyChecking=${hostKeyPolicy}`,
+    "-o", "BatchMode=yes",
+    "-o", "ForwardAgent=no",
+    "-o", `ConnectTimeout=${Math.ceil(timeout / 1000)}`,
+  );
+
+  if (target.sshArgs) {
+    const extra = Array.isArray(target.sshArgs) ? target.sshArgs : target.sshArgs.split(/\s+/);
+    sshArgs.push(...extra);
+  }
+
+  if (target.user) sshArgs.push("-l", target.user);
+  sshArgs.push(target.host, remoteCmd);
+
+  const child = spawn(sshBinary, sshArgs, {
+    stdio: ["pipe", "ignore", "pipe"],
+    timeout,
+  });
+
+  child.stdin.on("error", () => {});
+  child.stdin.write(ini);
+  child.stdin.end();
+
+  let stderr = "";
+  child.stderr.on("data", (d) => { if (stderr.length < MAX_STDERR) stderr += d.toString(); });
+
+  child.on("close", (code) => {
+    if (code !== 0) {
+      process.stderr.write(`cc-aws-keepalive: sync to ${target.host} failed (exit ${code})${stderr ? ": " + stderr.trim() : ""}\n`);
+    }
+  });
+  child.on("error", (err) => {
+    process.stderr.write(`cc-aws-keepalive: sync to ${target.host} error: ${err.message}\n`);
+  });
+  child.unref();
+}
+
+function syncWebhook(target, creds, config) {
+  const timeout = (config.syncTimeoutSeconds ?? 15) * 1000;
+  let url;
+  try { url = new URL(target.url); } catch {
+    process.stderr.write(`cc-aws-keepalive: invalid webhook URL "${target.url}"\n`);
+    return;
+  }
+
+  if (url.protocol !== "https:") {
+    process.stderr.write(`cc-aws-keepalive: webhook sync REFUSED — ${target.url} must use https://\n`);
+    return;
+  }
+
+  if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === "0") {
+    process.stderr.write("cc-aws-keepalive: webhook sync REFUSED — NODE_TLS_REJECT_UNAUTHORIZED=0 disables TLS\n");
+    return;
+  }
+
+  const payload = JSON.stringify({
+    profile: target.remoteProfile || config.profile,
+    credentials: {
+      aws_access_key_id: creds.aws_access_key_id,
+      aws_secret_access_key: creds.aws_secret_access_key,
+      aws_session_token: creds.aws_session_token || "",
+    },
+    timestamp: Date.now(),
+  });
+
+  const headers = {
+    "Content-Type": "application/json",
+    "Content-Length": String(Buffer.byteLength(payload)),
+  };
+  if (target.headers) {
+    for (const [k, v] of Object.entries(target.headers)) {
+      headers[k] = v.replace(/\$\{(\w+)\}/g, (_, name) => process.env[name] || "");
+    }
+  }
+
+  import("node:https").then(({ request }) => {
+    const req = request(url, { method: target.method || "POST", headers, timeout }, (res) => {
+      if (res.statusCode >= 400) {
+        process.stderr.write(`cc-aws-keepalive: webhook ${target.url} returned ${res.statusCode}\n`);
+      }
+      res.resume();
+    });
+    req.on("error", (err) => {
+      process.stderr.write(`cc-aws-keepalive: webhook ${target.url} failed: ${err.message}\n`);
+    });
+    req.on("timeout", () => req.destroy());
+    req.write(payload);
+    req.end();
+    req.socket?.unref?.();
+  });
+}
+
+function syncCommand(target, creds, config) {
+  const timeout = (config.syncTimeoutSeconds ?? 15) * 1000;
+  const payload = JSON.stringify({
+    profile: target.remoteProfile || config.profile,
+    credentials: {
+      aws_access_key_id: creds.aws_access_key_id,
+      aws_secret_access_key: creds.aws_secret_access_key,
+      aws_session_token: creds.aws_session_token || "",
+    },
+    expiration: config.expirationField ? (creds[config.expirationField] || "") : "",
+    timestamp: Date.now(),
+  });
+
+  const child = spawn(target.command, {
+    shell: true,
+    stdio: ["pipe", "ignore", "pipe"],
+    timeout,
+  });
+
+  child.stdin.on("error", () => {});
+  child.stdin.write(payload);
+  child.stdin.end();
+
+  let stderr = "";
+  child.stderr.on("data", (d) => { if (stderr.length < MAX_STDERR) stderr += d.toString(); });
+
+  child.on("close", (code) => {
+    if (code !== 0) {
+      process.stderr.write(`cc-aws-keepalive: sync command failed (exit ${code})${stderr ? ": " + stderr.trim() : ""}\n`);
+    }
+  });
+  child.on("error", (err) => {
+    process.stderr.write(`cc-aws-keepalive: sync command error: ${err.message}\n`);
+  });
+  child.unref();
+}
+
+export function syncCredentials(config) {
+  if (!config.syncTargets?.length) return;
+  if (!shouldSync(config)) return;
+
+  const creds = parseCredentials(config.profile);
+  if (!creds || !creds.aws_access_key_id || !creds.aws_secret_access_key) return;
+
+  if (!creds.aws_session_token) {
+    process.stderr.write("cc-aws-keepalive: sync REFUSED — no session token (will not sync long-lived keys)\n");
+    return;
+  }
+
+  markSynced();
+
+  const profile = config.profile;
+  const ini = buildIniBlock(profile, creds, config.expirationField);
+
+  for (const target of config.syncTargets) {
+    try {
+      const remoteProfile = target.remoteProfile || profile;
+      const targetIni = remoteProfile !== profile
+        ? buildIniBlock(remoteProfile, creds, config.expirationField)
+        : ini;
+
+      switch (target.type) {
+        case "ssh":
+          syncSsh(target, targetIni, config);
+          break;
+        case "webhook":
+          syncWebhook(target, creds, config);
+          break;
+        case "command":
+          syncCommand(target, creds, config);
+          break;
+        default:
+          process.stderr.write(`cc-aws-keepalive: unknown sync type "${target.type}"\n`);
+      }
+    } catch (err) {
+      process.stderr.write(`cc-aws-keepalive: sync to ${target.host || target.url || "target"} failed: ${err.message}\n`);
+    }
+  }
+}

--- a/plugins/cc-aws-keepalive/credential-sync.test.mjs
+++ b/plugins/cc-aws-keepalive/credential-sync.test.mjs
@@ -1,0 +1,495 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+function makeTmpHome() {
+  return mkdtempSync(join(tmpdir(), "ccsync-"));
+}
+
+function writeCredentials(home, content) {
+  const awsDir = join(home, ".aws");
+  mkdirSync(awsDir, { recursive: true });
+  writeFileSync(join(awsDir, "credentials"), content, "utf8");
+}
+
+function writeConfig(home, obj) {
+  const configDir = join(home, ".config", "cc-aws-keepalive");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "config.json"), JSON.stringify(obj), "utf8");
+}
+
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+function setHome(dir) {
+  process.env.HOME = dir;
+  process.env.USERPROFILE = dir;
+}
+
+function restoreHome() {
+  process.env.HOME = ORIGINAL_HOME;
+  process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+}
+
+// Fresh import each time to pick up new HOME
+let importCounter = 0;
+async function freshImport(mod) {
+  importCounter++;
+  return import(`./${mod}?bust=${importCounter}`);
+}
+
+// ============================================================================
+// buildIniBlock — pure function
+// ============================================================================
+
+describe("buildIniBlock", () => {
+  let buildIniBlock;
+  let home;
+
+  beforeEach(async () => {
+    home = makeTmpHome();
+    setHome(home);
+    const mod = await freshImport("credential-sync.mjs");
+    // buildIniBlock is not exported, so we test it indirectly via syncCredentials
+    // Actually we need to test it directly — export it for testing
+    // Since it's not exported, we'll test through syncCredentials behavior
+    restoreHome();
+  });
+
+  afterEach(() => {
+    restoreHome();
+    try { rmSync(home, { recursive: true }); } catch {}
+  });
+});
+
+// ============================================================================
+// shouldSync — cooldown logic
+// ============================================================================
+
+describe("shouldSync", () => {
+  let home;
+
+  afterEach(() => {
+    restoreHome();
+    try { rmSync(home, { recursive: true }); } catch {}
+  });
+
+  it("syncs when no state file exists", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeConfig(home, { profile: "default", syncTargets: [{ type: "command", command: "true" }] });
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+    // Should not throw — sync proceeds (command "true" will fail silently since we're testing logic)
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "command", command: "true" }],
+      syncCooldownSeconds: 60,
+      syncTimeoutSeconds: 5,
+    });
+
+    // Verify state file was written
+    const stateFile = join(home, ".config", "cc-aws-keepalive", ".last-sync");
+    const content = readFileSync(stateFile, "utf8");
+    const ts = parseInt(content, 10);
+    assert.ok(Math.abs(ts - Date.now()) < 5000);
+  });
+
+  it("skips sync within cooldown window", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    const stateDir = join(home, ".config", "cc-aws-keepalive");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, ".last-sync"), String(Date.now()), { mode: 0o600 });
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    // Capture stderr to verify sync was skipped (no errors, no commands run)
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "command", command: "echo SHOULD_NOT_RUN >&2" }],
+      syncCooldownSeconds: 60,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    // Should have been skipped — no output
+    assert.ok(!stderrOutput.includes("SHOULD_NOT_RUN"));
+  });
+
+  it("syncs when cooldown has elapsed", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    // With cooldown of 0, sync should always proceed
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "command", command: "true" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    // No "REFUSED" or guard error — sync proceeded
+    assert.ok(!stderrOutput.includes("REFUSED"));
+  });
+
+  it("treats NaN in state file as expired cooldown", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    // Should not be blocked by NaN in state file
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "command", command: "true" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    assert.ok(!stderrOutput.includes("REFUSED"));
+  });
+});
+
+// ============================================================================
+// syncCredentials — guard clauses
+// ============================================================================
+
+describe("syncCredentials guards", () => {
+  let home;
+
+  afterEach(() => {
+    restoreHome();
+    try { rmSync(home, { recursive: true }); } catch {}
+  });
+
+  it("returns immediately when syncTargets is empty", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({ profile: "default", syncTargets: [], syncCooldownSeconds: 60 });
+
+    process.stderr.write = origWrite;
+    assert.equal(stderrOutput, "");
+  });
+
+  it("returns immediately when syncTargets is undefined", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({ profile: "default", syncCooldownSeconds: 60 });
+
+    process.stderr.write = origWrite;
+    assert.equal(stderrOutput, "");
+  });
+
+  it("refuses to sync without session token", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "command", command: "true" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    assert.ok(stderrOutput.includes("REFUSED"));
+    assert.ok(stderrOutput.includes("session token"));
+  });
+
+  it("refuses when credentials are missing", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    // No credentials file at all
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "command", command: "echo BAD >&2" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    assert.ok(!stderrOutput.includes("BAD"));
+  });
+
+  it("logs unknown sync type", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "ftp", host: "x" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    assert.ok(stderrOutput.includes('unknown sync type "ftp"'));
+  });
+});
+
+// ============================================================================
+// syncWebhook — security guards
+// ============================================================================
+
+describe("syncWebhook security", () => {
+  let home;
+
+  afterEach(() => {
+    restoreHome();
+    try { rmSync(home, { recursive: true }); } catch {}
+  });
+
+  it("refuses non-HTTPS webhook URLs", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "webhook", url: "http://evil.com/creds" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    assert.ok(stderrOutput.includes("REFUSED"));
+    assert.ok(stderrOutput.includes("https://"));
+  });
+
+  it("refuses when NODE_TLS_REJECT_UNAUTHORIZED=0", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+    const origTLS = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "webhook", url: "https://legit.com/creds" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    if (origTLS === undefined) delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    else process.env.NODE_TLS_REJECT_UNAUTHORIZED = origTLS;
+
+    assert.ok(stderrOutput.includes("REFUSED"));
+    assert.ok(stderrOutput.includes("NODE_TLS_REJECT_UNAUTHORIZED"));
+  });
+
+  it("refuses malformed webhook URL", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "webhook", url: "not a url at all" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    assert.ok(stderrOutput.includes("invalid webhook URL"));
+  });
+});
+
+// ============================================================================
+// syncSsh — remotePath validation
+// ============================================================================
+
+describe("syncSsh remotePath validation", () => {
+  let home;
+
+  afterEach(() => {
+    restoreHome();
+    try { rmSync(home, { recursive: true }); } catch {}
+  });
+
+  it("refuses remotePath with shell metacharacters", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "ssh", host: "localhost", remotePath: "; rm -rf /; #" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    assert.ok(stderrOutput.includes("invalid remotePath"));
+  });
+
+  it("accepts valid remotePath", async () => {
+    home = makeTmpHome();
+    setHome(home);
+    writeCredentials(home, [
+      "[default]",
+      "aws_access_key_id = AKID",
+      "aws_secret_access_key = SECRET",
+      "aws_session_token = TOKEN",
+    ].join("\n"));
+
+    const { syncCredentials } = await freshImport("credential-sync.mjs");
+
+    let stderrOutput = "";
+    const origWrite = process.stderr.write;
+    process.stderr.write = (msg) => { stderrOutput += msg; };
+
+    syncCredentials({
+      profile: "default",
+      syncTargets: [{ type: "ssh", host: "localhost", remotePath: "~/.aws/credentials" }],
+      syncCooldownSeconds: 0,
+      syncTimeoutSeconds: 5,
+    });
+
+    process.stderr.write = origWrite;
+    // Should NOT contain remotePath error (will fail on connection, but that's fine)
+    assert.ok(!stderrOutput.includes("invalid remotePath"));
+  });
+});
+
+describe("syncSsh host-key policy", () => {
+  it("requires a previously verified host key by default", async () => {
+    const { getSshHostKeyPolicy } = await freshImport("credential-sync.mjs");
+    assert.equal(getSshHostKeyPolicy({}), "yes");
+  });
+
+  it("allows trust-on-first-use only through an explicit opt-in", async () => {
+    const { getSshHostKeyPolicy } = await freshImport("credential-sync.mjs");
+    assert.equal(getSshHostKeyPolicy({ acceptNewHostKey: true }), "accept-new");
+    assert.equal(getSshHostKeyPolicy({ acceptNewHostKey: false }), "yes");
+  });
+});

--- a/plugins/cc-aws-keepalive/docs/images/banner.svg
+++ b/plugins/cc-aws-keepalive/docs/images/banner.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 200" width="900" height="200">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#FF9900"/>
+      <stop offset="100%" stop-color="#0D1B2A"/>
+    </linearGradient>
+  </defs>
+  <rect width="900" height="200" rx="12" fill="url(#bg)"/>
+  <g stroke="#ffffff" stroke-opacity="0.04" stroke-width="1">
+    <line x1="0" y1="50" x2="900" y2="50"/>
+    <line x1="0" y1="100" x2="900" y2="100"/>
+    <line x1="0" y1="150" x2="900" y2="150"/>
+    <line x1="150" y1="0" x2="150" y2="200"/>
+    <line x1="300" y1="0" x2="300" y2="200"/>
+    <line x1="450" y1="0" x2="450" y2="200"/>
+    <line x1="600" y1="0" x2="600" y2="200"/>
+    <line x1="750" y1="0" x2="750" y2="200"/>
+  </g>
+  <g transform="translate(60, 55)">
+    <rect x="5" y="10" width="50" height="40" rx="6" fill="none" stroke="#ffffff" stroke-width="2" opacity="0.3"/>
+    <text x="30" y="37" text-anchor="middle" font-family="monospace" font-size="16" fill="#ffffff" opacity="0.6">&gt;_</text>
+  </g>
+  <text x="200" y="95" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="44" font-weight="700" fill="#ffffff" letter-spacing="-1">cc-aws-keepalive</text>
+  <text x="202" y="130" font-family="'Segoe UI', 'Helvetica Neue', Arial, sans-serif" font-size="15" fill="#ffffff" opacity="0.65" letter-spacing="0.3">Keep Claude Code alive through AWS credential expiration</text>
+</svg>

--- a/plugins/cc-aws-keepalive/hooks/hooks.json
+++ b/plugins/cc-aws-keepalive/hooks/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"$CLAUDE_PLUGIN_ROOT/aws-cred-check.mjs\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/cc-aws-keepalive/hooks/hooks.json
+++ b/plugins/cc-aws-keepalive/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "node \"$CLAUDE_PLUGIN_ROOT/aws-cred-check.mjs\"",
-            "timeout": 10
+            "timeout": 15
           }
         ]
       }

--- a/plugins/cc-aws-keepalive/install.mjs
+++ b/plugins/cc-aws-keepalive/install.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// Cross-platform installer for cc-aws-keepalive
+import { existsSync, mkdirSync, copyFileSync, readFileSync, writeFileSync, realpathSync, chmodSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve, dirname } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const home = homedir();
+const configDir = join(home, ".config", "cc-aws-keepalive");
+const configFile = join(configDir, "config.json");
+const scriptDir = resolve(__dirname);
+
+// Detect OMC
+const claudeConfigDir = process.env.CLAUDE_CONFIG_DIR || join(home, ".claude");
+const omcHud = join(claudeConfigDir, "hud", "omc-hud.mjs");
+const hasOmc = existsSync(omcHud);
+
+// Detect existing settings
+let settings = {};
+const settingsPath = join(claudeConfigDir, "settings.json");
+if (existsSync(settingsPath)) {
+  try {
+    settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+  } catch { /* ignore */ }
+}
+
+console.log("cc-aws-keepalive installer\n");
+
+// 1. Config
+if (!existsSync(configFile)) {
+  mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  copyFileSync(join(__dirname, "config.example.json"), configFile);
+  if (process.platform !== "win32") {
+    chmodSync(configFile, 0o600);
+  }
+  console.log(`Created: ${configFile}`);
+  console.log("Edit it to set your AWS profile, expiration field, and login command.\n");
+} else {
+  console.log(`Config exists: ${configFile} (not overwritten)\n`);
+}
+
+// 2. Detect plugin vs manual install — true only when running from CC's plugin cache
+// Use realpathSync to handle macOS /var → /private/var symlink resolution
+const pluginCachePath = join(claudeConfigDir, "plugins", "cache");
+const normPath = (p) => process.platform === "win32" ? p.toLowerCase() : p;
+const isPlugin = existsSync(pluginCachePath)
+  ? normPath(realpathSync(scriptDir)).startsWith(normPath(realpathSync(pluginCachePath)))
+  : false;
+
+// 3. Core settings (always needed)
+console.log("=== Add to ~/.claude/settings.json ===\n");
+
+if (isPlugin) {
+  console.log("Plugin detected — the UserPromptSubmit hook is auto-registered.");
+  console.log("You only need to add the credential settings:\n");
+  console.log(JSON.stringify({
+    awsCredentialExport: `node ${scriptDir}/aws-cred-export.mjs`,
+    awsAuthRefresh: `node ${scriptDir}/aws-auth-refresh.mjs`,
+  }, null, 2));
+} else {
+  console.log("Core (credential refresh + proactive hook):\n");
+  console.log(JSON.stringify({
+    awsCredentialExport: `node ${scriptDir}/aws-cred-export.mjs`,
+    awsAuthRefresh: `node ${scriptDir}/aws-auth-refresh.mjs`,
+    hooks: {
+      UserPromptSubmit: [{
+        matcher: "",
+        hooks: [{
+          type: "command",
+          command: `node ${scriptDir}/aws-cred-check.mjs`,
+        }],
+      }],
+    },
+  }, null, 2));
+}
+
+// 4. Status line timer
+const MARKER = "// [cc-aws-keepalive:timer-start]";
+
+if (hasOmc) {
+  // Clean up legacy patch from omc-hud.mjs if present (old installer versions patched it directly)
+  const hudContent = readFileSync(omcHud, "utf8");
+  if (hudContent.includes(MARKER)) {
+    const hLines = hudContent.split(/\r?\n/);
+    const startIdx = hLines.findIndex(l => l.includes(MARKER));
+    let endIdx = hLines.findIndex(l => l.includes("// [cc-aws-keepalive:timer-end]"));
+    if (endIdx === -1) endIdx = Math.min(startIdx + 2, hLines.length - 1);
+    if (startIdx !== -1) {
+      let removeStart = startIdx;
+      let removeEnd = endIdx;
+      if (removeStart > 0 && hLines[removeStart - 1].trim() === "") removeStart--;
+      if (removeEnd < hLines.length - 1 && hLines[removeEnd + 1].trim() === "") removeEnd++;
+      hLines.splice(removeStart, removeEnd - removeStart + 1);
+      writeFileSync(omcHud, hLines.join("\n"));
+      console.log("\n\nRemoved legacy patch from omc-hud.mjs.");
+    }
+  }
+
+  // Create wrapper script that survives OMC updates (lives outside omc-hud.mjs)
+  const wrapperPath = join(dirname(omcHud), "aws-hud-wrapper.mjs");
+  const timerUrl = pathToFileURL(join(scriptDir, "omc-timer.mjs")).href;
+  const wrapper = [
+    '#!/usr/bin/env node',
+    '// AWS timer wrapper: intercepts OMC HUD stdout, appends AWS session timer.',
+    '// Created by cc-aws-keepalive. OMC-update-safe (lives outside omc-hud.mjs).',
+    'import { pathToFileURL } from "node:url";',
+    'import { join } from "node:path";',
+    'import { homedir } from "node:os";',
+    '',
+    'try {',
+    `  const { patchStdout } = await import("${timerUrl}");`,
+    '  patchStdout();',
+    '} catch { /* cc-aws-keepalive not available — continue without timer */ }',
+    '',
+    'const configDir = process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");',
+    'await import(pathToFileURL(join(configDir, "hud", "omc-hud.mjs")).href);',
+    '',
+  ].join("\n");
+  writeFileSync(wrapperPath, wrapper);
+
+  // Update statusLine in settings.json to use the wrapper
+  if (existsSync(settingsPath)) {
+    try {
+      const current = JSON.parse(readFileSync(settingsPath, "utf8"));
+      const sl = current.statusLine;
+      if (sl && typeof sl.command === "string" && sl.command.includes("omc-hud.mjs") && !sl.command.includes("aws-hud-wrapper.mjs")) {
+        current.statusLine.command = sl.command.replace("omc-hud.mjs", "aws-hud-wrapper.mjs");
+        writeFileSync(settingsPath, JSON.stringify(current, null, 2) + "\n");
+        console.log("\n\nOMC HUD wrapper installed — AWS timer shows inline (e.g., aws:5h23m).");
+        console.log("Survives OMC updates (no patching of omc-hud.mjs).");
+      } else {
+        console.log("\n\nOMC HUD wrapper created at: " + wrapperPath);
+        console.log("Update your statusLine command to use aws-hud-wrapper.mjs instead of omc-hud.mjs.");
+      }
+    } catch {
+      console.log("\n\nOMC HUD wrapper created at: " + wrapperPath);
+      console.log("Update your statusLine command to use aws-hud-wrapper.mjs instead of omc-hud.mjs.");
+    }
+  }
+} else {
+  console.log("\n\nOptional — show session timer in status bar:\n");
+  console.log(JSON.stringify({
+    statusLine: {
+      type: "command",
+      command: `node ${scriptDir}/aws-statusline.mjs`,
+    },
+  }, null, 2));
+}
+
+// 5. Auto-update settings.json credential paths on plugin version change
+if (isPlugin && existsSync(settingsPath)) {
+  try {
+    const current = JSON.parse(readFileSync(settingsPath, "utf8"));
+    let updated = false;
+    for (const [key, script] of [
+      ["awsCredentialExport", "aws-cred-export.mjs"],
+      ["awsAuthRefresh", "aws-auth-refresh.mjs"],
+    ]) {
+      const val = current[key];
+      if (typeof val !== "string") continue;
+      // Replace only this plugin's cache segment, preserving wrapper commands/flags.
+      // The marketplace directory varies (for example, cc-aws-keepalive or
+      // awesome-claude-code-plugins), so do not hard-code it.
+      const versionRe = /[/\\]plugins[/\\]cache[/\\][^/\\]+[/\\]cc-aws-keepalive[/\\][^/\\]+/;
+      const newSegment = scriptDir.match(versionRe)?.[0];
+      if (newSegment && versionRe.test(val) && !val.includes(scriptDir)) {
+        current[key] = val.replace(versionRe, newSegment);
+        updated = true;
+      }
+    }
+    if (updated) {
+      writeFileSync(settingsPath, JSON.stringify(current, null, 2) + "\n");
+      console.log("\nUpdated settings.json credential paths to current plugin version.");
+    }
+  } catch { /* settings.json parse failed — skip */ }
+}
+
+console.log("\nDone.");

--- a/plugins/cc-aws-keepalive/install.test.mjs
+++ b/plugins/cc-aws-keepalive/install.test.mjs
@@ -1,0 +1,40 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const homes = [];
+
+afterEach(() => {
+  for (const home of homes.splice(0)) rmSync(home, { recursive: true, force: true });
+});
+
+describe("aggregate marketplace upgrades", () => {
+  it("updates credential paths without hard-coding the marketplace name", () => {
+    const home = mkdtempSync(join(tmpdir(), "cc-install-"));
+    homes.push(home);
+    const pluginDir = join(home, ".claude", "plugins", "cache", "awesome-claude-code-plugins", "cc-aws-keepalive", "0.5.1-ccplugins.1");
+    mkdirSync(pluginDir, { recursive: true });
+    for (const file of ["install.mjs", "config.example.json", "aws-statusline.mjs", "omc-timer.mjs"]) {
+      cpSync(join(dirname(fileURLToPath(import.meta.url)), file), join(pluginDir, file));
+    }
+    const settingsPath = join(home, ".claude", "settings.json");
+    writeFileSync(settingsPath, JSON.stringify({
+      awsCredentialExport: "node ~/.claude/plugins/cache/awesome-claude-code-plugins/cc-aws-keepalive/0.4.0/aws-cred-export.mjs",
+      awsAuthRefresh: "node ~/.claude/plugins/cache/other-marketplace/cc-aws-keepalive/0.4.0/aws-auth-refresh.mjs",
+    }));
+
+    const result = spawnSync(process.execPath, [join(pluginDir, "install.mjs")], {
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+    assert.match(settings.awsCredentialExport, /awesome-claude-code-plugins[/\\]cc-aws-keepalive[/\\]0\.5\.1-ccplugins\.1/);
+    assert.match(settings.awsAuthRefresh, /awesome-claude-code-plugins[/\\]cc-aws-keepalive[/\\]0\.5\.1-ccplugins\.1/);
+  });
+});

--- a/plugins/cc-aws-keepalive/lib.mjs
+++ b/plugins/cc-aws-keepalive/lib.mjs
@@ -1,0 +1,161 @@
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const CONFIG_PATH = join(
+  homedir(),
+  ".config",
+  "cc-aws-keepalive",
+  "config.json"
+);
+
+const DEFAULTS = {
+  profile: "default",
+  expirationField: "",
+  loginCmd: "",
+  autoLoginCmd: "",
+  autoLoginMinutes: 0,
+  warnMinutes: 30,
+  timerWarnMinutes: 60,
+  statusLineCmd: "",
+  syncTargets: [],
+  syncTimeoutSeconds: 15,
+  syncCooldownSeconds: 60,
+};
+
+export function loadConfig() {
+  const config = { ...DEFAULTS };
+  if (existsSync(CONFIG_PATH)) {
+    try {
+      const parsed = JSON.parse(readFileSync(CONFIG_PATH, "utf8"));
+      // Warn on unknown keys
+      for (const key of Object.keys(parsed)) {
+        if (!(key in DEFAULTS)) {
+          process.stderr.write(`cc-aws-keepalive: unknown config key "${key}" (typo?)\n`);
+        }
+      }
+      // Type-coerce numeric fields, warn on bad types
+      for (const [key, def] of Object.entries(DEFAULTS)) {
+        if (key in parsed) {
+          const val = parsed[key];
+          const expected = typeof def;
+          if (expected === "number" && typeof val === "string") {
+            const num = Number(val);
+            if (!isNaN(num)) { parsed[key] = num; }
+            else { process.stderr.write(`cc-aws-keepalive: "${key}" should be a number, got "${val}"\n`); }
+          } else if (expected === "string" && typeof val !== "string") {
+            process.stderr.write(`cc-aws-keepalive: "${key}" should be a string, got ${typeof val}\n`);
+            parsed[key] = String(val);
+          }
+        }
+      }
+      Object.assign(config, parsed);
+    } catch (e) {
+      process.stderr.write(`cc-aws-keepalive: config.json is malformed (${e.message}). Using defaults.\n`);
+    }
+  }
+  // Env override
+  if (process.env.CC_KEEPALIVE_PROFILE) {
+    config.profile = process.env.CC_KEEPALIVE_PROFILE;
+  }
+  // Validate profile name (prevent CLI flag injection via --profile)
+  if (config.profile && !/^[a-zA-Z0-9._-]+$/.test(config.profile)) {
+    process.stderr.write(`cc-aws-keepalive: invalid profile name "${config.profile}" (only alphanumeric, dots, hyphens, underscores allowed)\n`);
+    config.profile = "default";
+  }
+  // Warn about ineffective auto-login config
+  if (config.autoLoginMinutes > 0 && !config.expirationField) {
+    process.stderr.write("cc-aws-keepalive: autoLoginMinutes requires expirationField to be set. Auto-login disabled.\n");
+  }
+  return config;
+}
+
+export function parseCredentials(profile) {
+  const credsPath = join(homedir(), ".aws", "credentials");
+  if (!existsSync(credsPath)) return null;
+
+  const content = readFileSync(credsPath, "utf8");
+  const lines = content.split(/\r?\n/);
+  const result = {};
+  let inProfile = false;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    const profileMatch = trimmed.match(/^\[(.+)\]$/);
+    if (profileMatch) {
+      inProfile = profileMatch[1] === profile;
+      continue;
+    }
+    if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith(";")) continue;
+    if (inProfile && trimmed.includes("=")) {
+      const eqIdx = trimmed.indexOf("=");
+      const key = trimmed.slice(0, eqIdx).trim();
+      const val = trimmed.slice(eqIdx + 1).trim();
+      result[key] = val;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : null;
+}
+
+export function getRemaining(config) {
+  const creds = parseCredentials(config.profile);
+  if (!creds || !config.expirationField) return null;
+
+  const raw = creds[config.expirationField];
+  let exp;
+  if (/^\d+$/.test(raw)) {
+    exp = parseInt(raw, 10);
+    if (exp < 1_000_000_000) return null;
+  } else {
+    const parsed = Date.parse(raw);
+    if (isNaN(parsed)) return null;
+    exp = Math.floor(parsed / 1000);
+    if (exp < 1_000_000_000) return null;
+  }
+
+  return { remaining: exp - Math.floor(Date.now() / 1000), expiration: exp };
+}
+
+export function formatTime(seconds) {
+  if (seconds <= 0) return "EXPIRED";
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h > 0) return `${h}h${m}m`;
+  return m > 0 ? `${m}m` : "<1m";
+}
+
+export const STATE_DIR = join(homedir(), ".config", "cc-aws-keepalive");
+const LOCK_FILE = join(STATE_DIR, ".auto-login.lock");
+const LOCK_MAX_AGE_SEC = 300;
+
+export function tryAcquireAutoLoginLock() {
+  try { mkdirSync(STATE_DIR, { recursive: true }); } catch { return false; }
+  try {
+    const existing = readFileSync(LOCK_FILE, "utf8").trim();
+    const age = Date.now() / 1000 - parseInt(existing, 10);
+    if (age >= 0 && age < LOCK_MAX_AGE_SEC) return false;
+    unlinkSync(LOCK_FILE);
+  } catch { /* no lockfile or unreadable — proceed */ }
+  try {
+    writeFileSync(LOCK_FILE, String(Math.floor(Date.now() / 1000)), { flag: "wx" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function releaseAutoLoginLock() {
+  try { unlinkSync(LOCK_FILE); } catch { /* already gone */ }
+}
+
+let _sleepBuf;
+try { _sleepBuf = new Int32Array(new SharedArrayBuffer(4)); } catch { _sleepBuf = null; }
+export function sleepSync(ms) {
+  if (_sleepBuf) {
+    Atomics.wait(_sleepBuf, 0, 0, ms);
+  } else {
+    const end = Date.now() + ms;
+    while (Date.now() < end) { /* busy wait fallback */ }
+  }
+}

--- a/plugins/cc-aws-keepalive/lib.test.mjs
+++ b/plugins/cc-aws-keepalive/lib.test.mjs
@@ -1,0 +1,725 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Helper: create an isolated tmpdir and point HOME at it so that lib.mjs
+// functions (which call homedir()) read from our temp files.
+// ---------------------------------------------------------------------------
+function makeTmpHome() {
+  const dir = mkdtempSync(join(tmpdir(), "cckeep-"));
+  return dir;
+}
+
+function writeCredentials(home, content) {
+  const awsDir = join(home, ".aws");
+  mkdirSync(awsDir, { recursive: true });
+  writeFileSync(join(awsDir, "credentials"), content, "utf8");
+}
+
+function writeConfig(home, obj) {
+  const configDir = join(home, ".config", "cc-aws-keepalive");
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, "config.json"), JSON.stringify(obj), "utf8");
+}
+
+// We need a fresh import of lib.mjs for each test group that depends on HOME,
+// because homedir() reads process.env.HOME at call time.  We cache the original
+// HOME and restore it in afterEach.
+const ORIGINAL_HOME = process.env.HOME;
+const ORIGINAL_USERPROFILE = process.env.USERPROFILE;
+
+// ============================================================================
+// formatTime -- pure function, no I/O
+// ============================================================================
+
+describe("formatTime", () => {
+  let formatTime;
+
+  beforeEach(async () => {
+    ({ formatTime } = await import("./lib.mjs"));
+  });
+
+  it("returns EXPIRED for 0", () => {
+    assert.equal(formatTime(0), "EXPIRED");
+  });
+
+  it("returns EXPIRED for -1", () => {
+    assert.equal(formatTime(-1), "EXPIRED");
+  });
+
+  it("returns EXPIRED for -100", () => {
+    assert.equal(formatTime(-100), "EXPIRED");
+  });
+
+  it("returns <1m for 1 second", () => {
+    assert.equal(formatTime(1), "<1m");
+  });
+
+  it("returns <1m for 30 seconds", () => {
+    assert.equal(formatTime(30), "<1m");
+  });
+
+  it("returns <1m for 59 seconds", () => {
+    assert.equal(formatTime(59), "<1m");
+  });
+
+  it("returns 1m for 60 seconds", () => {
+    assert.equal(formatTime(60), "1m");
+  });
+
+  it("returns 1m for 119 seconds", () => {
+    assert.equal(formatTime(119), "1m");
+  });
+
+  it("returns 59m for 3599 seconds", () => {
+    assert.equal(formatTime(3599), "59m");
+  });
+
+  it("returns 1h0m for 3600 seconds", () => {
+    assert.equal(formatTime(3600), "1h0m");
+  });
+
+  it("returns 2h30m for 9000 seconds", () => {
+    assert.equal(formatTime(9000), "2h30m");
+  });
+});
+
+// ============================================================================
+// parseCredentials
+// ============================================================================
+
+describe("parseCredentials", () => {
+  let tmpHome;
+  let parseCredentials;
+
+  beforeEach(async () => {
+    tmpHome = makeTmpHome();
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    // Dynamic import with cache-busting query so the module re-evaluates homedir()
+    const mod = await import(`./lib.mjs?pc=${Date.now()}${Math.random()}`);
+    parseCredentials = mod.parseCredentials;
+  });
+
+  afterEach(() => {
+    process.env.HOME = ORIGINAL_HOME;
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("parses single [default] profile with all 3 keys", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = AKIAEXAMPLE",
+        "aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+        "aws_session_token = FwoGZXIvYXdzEA==",
+      ].join("\n")
+    );
+
+    const result = parseCredentials("default");
+    assert.equal(result.aws_access_key_id, "AKIAEXAMPLE");
+    assert.equal(
+      result.aws_secret_access_key,
+      "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    );
+    assert.equal(result.aws_session_token, "FwoGZXIvYXdzEA==");
+  });
+
+  it("parses named profile among multiple profiles", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = DEFAULT_KEY",
+        "aws_secret_access_key = DEFAULT_SECRET",
+        "",
+        "[staging]",
+        "aws_access_key_id = STAGING_KEY",
+        "aws_secret_access_key = STAGING_SECRET",
+        "",
+        "[production]",
+        "aws_access_key_id = PROD_KEY",
+        "aws_secret_access_key = PROD_SECRET",
+      ].join("\n")
+    );
+
+    const result = parseCredentials("staging");
+    assert.equal(result.aws_access_key_id, "STAGING_KEY");
+    assert.equal(result.aws_secret_access_key, "STAGING_SECRET");
+    assert.equal(result.aws_session_token, undefined);
+  });
+
+  it("returns null when profile not found", () => {
+    writeCredentials(
+      tmpHome,
+      ["[default]", "aws_access_key_id = AKIAEXAMPLE"].join("\n")
+    );
+
+    const result = parseCredentials("nonexistent");
+    assert.equal(result, null);
+  });
+
+  it("returns null when credentials file does not exist", () => {
+    // tmpHome has no .aws directory at all
+    const result = parseCredentials("default");
+    assert.equal(result, null);
+  });
+
+  it("handles CRLF line endings", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = AKIACRLF",
+        "aws_secret_access_key = SECRETCRLF",
+      ].join("\r\n")
+    );
+
+    const result = parseCredentials("default");
+    assert.equal(result.aws_access_key_id, "AKIACRLF");
+    assert.equal(result.aws_secret_access_key, "SECRETCRLF");
+  });
+
+  it("handles spaces around = in key-value pairs", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "  aws_access_key_id   =   SPACEDKEY  ",
+        "  aws_secret_access_key   =   SPACEDSECRET  ",
+      ].join("\n")
+    );
+
+    const result = parseCredentials("default");
+    assert.equal(result.aws_access_key_id, "SPACEDKEY");
+    assert.equal(result.aws_secret_access_key, "SPACEDSECRET");
+  });
+
+  it("handles values containing = (base64 tokens)", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = AKIABASE64",
+        "aws_secret_access_key = SECRET",
+        "aws_session_token = FwoGZXIvYXdzEBY=dGVzdA==",
+      ].join("\n")
+    );
+
+    const result = parseCredentials("default");
+    assert.equal(result.aws_session_token, "FwoGZXIvYXdzEBY=dGVzdA==");
+  });
+
+  it("returns null for empty file", () => {
+    writeCredentials(tmpHome, "");
+    const result = parseCredentials("default");
+    assert.equal(result, null);
+  });
+
+  it("skips comment lines starting with #", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "# This is a comment",
+        "aws_access_key_id = AKIACOMMENT",
+        "# Another comment",
+        "aws_secret_access_key = SECRETCOMMENT",
+      ].join("\n")
+    );
+
+    const result = parseCredentials("default");
+    assert.equal(result.aws_access_key_id, "AKIACOMMENT");
+    assert.equal(result.aws_secret_access_key, "SECRETCOMMENT");
+    assert.equal(Object.keys(result).length, 2);
+  });
+
+  it("skips comment lines starting with ;", () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "; semicolon comment",
+        "aws_access_key_id = AKIASEMI",
+      ].join("\n")
+    );
+
+    const result = parseCredentials("default");
+    assert.equal(result.aws_access_key_id, "AKIASEMI");
+    assert.equal(Object.keys(result).length, 1);
+  });
+});
+
+// ============================================================================
+// loadConfig
+// ============================================================================
+
+describe("loadConfig", () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+    delete process.env.CC_KEEPALIVE_PROFILE;
+  });
+
+  afterEach(() => {
+    process.env.HOME = ORIGINAL_HOME;
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+    delete process.env.CC_KEEPALIVE_PROFILE;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns defaults when config file is missing", async () => {
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.profile, "default");
+    assert.equal(config.expirationField, "");
+    assert.equal(config.loginCmd, "");
+    assert.equal(config.autoLoginCmd, "");
+    assert.equal(config.autoLoginMinutes, 0);
+    assert.equal(config.warnMinutes, 30);
+    assert.equal(config.timerWarnMinutes, 60);
+    assert.equal(config.statusLineCmd, "");
+  });
+
+  it("merges partial config over defaults", async () => {
+    writeConfig(tmpHome, { profile: "staging", warnMinutes: 10 });
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.profile, "staging");
+    assert.equal(config.warnMinutes, 10);
+    // Non-overridden defaults remain
+    assert.equal(config.expirationField, "");
+    assert.equal(config.autoLoginMinutes, 0);
+    assert.equal(config.timerWarnMinutes, 60);
+  });
+
+  it("handles corrupt JSON and returns defaults", async () => {
+    const configDir = join(tmpHome, ".config", "cc-aws-keepalive");
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), "{broken json!!!", "utf8");
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.profile, "default");
+    assert.equal(config.warnMinutes, 30);
+  });
+
+  it("CC_KEEPALIVE_PROFILE env var overrides profile", async () => {
+    writeConfig(tmpHome, { profile: "from-config" });
+    process.env.CC_KEEPALIVE_PROFILE = "from-env";
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.profile, "from-env");
+  });
+
+  it("warns on unknown config keys", async () => {
+    writeConfig(tmpHome, { profile: "test", unknownKey: "val" });
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.profile, "test");
+  });
+
+  it("coerces numeric string values to numbers", async () => {
+    writeConfig(tmpHome, { warnMinutes: "15", autoLoginMinutes: "5" });
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.warnMinutes, 15);
+    assert.equal(config.autoLoginMinutes, 5);
+  });
+
+  it("warns when numeric field gets non-numeric string", async () => {
+    writeConfig(tmpHome, { warnMinutes: "abc" });
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.warnMinutes, "abc"); // warns but keeps the value
+  });
+
+  it("warns and coerces when string field gets non-string value", async () => {
+    writeConfig(tmpHome, { profile: 123 });
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.profile, "123");
+  });
+
+  it("warns when autoLoginMinutes set without expirationField", async () => {
+    writeConfig(tmpHome, { autoLoginMinutes: 30, expirationField: "" });
+
+    const { loadConfig } = await import(
+      `./lib.mjs?lc=${Date.now()}${Math.random()}`
+    );
+    const config = loadConfig();
+    assert.equal(config.autoLoginMinutes, 30);
+  });
+});
+
+// ============================================================================
+// getRemaining
+// ============================================================================
+
+describe("getRemaining", () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = ORIGINAL_HOME;
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("returns null when expirationField is empty", async () => {
+    writeCredentials(
+      tmpHome,
+      ["[default]", "aws_access_key_id = KEY", "x_expiration = 9999999999"].join(
+        "\n"
+      )
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({ profile: "default", expirationField: "" });
+    assert.equal(result, null);
+  });
+
+  it("returns null when expiration value is NaN", async () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = KEY",
+        "x_expiration = not-a-number",
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.equal(result, null);
+  });
+
+  it("parses ISO-8601 date string as valid expiration", async () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = KEY",
+        "x_expiration = 2026-04-24T12:00:00Z",
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.ok(result !== null);
+    assert.ok(result.remaining < 0, "past ISO-8601 date should have negative remaining");
+    assert.equal(result.expiration, Math.floor(Date.parse("2026-04-24T12:00:00Z") / 1000));
+  });
+
+  it("returns null for sub-epoch value", async () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = KEY",
+        "x_expiration = 12345",
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.equal(result, null);
+  });
+
+  it("returns null for digits with trailing junk", async () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = KEY",
+        "x_expiration = 9999999999abc",
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.equal(result, null);
+  });
+
+  it("returns positive remaining for future expiry", async () => {
+    const futureEpoch = Math.floor(Date.now() / 1000) + 3600; // 1 hour from now
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = KEY",
+        `x_expiration = ${futureEpoch}`,
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.ok(result !== null);
+    assert.ok(result.remaining > 0, `expected positive remaining, got ${result.remaining}`);
+    assert.equal(result.expiration, futureEpoch);
+    // Should be roughly 3600 (allow 5s tolerance for test execution time)
+    assert.ok(result.remaining >= 3595 && result.remaining <= 3600);
+  });
+
+  it("returns negative remaining for past expiry", async () => {
+    const pastEpoch = Math.floor(Date.now() / 1000) - 600; // 10 minutes ago
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = KEY",
+        `x_expiration = ${pastEpoch}`,
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.ok(result !== null);
+    assert.ok(result.remaining < 0, `expected negative remaining, got ${result.remaining}`);
+    assert.equal(result.expiration, pastEpoch);
+  });
+
+  it("parses ISO-8601 expiration timestamp", async () => {
+    const futureDate = new Date(Date.now() + 3600_000).toISOString();
+    writeCredentials(
+      tmpHome,
+      [
+        "[default]",
+        "aws_access_key_id = KEY",
+        `x_expiration = ${futureDate}`,
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.ok(result !== null);
+    assert.ok(result.remaining > 3500 && result.remaining <= 3600);
+  });
+
+  it("returns null when expiration field exists in different profile only", async () => {
+    writeCredentials(
+      tmpHome,
+      [
+        "[other]",
+        "aws_access_key_id = KEY",
+        "x_expiration = 9999999999",
+        "",
+        "[default]",
+        "aws_access_key_id = KEY2",
+      ].join("\n")
+    );
+
+    const { getRemaining } = await import(
+      `./lib.mjs?gr=${Date.now()}${Math.random()}`
+    );
+    const result = getRemaining({
+      profile: "default",
+      expirationField: "x_expiration",
+    });
+    assert.equal(result, null);
+  });
+});
+
+// ============================================================================
+// tryAcquireAutoLoginLock / releaseAutoLoginLock
+// ============================================================================
+
+describe("auto-login lock", () => {
+  let tmpHome;
+
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+    process.env.HOME = tmpHome;
+    process.env.USERPROFILE = tmpHome;
+  });
+
+  afterEach(() => {
+    process.env.HOME = ORIGINAL_HOME;
+    process.env.USERPROFILE = ORIGINAL_USERPROFILE;
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("acquires lock when no lockfile exists", async () => {
+    const { tryAcquireAutoLoginLock, releaseAutoLoginLock } = await import(
+      `./lib.mjs?lock=${Date.now()}${Math.random()}`
+    );
+    const acquired = tryAcquireAutoLoginLock();
+    assert.equal(acquired, true);
+    const lockPath = join(tmpHome, ".config", "cc-aws-keepalive", ".auto-login.lock");
+    assert.equal(existsSync(lockPath), true);
+    releaseAutoLoginLock();
+  });
+
+  it("fails to acquire when lock is held (recent)", async () => {
+    const { tryAcquireAutoLoginLock } = await import(
+      `./lib.mjs?lock=${Date.now()}${Math.random()}`
+    );
+    const stateDir = join(tmpHome, ".config", "cc-aws-keepalive");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, ".auto-login.lock"), String(Math.floor(Date.now() / 1000)));
+
+    const acquired = tryAcquireAutoLoginLock();
+    assert.equal(acquired, false);
+  });
+
+  it("acquires lock when existing lock is stale (>5min)", async () => {
+    const { tryAcquireAutoLoginLock, releaseAutoLoginLock } = await import(
+      `./lib.mjs?lock=${Date.now()}${Math.random()}`
+    );
+    const stateDir = join(tmpHome, ".config", "cc-aws-keepalive");
+    mkdirSync(stateDir, { recursive: true });
+    const staleTime = Math.floor(Date.now() / 1000) - 400;
+    writeFileSync(join(stateDir, ".auto-login.lock"), String(staleTime));
+
+    const acquired = tryAcquireAutoLoginLock();
+    assert.equal(acquired, true);
+    releaseAutoLoginLock();
+  });
+
+  it("releaseAutoLoginLock removes the lockfile", async () => {
+    const { tryAcquireAutoLoginLock, releaseAutoLoginLock } = await import(
+      `./lib.mjs?lock=${Date.now()}${Math.random()}`
+    );
+    tryAcquireAutoLoginLock();
+    const lockPath = join(tmpHome, ".config", "cc-aws-keepalive", ".auto-login.lock");
+    assert.equal(existsSync(lockPath), true);
+    releaseAutoLoginLock();
+    assert.equal(existsSync(lockPath), false);
+  });
+
+  it("releaseAutoLoginLock is safe when no lockfile exists", async () => {
+    const { releaseAutoLoginLock } = await import(
+      `./lib.mjs?lock=${Date.now()}${Math.random()}`
+    );
+    assert.doesNotThrow(() => releaseAutoLoginLock());
+  });
+
+  it("acquires lock when existing lock has future timestamp (clock skew)", async () => {
+    const { tryAcquireAutoLoginLock, releaseAutoLoginLock } = await import(
+      `./lib.mjs?lock=${Date.now()}${Math.random()}`
+    );
+    const stateDir = join(tmpHome, ".config", "cc-aws-keepalive");
+    mkdirSync(stateDir, { recursive: true });
+    const futureTime = Math.floor(Date.now() / 1000) + 9999;
+    writeFileSync(join(stateDir, ".auto-login.lock"), String(futureTime));
+
+    const acquired = tryAcquireAutoLoginLock();
+    assert.equal(acquired, true);
+    releaseAutoLoginLock();
+  });
+
+  it("acquires lock when existing lock contains non-numeric garbage", async () => {
+    const { tryAcquireAutoLoginLock, releaseAutoLoginLock } = await import(
+      `./lib.mjs?lock=${Date.now()}${Math.random()}`
+    );
+    const stateDir = join(tmpHome, ".config", "cc-aws-keepalive");
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, ".auto-login.lock"), "corrupted-data");
+
+    const acquired = tryAcquireAutoLoginLock();
+    assert.equal(acquired, true);
+    releaseAutoLoginLock();
+  });
+
+  it("second acquire fails when first already holds lock (concurrent simulation)", async () => {
+    const mod1 = await import(`./lib.mjs?lock=${Date.now()}${Math.random()}`);
+    const mod2 = await import(`./lib.mjs?lock=${Date.now()}${Math.random()}`);
+
+    const first = mod1.tryAcquireAutoLoginLock();
+    assert.equal(first, true);
+
+    const second = mod2.tryAcquireAutoLoginLock();
+    assert.equal(second, false);
+
+    mod1.releaseAutoLoginLock();
+  });
+});
+
+// ============================================================================
+// sleepSync
+// ============================================================================
+
+describe("sleepSync", () => {
+  it("blocks for approximately the specified duration", async () => {
+    const { sleepSync } = await import(
+      `./lib.mjs?sleep=${Date.now()}${Math.random()}`
+    );
+    const start = Date.now();
+    sleepSync(50);
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed >= 45, `expected >=45ms, got ${elapsed}ms`);
+    assert.ok(elapsed < 500, `expected <500ms, got ${elapsed}ms`);
+  });
+});

--- a/plugins/cc-aws-keepalive/omc-timer.mjs
+++ b/plugins/cc-aws-keepalive/omc-timer.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// OMC HUD integration: intercepts stdout, appends AWS session timer.
+// Called via `import` from aws-hud-wrapper.mjs — do not run standalone.
+import { loadConfig, getRemaining, formatTime } from "./lib.mjs";
+
+function awsTimer() {
+  try {
+    const config = loadConfig();
+    const info = getRemaining(config);
+    if (!info) return "";
+    const text = formatTime(info.remaining);
+    const warnSec = config.timerWarnMinutes * 60;
+    if (info.remaining <= 0) return `\x1b[31maws:${text}\x1b[0m`;
+    if (info.remaining <= warnSec) return `\x1b[33maws:${text}\x1b[0m`;
+    return `aws:${text}`;
+  } catch { return ""; }
+}
+
+let patched = false;
+export function patchStdout() {
+  if (patched) return;
+  patched = true;
+  const chunks = [];
+  const origWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk, encoding, callback) => {
+    if (typeof chunk === "string") {
+      chunks.push(chunk);
+    } else if (Buffer.isBuffer(chunk)) {
+      chunks.push(chunk.toString(typeof encoding === "string" ? encoding : "utf8"));
+    } else if (chunk instanceof Uint8Array) {
+      chunks.push(Buffer.from(chunk.buffer, chunk.byteOffset, chunk.byteLength)
+        .toString(typeof encoding === "string" ? encoding : "utf8"));
+    } else {
+      chunks.push(String(chunk));
+    }
+    if (typeof encoding === "function") encoding();
+    else if (typeof callback === "function") callback();
+    return true;
+  };
+  process.on("exit", () => {
+    process.stdout.write = origWrite;
+    const raw = chunks.join("");
+    const lines = raw.split(/\r?\n/);
+    // Remove trailing empty element from split (artifact of trailing \n)
+    if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+    const timer = awsTimer();
+    if (lines.length > 0 && timer) {
+      const idx = lines.findIndex(l => l.length > 0);
+      if (idx !== -1) lines[idx] += " | " + timer;
+      else lines.push(timer);
+    } else if (timer) {
+      lines.push(timer);
+    }
+    if (lines.length > 0) origWrite(lines.join("\n") + "\n");
+  });
+}

--- a/plugins/cc-aws-keepalive/package.json
+++ b/plugins/cc-aws-keepalive/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "cc-aws-keepalive",
+  "version": "0.5.1-ccplugins.1",
+  "description": "Keep Claude Code sessions alive through AWS credential expiration",
+  "type": "module",
+  "license": "GPL-3.0",
+  "author": "GeiserX",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GeiserX/cc-aws-keepalive.git"
+  },
+  "files": [
+    "*.mjs",
+    "hooks",
+    ".claude-plugin",
+    "config.example.json",
+    "DOWNSTREAM-CHANGES.md",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "test": "node --test"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}


### PR DESCRIPTION
Adds a complete, tested cc-aws-keepalive plugin to the Automation DevOps section.

This revision:
- rebases the branch onto current main without removing any README or marketplace entries;
- vendors a complete GPL-3.0 plugin package derived from upstream 0.5.0 as 0.5.1-ccplugins.1, with a dated downstream modification notice;
- registers the plugin in the central marketplace and both README indexes;
- emits proactive warnings through the documented Claude Code hook JSON contract;
- supports aggregate-marketplace cache paths and reactive STS fallback;
- requires verified SSH host keys by default and removes plaintext SSH-password support; and
- documents Node.js 18+ as a separate prerequisite.

Validation: Claude plugin validation, marketplace validation, JSON/catalog invariants, JavaScript syntax checks, npm package contents, Node 18 compatibility, and 71 tests all pass.

Created using Codex.