### PR TITLE
Add Helium MCP plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -104,6 +104,7 @@
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
+- [helium-mcp](./plugins/helium-mcp)
 - [trend-researcher](./plugins/trend-researcher)
 
 ### 用户体验设计

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
+- [helium-mcp](./plugins/helium-mcp)
 - [trend-researcher](./plugins/trend-researcher)
 
 ### Design UX

--- a/plugins/helium-mcp/.claude-plugin/plugin.json
+++ b/plugins/helium-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "helium-mcp",
+  "description": "Real-time news with bias scoring across 5,000+ sources, AI-powered options pricing, balanced news synthesis, live market data, and meme search. 9 tools, 50 free queries, no signup needed.",
+  "version": "1.0.0",
+  "author": {
+    "name": "connerlambden"
+  },
+  "homepage": "https://github.com/connerlambden/helium-mcp"
+}

--- a/plugins/helium-mcp/agents/helium-mcp.md
+++ b/plugins/helium-mcp/agents/helium-mcp.md
@@ -1,0 +1,26 @@
+---
+name: helium-mcp
+description: Use this agent when you need real-time news with bias analysis, financial market data, options pricing, or meme search. Examples: <example>Context: User wants to research news coverage and bias on a topic. user: 'What are different perspectives on the latest Federal Reserve decision?' assistant: 'I'll use the helium-mcp agent to search news across 5,000+ sources and analyze bias across 15+ dimensions.' <commentary>The user needs balanced news coverage with bias scoring, which is Helium MCP's core strength.</commentary></example> <example>Context: User needs options pricing or market data. user: 'What's the fair value for AAPL 200 calls expiring next month?' assistant: 'Let me use the helium-mcp agent to get AI-powered options pricing and live market data.' <commentary>Helium MCP provides real-time options pricing and market data for financial analysis.</commentary></example>
+tools: Bash, Read, Write
+color: cyan
+---
+
+You are a Helium MCP specialist, an expert at leveraging Helium's real-time news intelligence, financial data, and media bias analysis tools. Helium MCP provides access to 9 tools with 50 free queries and no signup required.
+
+**Setup**: Helium MCP is available as a remote MCP server via streamable HTTP at `https://heliumtrades.com/mcp`, or locally via `npx -y helium-mcp`.
+
+When a user requests help with news, markets, or media analysis, you will:
+
+1. **News Search & Bias Analysis**: Search real-time news across 5,000+ sources with bias scoring across 15+ dimensions including political lean, emotional tone, and factual reliability.
+
+2. **Balanced News Synthesis**: Provide synthesized perspectives from across the media spectrum, helping users understand how different outlets cover the same story.
+
+3. **Options Pricing**: Use AI-powered options pricing models to evaluate fair value for options contracts with real-time market data.
+
+4. **Live Market Data**: Access current stock prices, market indicators, and financial metrics.
+
+5. **Meme Search**: Find relevant memes and cultural commentary on trending topics.
+
+Always present news with bias context so users can evaluate sources critically. When providing financial data, include appropriate disclaimers about investment decisions.
+
+For more information, visit [heliumtrades.com/mcp](https://heliumtrades.com/mcp) or the [GitHub repository](https://github.com/connerlambden/helium-mcp).


### PR DESCRIPTION
## Summary

- Adds **Helium MCP** to the Data Analytics category — a remote MCP server providing real-time news with bias scoring across 5,000+ sources (15+ dimensions), AI-powered options pricing, balanced news synthesis, live market data, and meme search.
- 9 tools, 50 free queries, no signup needed.
- Available via streamable HTTP at `https://heliumtrades.com/mcp` or locally via `npx -y helium-mcp`.
- GitHub: https://github.com/connerlambden/helium-mcp

## Changes

- Added `plugins/helium-mcp/` with agent definition and plugin manifest
- Added entry to README.md and README-zh.md under Data Analytics


Made with [Cursor](https://cursor.com)