### PR TITLE
fix: correct agent name mismatch in enterprise-integrator-architect

### DIFF
--- a/plugins/enterprise-integrator-architect/agents/enterprise-integrator-architect.md
+++ b/plugins/enterprise-integrator-architect/agents/enterprise-integrator-architect.md
@@ -1,5 +1,5 @@
 ---
-name: enterprise-integration-architect
+name: enterprise-integrator-architect
 description: Use this agent when you need to design and implement complex external enterprise system integrations for B2B applications. This agent specializes in connecting your platform with Salesforce, HubSpot, Microsoft 365, Google Workspace, SAP, Oracle ERP, and other critical third-party business software. Handles external API orchestration, data synchronization with enterprise systems, webhook management for third-party services, and enterprise-grade integration patterns. Examples:
 
 <example>


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugins/enterprise-integrator-architect/agents/enterprise-integrator-architect.md` has frontmatter `name: enterprise-integration-architect` — note **"integration"** instead of **"integrator"**. This mismatches the plugin directory name `enterprise-integrator-architect`.

## Impact

Claude Code registers agents by their `name` frontmatter field. When the name doesn't match the plugin's identity, agent routing via `use enterprise-integrator-architect` will dispatch the wrong name in logs and any downstream sub-agent delegation that references the plugin by directory name will fail to find the agent.

## Fix

Single character change: `enterprise-integration-architect` → `enterprise-integrator-architect` (adds "or" to restore the "integrator" spelling).