### PR TITLE
Add claude-snapshot plugin under Automation DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ultrathink](./plugins/ultrathink)
 
 ### Automation DevOps
+- [claude-snapshot](https://github.com/adhenawer/claude-snapshot) - Portable `.tar.gz` snapshots of your Claude Code setup (settings, hooks, plugins, MCPs) with diff-before-apply and `.bak` rollback for migration and backup across machines.
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)


### PR DESCRIPTION
## Summary

Adds [claude-snapshot](https://github.com/adhenawer/claude-snapshot) under the **Automation DevOps** section as an external-link entry (the plugin lives in its own repo, installable via `/plugin marketplace add adhenawer/claude-snapshot`).

## What it does

Portable snapshots of your `~/.claude/` setup. Export as a `.tar.gz` on one machine, apply on another in under two minutes — with `\$HOME` path normalization, diff-before-apply, and automatic `.bak` rollback of every overwritten file.

## Surface area

- 4 slash commands: `/snapshot:export`, `/snapshot:inspect`, `/snapshot:diff`, `/snapshot:apply`
- Captures: `settings.json`, global `CLAUDE.md`, hooks, plugin manifests, and MCP servers (from `~/.claude.json`, `mcpServers` key only — OAuth tokens excluded)
- Tarball carries a structured manifest with `schemaVersion`, SHA-256 checksums, and MCP install-method classification (`npm`/`pip`/`binary`/`manual`)
- Cross-platform Node.js ESM — same code on macOS and Linux
- 57 tests, CI matrix (macOS/Ubuntu × Node 18/20/22), MIT licensed

Happy to vendor a subtree copy under `./plugins/claude-snapshot` instead if the project prefers that over external-link entries — let me know.