### PR TITLE
Add idea-to-deploy plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -58,6 +58,7 @@
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [idea-to-deploy](./plugins/idea-to-deploy)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [idea-to-deploy](./plugins/idea-to-deploy)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/plugins/idea-to-deploy/.claude-plugin/plugin.json
+++ b/plugins/idea-to-deploy/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
     "name": "HiH-DimaN",
     "url": "https://github.com/HiH-DimaN"
   },
-  "homepage": "https://github.com/HiH-DimaN/idea-to-deploy"
+  "homepage": "https://github.com/hihol-labs/idea-to-deploy"
 }

--- a/plugins/idea-to-deploy/.claude-plugin/plugin.json
+++ b/plugins/idea-to-deploy/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "idea-to-deploy",
+  "description": "Complete project lifecycle methodology — 19 skills + 6 specialized subagents from idea to deployed product",
+  "version": "1.17.2",
+  "author": {
+    "name": "HiH-DimaN",
+    "url": "https://github.com/HiH-DimaN"
+  },
+  "homepage": "https://github.com/HiH-DimaN/idea-to-deploy"
+}

--- a/plugins/idea-to-deploy/commands/project.md
+++ b/plugins/idea-to-deploy/commands/project.md
@@ -1,0 +1,41 @@
+---
+description: Smart project lifecycle router — from idea to deployed product. Routes to /kickstart (full cycle), /blueprint (planning only), or /guide (step-by-step prompts).
+---
+
+## Context
+
+- Current directory: !`pwd`
+- Git status: !`git status --short 2>/dev/null || echo "Not a git repo"`
+
+## Your task
+
+You are the entry point for the **idea-to-deploy** methodology — a complete project lifecycle from idea to deployed and hardened product.
+
+Assess the user's request and route to the appropriate workflow:
+
+**A) Full lifecycle** (idea → deployed product) → `/kickstart`
+- User has an idea and wants a working project
+- Covers: product discovery (MoSCoW/RICE), architecture, implementation plan, scaffolding, coding, testing, deployment
+
+**B) Planning only** (no code) → `/blueprint`
+- User wants documentation: strategic plan, architecture, PRD, implementation plan
+- No code generation, just thorough planning artifacts
+
+**C) Step-by-step guide** (existing docs) → `/guide`
+- User already has documentation and wants copy-paste prompts to build via Claude Code
+
+Ask the user which scenario fits, then delegate to the appropriate skill.
+
+For work on **existing** codebases (bugs, refactoring, testing, deployment), use `/task` instead.
+
+### Available skills (19 total)
+- **Creation:** /kickstart, /blueprint, /guide
+- **Daily work:** /task (router), /bugfix, /refactor, /doc, /test, /perf, /explain
+- **Quality:** /review (self-review mode with binary rubric), /security-audit, /deps-audit
+- **Operations:** /migrate, /harden, /infra
+- **Workflow:** /project (this router), /session-save
+
+### Subagents (6 total)
+- architect, code-reviewer, doc-writer, perf-analyzer, test-generator, security-auditor
+
+Full documentation: https://github.com/HiH-DimaN/idea-to-deploy

--- a/plugins/idea-to-deploy/commands/project.md
+++ b/plugins/idea-to-deploy/commands/project.md
@@ -38,4 +38,4 @@ For work on **existing** codebases (bugs, refactoring, testing, deployment), use
 ### Subagents (6 total)
 - architect, code-reviewer, doc-writer, perf-analyzer, test-generator, security-auditor
 
-Full documentation: https://github.com/HiH-DimaN/idea-to-deploy
+Full documentation: https://github.com/hihol-labs/idea-to-deploy


### PR DESCRIPTION
## Summary

Adds **[idea-to-deploy](https://github.com/hihol-labs/idea-to-deploy)** — a complete project lifecycle methodology plugin with 19 skills and 6 specialized subagents, covering the full path from idea to deployed and hardened product.

### What it includes

- **19 skills:** `/project`, `/kickstart`, `/blueprint`, `/guide`, `/task`, `/bugfix`, `/refactor`, `/doc`, `/test`, `/perf`, `/explain`, `/review`, `/security-audit`, `/deps-audit`, `/migrate`, `/harden`, `/infra`, `/session-save`, `/discover`
- **6 subagents:** architect, code-reviewer, doc-writer, perf-analyzer, test-generator, security-auditor
- **Key features:** Smart routing (project creation vs daily work), product discovery (MoSCoW/RICE), self-review with binary rubric, session context persistence, safety guardrails

### Changes

- `plugins/idea-to-deploy/.claude-plugin/plugin.json` — plugin metadata
- `plugins/idea-to-deploy/commands/project.md` — main entry-point command (smart router)
- `README.md` — added entry to Workflow Orchestration section
- `README-zh.md` — added entry to Workflow Orchestration section

**License:** MIT  
**Repo:** https://github.com/hihol-labs/idea-to-deploy  
**Version:** 1.17.2

---
**Update 2026-04-20:** Repository transferred to `hihol-labs` org. All URLs updated in this PR. GitHub redirect from old path still works.
