### PR TITLE
Add whatsapp-claude-plugin to Communication & Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
     - [Automation DevOps](#automation-devops)
     - [Business Sales](#business-sales)
     - [Code Quality Testing](#code-quality-testing)
+    - [Communication & Integrations](#communication--integrations)
     - [Data Analytics](#data-analytics)
     - [Design UX](#design-ux)
     - [Development Engineering](#development-engineering)
@@ -98,6 +99,9 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [test-results-analyzer](./plugins/test-results-analyzer)
 - [test-writer-fixer](./plugins/test-writer-fixer)
 - [unit-test-generator](./plugins/unit-test-generator)
+
+### Communication & Integrations
+- [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.
 
 ### Data Analytics
 - [analytics-reporter](./plugins/analytics-reporter)


### PR DESCRIPTION
## Summary
- Adds [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) to a new **Communication & Integrations** category
- WhatsApp channel plugin for Claude Code — officially published on the Anthropic Plugin Marketplace
- Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control
- Author: Richie Liu | Version: 0.3.3

## Changes
- Added `Communication & Integrations` section to the table of contents
- Added plugin entry with description and link to the external repository