### PR TITLE
Add claude-code-sessions plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Data Analytics
 - [analytics-reporter](./plugins/analytics-reporter)
+- [claude-code-sessions](https://github.com/apappascs/claude-code-sessions) — Session intelligence plugin. 11 skills for full-text search, token analytics, task management, session comparison, timeline views, and context recovery across all sessions. Includes a web dashboard. Zero runtime dependencies, read-only.
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)


### PR DESCRIPTION
Adds [claude-code-sessions](https://github.com/apappascs/claude-code-sessions) under Data Analytics.

Session intelligence plugin with 11 skills:

- /session-search, /session-stats, /session-list, /session-detail, /session-diff
- /session-timeline, /session-resume, /session-tasks, /session-export
- /session-cleanup, /session-delete

Plus a web dashboard. Same TypeScript modules power skills, dashboard, and CLI. Zero runtime dependencies. Read-only. MIT licensed.