### PR TITLE
Add Qovery Deploy Skill to Automation DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)
 - [monitoring-observability-specialist](./plugins/monitoring-observability-specialist)
 - [n8n-workflow-builder](./plugins/n8n-workflow-builder)
+- [qovery-deploy](https://github.com/Qovery/qovery-skills) - Deploy any app to Kubernetes on AWS/GCP/Azure/Scaleway. Creates Dockerfiles, provisions databases, deploys via CLI+API or Terraform. Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`
 
 ### Business Sales
 - [b2b-project-shipper](./plugins/b2b-project-shipper)


### PR DESCRIPTION
Adds [Qovery Deploy Skill](https://github.com/Qovery/qovery-skills) — deploy any application to Kubernetes from AI coding tools. Analyzes codebases, creates Dockerfiles for 12+ frameworks, provisions databases, deploys via CLI+API or Terraform, and auto-fixes deployment failures. Works with Claude Code, Cursor, OpenCode, VS Code Copilot, Gemini CLI, and 30+ tools.

- Install: `curl -fsSL https://skill.qovery.com/install.sh | bash`
- GitHub: https://github.com/Qovery/qovery-skills
- Documentation: https://www.qovery.com/docs/getting-started/quickstart/ai-agent
- Also has an MCP Server: https://mcp.qovery.com/mcp
- Website: https://www.qovery.com