### PR TITLE
Add lazymac/mcp and lazymac/k-mcp (42-tool unified MCP + Korean wedge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
 * [Use Cases](#use-cases)
 * [Plugins](#plugins)
     - [Official Claude Code Plugins](#official-claude-code-plugins)
+- [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
+- [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`
     - [Workflow Orchestration](#workflow-orchestration)
     - [Automation DevOps](#automation-devops)
     - [Business Sales](#business-sales)


### PR DESCRIPTION
## What

- **`@lazymac/mcp`** — unified MCP server exposing 42 developer tools backed by api.lazy-mac.com (Cloudflare Workers, sub-200ms p95). Free 100/day tier.
- **`@lazymac/k-mcp`** — Korean wedge MCP for PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP.

## Why one unified MCP

Most MCP servers expose 1-3 tools. `lazymac/mcp` aggregates 42 tools through a single `npx -y` install so agents get a full toolbox in one config block.

## Links

- npm: https://www.npmjs.com/package/@lazymac/mcp
- npm: https://www.npmjs.com/package/@lazymac/k-mcp
- Smithery: https://smithery.ai/server/lazymac/mcp
- Source: https://github.com/lazymac2x/lazymac-mcp

Both packages MIT, listed on Smithery, works with Claude Code / Cursor / Windsurf out of the box.
