### PR TITLE
Add nexus-agents to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
+- [nexus-agents](https://github.com/williamzujkowski/nexus-agents) — Multi-CLI orchestration with 30 MCP tools, 12 expert agents, 17 skills, and Budget→TOPSIS→LinUCB routing. Coordinates Claude, Gemini, Codex, and OpenCode via consensus voting.
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
 - [studio-coach](./plugins/studio-coach)
 - [ultrathink](./plugins/ultrathink)


### PR DESCRIPTION
Adds [nexus-agents](https://github.com/williamzujkowski/nexus-agents) to the Workflow Orchestration category.

**What it is:** Multi-CLI orchestration platform routing tasks to Claude, Gemini, Codex, and OpenCode through a Budget→TOPSIS→LinUCB composite router that learns from outcomes.

**Plugin surface:**
- 30 MCP tools (`orchestrate`, `consensus_vote`, research pipelines, code intel, memory, weather reports)
- 12 expert agents at `agents/*.md`
- 17 skills at `skills/<name>/SKILL.md` (Anthropic Agent Skills spec)
- 2 PreToolUse governance hooks (fitness-gate, secret-scan)

**Install:**
```
/plugin marketplace add williamzujkowski/nexus-agents
/plugin install nexus-agents@williamzujkowski
```

**License:** MIT. CI runs gitleaks + CodeQL + Semgrep; zero `any` TypeScript policy enforced.