### PR TITLE
Add nhs-mcp-search and ai-dev-jobs-search plugins

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,42 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "nhs-mcp-search",
+      "source": "./plugins/nhs-mcp-search",
+      "description": "Search 8,600+ AI tools, MCP servers, and APIs via Not Human Search. Query the index, check agentic readiness scores, verify MCP endpoints, and submit new tools.",
+      "version": "1.0.0",
+      "author": {
+        "name": "United Ideas",
+        "url": "https://nothumansearch.ai"
+      },
+      "category": "Data Analytics",
+      "homepage": "https://nothumansearch.ai",
+      "keywords": [
+        "mcp",
+        "search",
+        "ai-tools",
+        "discovery"
+      ]
+    },
+    {
+      "name": "ai-dev-jobs-search",
+      "source": "./plugins/ai-dev-jobs-search",
+      "description": "Search 5,400+ AI and ML developer jobs with salary data, company info, and remote filters via AI Dev Jobs MCP server.",
+      "version": "1.0.0",
+      "author": {
+        "name": "United Ideas",
+        "url": "https://aidevboard.com"
+      },
+      "category": "Data Analytics",
+      "homepage": "https://aidevboard.com",
+      "keywords": [
+        "jobs",
+        "ai",
+        "career",
+        "search"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -100,10 +100,12 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [unit-test-generator](./plugins/unit-test-generator)
 
 ### Data Analytics
+- [ai-dev-jobs-search](./plugins/ai-dev-jobs-search)
 - [analytics-reporter](./plugins/analytics-reporter)
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
+- [nhs-mcp-search](./plugins/nhs-mcp-search)
 - [trend-researcher](./plugins/trend-researcher)
 
 ### Design UX

--- a/plugins/ai-dev-jobs-search/.claude-plugin/plugin.json
+++ b/plugins/ai-dev-jobs-search/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "ai-dev-jobs-search",
+  "description": "Search 5,400+ AI and ML developer jobs with salary data, company info, and remote filters. MCP endpoint at aidevboard.com/mcp with search_jobs, get_job, list_companies, and get_stats tools.",
+  "version": "1.0.0",
+  "author": {
+    "name": "United Ideas",
+    "url": "https://aidevboard.com"
+  },
+  "homepage": "https://aidevboard.com",
+  "keywords": [
+    "jobs",
+    "ai",
+    "career",
+    "search"
+  ]
+}

--- a/plugins/ai-dev-jobs-search/agents/ai-dev-jobs-search.md
+++ b/plugins/ai-dev-jobs-search/agents/ai-dev-jobs-search.md
@@ -1,0 +1,26 @@
+---
+name: ai-dev-jobs-search
+description: Use this agent when searching for AI, ML, or data science job postings. Queries the AI Dev Jobs index of 5,400+ positions with salary data and remote filters. Examples:\n\n<example>\nContext: Job search\nuser: "Find remote ML engineer jobs paying over $150k"\nassistant: "I'll search AI Dev Jobs for remote ML engineer positions with salaries above $150k."\n<commentary>\nAI Dev Jobs tracks positions from 265+ companies with salary ranges and work-mode filters.\n</commentary>\n</example>\n\n<example>\nContext: Market research\nuser: "What companies are hiring for AI roles right now?"\nassistant: "I'll pull the latest hiring company data from AI Dev Jobs to show active AI employers."\n<commentary>\nThe list_companies and get_stats endpoints provide market-level hiring data.\n</commentary>\n</example>
+tools: Read, Bash, WebFetch
+---
+
+You are an AI job market research specialist. You search the AI Dev Jobs index to find relevant AI and ML developer positions.
+
+## Data Source
+
+- **AI Dev Jobs** (aidevboard.com) indexes 5,400+ AI and ML developer jobs
+- Covers 265+ companies with salary data, remote/hybrid/onsite filters, and experience levels
+- MCP endpoint: `aidevboard.com/mcp` (JSON-RPC with `search_jobs`, `get_job`, `list_companies`, `get_stats` tools)
+
+## How to Search
+
+Use the REST API:
+
+- **Search jobs**: `curl -s 'https://aidevboard.com/api/v1/jobs?q=QUERY&remote=true&min_salary=150000'`
+- **Get job details**: `curl -s 'https://aidevboard.com/api/v1/jobs/JOB_ID'`
+- **List companies**: `curl -s 'https://aidevboard.com/api/v1/companies'`
+- **Get stats**: `curl -s 'https://aidevboard.com/api/v1/stats'`
+
+## Output Format
+
+Present results as a structured list with: Title, Company, Location (remote/hybrid/onsite), Salary Range, and a link to the full listing. Include market statistics when relevant.

--- a/plugins/nhs-mcp-search/.claude-plugin/plugin.json
+++ b/plugins/nhs-mcp-search/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "nhs-mcp-search",
+  "description": "Search 8,600+ AI tools, MCP servers, and APIs via Not Human Search. Query the index, check agentic readiness scores, verify MCP endpoints, and submit new tools. MCP endpoint at nothumansearch.ai/mcp.",
+  "version": "1.0.0",
+  "author": {
+    "name": "United Ideas",
+    "url": "https://nothumansearch.ai"
+  },
+  "homepage": "https://nothumansearch.ai",
+  "keywords": [
+    "mcp",
+    "search",
+    "ai-tools",
+    "discovery"
+  ]
+}

--- a/plugins/nhs-mcp-search/agents/nhs-mcp-search.md
+++ b/plugins/nhs-mcp-search/agents/nhs-mcp-search.md
@@ -1,0 +1,25 @@
+---
+name: nhs-mcp-search
+description: Use this agent when you need to find AI tools, MCP servers, or APIs for a project. Searches the Not Human Search index of 8,600+ tools with agentic readiness scores. Examples:\n\n<example>\nContext: Finding MCP servers\nuser: "Find MCP servers for database management"\nassistant: "I'll search the Not Human Search index for database MCP servers and their agentic readiness scores."\n<commentary>\nNot Human Search indexes tools with scores based on MCP support, API availability, and documentation quality.\n</commentary>\n</example>\n\n<example>\nContext: Checking tool readiness\nuser: "Is Stripe indexed as an MCP server?"\nassistant: "I'll check the Not Human Search index for Stripe's agentic readiness and MCP verification status."\n<commentary>\nThe check endpoint returns whether a site is indexed and its score.\n</commentary>\n</example>
+tools: Read, Bash, WebFetch
+---
+
+You are an AI tool discovery specialist. You search the Not Human Search index to find AI tools, MCP servers, and APIs relevant to a user's project.
+
+## Data Source
+
+- **Not Human Search** (nothumansearch.ai) indexes 8,600+ AI tools and MCP servers
+- Each tool has an agentic readiness score (0-100) based on MCP support, API availability, structured data, and documentation
+- MCP endpoint: `nothumansearch.ai/mcp` (JSON-RPC with `search`, `check`, `verify_mcp`, `submit` tools)
+
+## How to Search
+
+Use the REST API for quick queries:
+
+- **Search**: `curl -s 'https://nothumansearch.ai/api/v1/search?q=QUERY'`
+- **Check a site**: `curl -s 'https://nothumansearch.ai/api/v1/check?url=DOMAIN'`
+- **Submit a tool**: `curl -s -X POST 'https://nothumansearch.ai/api/v1/submit' -H 'Content-Type: application/json' -d '{"url":"URL"}'`
+
+## Output Format
+
+Present results as a table with: Name, URL, Category, Agentic Score, and whether MCP is verified. Highlight high-scoring tools (80+) as strong integration candidates.


### PR DESCRIPTION
Adds two new Claude Code plugins for AI tool and job discovery:

- **nhs-mcp-search** — Search 8,600+ AI tools, MCP servers, and APIs via Not Human Search. Includes agentic readiness scoring and MCP endpoint verification.
- **ai-dev-jobs-search** — Search 5,400+ AI/ML developer jobs with salary data, company info, and remote filters.

Both plugins include:
- `.claude-plugin/plugin.json` manifest
- Agent definition in `agents/` directory
- Entries in `marketplace.json` under "Data Analytics"
- Entries in README under "Data Analytics"

Free APIs with no API key required. Both are listed in the official MCP registry.