### PR TITLE
Add sonmat and bobusang plugins

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -56,6 +56,7 @@
 
 ### 工作流编排
 - [angelos-symbo](./plugins/angelos-symbo)
+- [bobusang](https://github.com/jun0-ds/bobusang) — Claude Code多设备记忆系统，通过git自动同步在Windows、WSL2和Linux之间同步上下文。
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
@@ -94,6 +95,7 @@
 - [optimize](./plugins/optimize)
 - [performance-benchmarker](./plugins/performance-benchmarker)
 - [refractor](./plugins/refractor)
+- [sonmat](https://github.com/jun0-ds/sonmat) — 验证纪律插件，六个反应轴（guard、inspect、witness、punch、devil's advocate、scribe）用于AI-人类协作。
 - [test-file](./plugins/test-file)
 - [test-results-analyzer](./plugins/test-results-analyzer)
 - [test-writer-fixer](./plugins/test-writer-fixer)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Workflow Orchestration
 - [angelos-symbo](./plugins/angelos-symbo)
+- [bobusang](https://github.com/jun0-ds/bobusang) — Multi-device memory system for Claude Code. Syncs context across Windows, WSL2, and Linux with git-based auto-sync.
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)
@@ -94,6 +95,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [optimize](./plugins/optimize)
 - [performance-benchmarker](./plugins/performance-benchmarker)
 - [refractor](./plugins/refractor)
+- [sonmat](https://github.com/jun0-ds/sonmat) — Verification discipline plugin with six reactive axes (guard, inspect, witness, punch, devil's advocate, scribe) for AI-human collaboration.
 - [test-file](./plugins/test-file)
 - [test-results-analyzer](./plugins/test-results-analyzer)
 - [test-writer-fixer](./plugins/test-writer-fixer)


### PR DESCRIPTION
## sonmat

Verification discipline plugin for Claude Code with six reactive axes (guard, inspect, witness, punch, devil's advocate, scribe) for AI-human collaboration. Prompt-first architecture, zero runtime hook overhead.

- **Repo**: https://github.com/jun0-ds/sonmat
- **Category**: Code Quality Testing
- **Install**: `/plugin marketplace add jun0-ds/sonmat`
- **License**: MIT

## bobusang

Multi-device memory system for Claude Code. Syncs context across Windows, WSL2, and Linux with git-based auto-sync. 3-tier memory hierarchy (core/domain/archive).

- **Repo**: https://github.com/jun0-ds/bobusang
- **Category**: Workflow Orchestration
- **Install**: `git clone https://github.com/jun0-ds/bobusang && bash setup.sh`
- **License**: MIT

Both entries added to README.md and README-zh.md.