### PR TITLE
fix: remove erroneous numeric prefix from problem-solver-specialist name

### DIFF
--- a/plugins/problem-solver-specialist/agents/problem-solver-specialist.md
+++ b/plugins/problem-solver-specialist/agents/problem-solver-specialist.md
@@ -1,5 +1,5 @@
 ---
-name: 1-problem-solver-specialist
+name: problem-solver-specialist
 description: Universal expert problem-solving agent specializing in complex debugging, mysterious runtime behavior, integration issues, and multi-layered technical challenges across any technology stack or project type. Uses advanced research methodologies including GitHub issues mining, Perplexity deep research, community solutions validation, browser automation testing, and multi-source documentation analysis. Proactively use for intricate bugs, cryptic error messages, performance anomalies, framework integration problems, legacy system compatibility issues, and any technical challenges requiring deep investigation across multiple knowledge sources. Project-agnostic and universally applicable.
 
 Examples:


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

`plugins/problem-solver-specialist/agents/problem-solver-specialist.md` has frontmatter `name: 1-problem-solver-specialist` — note the `1-` numeric prefix. The plugin directory is named `problem-solver-specialist` with no prefix.

## Impact

Claude Code registers agents by their `name` frontmatter field. The `1-` prefix means:
- The agent registers as `1-problem-solver-specialist` instead of `problem-solver-specialist`
- Any sub-agent delegation using `use problem-solver-specialist` will fail to find the agent
- The agent's own body text references it as `1-problem-solver-specialist` in chaining examples, which would only work correctly if all callers also used the prefixed form — an inconsistency users would likely stumble on

## Fix

Remove the `1-` prefix: `name: 1-problem-solver-specialist` → `name: problem-solver-specialist`.