### PR TITLE
Add 3 external Qualixar tools (SLM, Hub, SkillFortify) for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [test-results-analyzer](./plugins/test-results-analyzer)
 - [test-writer-fixer](./plugins/test-writer-fixer)
 - [unit-test-generator](./plugins/unit-test-generator)
+- [slm-mcp-hub](https://github.com/qualixar/slm-mcp-hub) - External: Universal MCP gateway federating 430+ tools from 37 servers through one endpoint. 75% RAM reduction.
 
 ### Data Analytics
 - [analytics-reporter](./plugins/analytics-reporter)
@@ -132,6 +133,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
+- [superlocalmemory](https://github.com/qualixar/superlocalmemory) - External: Persistent memory + learning MCP server for Claude Code. Zero-cloud, 6-channel retrieval, 16K+ monthly downloads. Backed by 3 arXiv papers.
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)
@@ -188,6 +190,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+- [skillfortify](https://github.com/qualixar/skillfortify) - External: Formal verification scanner for AI agent skills (including Claude Code skills + MCP servers). 100% precision on 540-skill benchmark. ASBOM generation. arXiv:2603.00195.
 
 
 ## Tutorials


### PR DESCRIPTION
Adding 3 external Claude Code compatible tools from [Qualixar Platform](https://qualixar.com):

1. **[skillfortify](https://github.com/qualixar/skillfortify)** → Security, Compliance, & Legal — Scans Claude Code skills + MCP servers for security issues. 100% precision. arXiv:2603.00195.
2. **[superlocalmemory](https://github.com/qualixar/superlocalmemory)** → Development Engineering — Persistent memory MCP server. 16K+ monthly downloads.
3. **[slm-mcp-hub](https://github.com/qualixar/slm-mcp-hub)** → Code Quality Testing — Universal MCP gateway federating 430+ tools through one endpoint.

Marked as 'External:' to distinguish from in-repo plugins. All actively maintained, peer-reviewed.