### PR TITLE
Add tailtest to Code Quality Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [test-results-analyzer](./plugins/test-results-analyzer)
 - [test-writer-fixer](./plugins/test-writer-fixer)
 - [unit-test-generator](./plugins/unit-test-generator)
+- [tailtest](https://github.com/avansaber/tailtest) - Automatically generates and runs tests for every file Claude Code creates or modifies. PostToolUse hook detects changes, generates test scenarios, runs them, and surfaces failures. 8 languages (Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust). Zero config, zero commands.
 
 ### Data Analytics
 - [analytics-reporter](./plugins/analytics-reporter)


### PR DESCRIPTION
## Summary

Adds [tailtest](https://github.com/avansaber/tailtest) to the Code Quality Testing section.

tailtest is a Claude Code plugin that automatically generates and runs tests for every file Claude Code creates or modifies. The PostToolUse hook detects file changes, generates test scenarios, runs them, and surfaces only what fails.

- **8 languages:** Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust
- **Zero config:** no setup, no commands
- **Repo:** https://github.com/avansaber/tailtest
- **License:** Apache 2.0