### PR TITLE
Add toprank to Marketing Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [instagram-curator](./plugins/instagram-curator)
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
+- [toprank](./plugins/toprank)
 - [twitter-engager](./plugins/twitter-engager)
 
 ### Project & Product Management

--- a/plugins/toprank/.claude-plugin/plugin.json
+++ b/plugins/toprank/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "toprank",
+  "description": "SEO + Google Ads skills for Claude Code. Audits Search Console data, finds wasted ad spend, rewrites meta tags, generates schema markup, and ships fixes.",
+  "version": "1.0.0",
+  "author": {
+    "name": "nowork-studio"
+  },
+  "homepage": "https://github.com/nowork-studio/toprank"
+}

--- a/plugins/toprank/README.md
+++ b/plugins/toprank/README.md
@@ -1,0 +1,33 @@
+# toprank
+
+**SEO + Google Ads skills for Claude Code. Data-driven decisions, not dashboards.**
+
+Toprank gives Claude Code direct access to Google Search Console and Google Ads. It analyzes traffic, surfaces what's hurting rankings, finds wasted ad spend, and ships the fixes — rewriting meta tags, fixing headings, adding structured data, pausing wasteful keywords, optimizing bids, and more.
+
+## Skills
+
+**Google Ads**
+- `ads-audit` — Account audit + business context setup. Scores 7 health dimensions, identifies wasted spend.
+- `ads` — Campaign management: performance, keywords, bids, negatives.
+- `ads-copy` — RSA copy generator with A/B testing.
+
+**SEO**
+- `seo-analysis` — Full audit with GSC data, quick wins, 30-day plan.
+- `content-writer` — E-E-A-T content creation.
+- `keyword-research` — Keyword discovery + topic clusters.
+- `meta-tags-optimizer` — Titles, descriptions, OG/Twitter cards.
+- `schema-markup-generator` — JSON-LD for rich results.
+- `setup-cms` — WordPress, Strapi, Contentful, Ghost connectors.
+
+## Install
+
+```
+/plugin marketplace add nowork-studio/toprank
+/plugin install toprank@nowork-studio
+```
+
+## Links
+
+- **Source:** https://github.com/nowork-studio/toprank
+- **Docs & API key:** https://www.adsagent.org
+- **License:** MIT


### PR DESCRIPTION
Adds **toprank** to the Marketing Growth category.

## What is toprank?

A Claude Code plugin that provides SEO + Google Ads skills. It gives Claude direct access to Google Search Console and Google Ads — auditing traffic, finding wasted ad spend, rewriting meta tags, generating schema markup, optimizing keyword bids, and shipping the fixes.

**Skills included:**
- **Google Ads:** `ads-audit`, `ads`, `ads-copy`
- **SEO:** `seo-analysis`, `content-writer`, `keyword-research`, `meta-tags-optimizer`, `schema-markup-generator`, `setup-cms`
- **Cross-model:** `gemini` (second-opinion reviews)

## Links
- Source: https://github.com/nowork-studio/toprank
- License: MIT
- Install: \`/plugin marketplace add nowork-studio/toprank\`

## Checklist
- [x] Added under the correct category (Marketing Growth — SEO/Ads is marketing tooling)
- [x] Alphabetically ordered (between tiktok-strategist and twitter-engager)
- [x] Minimal plugin.json + README.md stub added under \`./plugins/toprank/\`
- [x] Homepage links to upstream repo