### PR TITLE
Add llm-wiki plugin under Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [generate-api-docs](./plugins/generate-api-docs)
 - [openapi-expert](./plugins/openapi-expert)
 - [update-claudemd](./plugins/update-claudemd)
+- [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) - Build a compounding, LLM-curated personal knowledge base in any project (Karpathy's LLM Wiki pattern). Skill + 5 `/wiki:*` commands with sharded indexes, BM25 search, and a structural lint script.
 
 ### Git Workflow
 - [analyze-issue](./plugins/analyze-issue)


### PR DESCRIPTION
Adds [llm-wiki](https://github.com/praneybehl/llm-wiki-plugin) under the **Documentation** section as an external-link entry (the plugin lives in its own repo, installable via `/plugin marketplace add praneybehl/llm-wiki-plugin`).

## What it does

Implementation of [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f) as a Claude Code plugin. Ingested sources (papers, articles, transcripts, PDFs, notes) get compiled once into persistent, structured markdown pages; subsequent queries read the pre-synthesized wiki rather than re-chunking raw sources, so knowledge compounds over time.

## Surface area

- `llm-wiki` skill (progressive-disclosure references)
- 5 slash commands: `/wiki:init`, `/wiki:ingest`, `/wiki:query`, `/wiki:lint`, `/wiki:stats`
- 4 bundled stdlib-only Python scripts: init, BM25 search with frontmatter filters, structural lint, size/shape stats
- Marketplace manifest — also installable via `npx skills add praneybehl/llm-wiki-plugin`

Happy to vendor a subtree copy under `./plugins/llm-wiki` instead if the project prefers that over external links — let me know.