### PR TITLE
fix: add missing tools declarations to agent-sdk-verifier agents

### DIFF
--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-py.md
@@ -2,6 +2,7 @@
 name: agent-sdk-verifier-py
 description: Use this agent to verify that a Python Agent SDK application is properly configured, follows SDK best practices and documentation recommendations, and is ready for deployment or testing. This agent should be invoked after a Python Agent SDK app has been created or modified.
 model: sonnet
+tools: Bash, Read, WebFetch
 ---
 
 You are a Python Agent SDK application verifier. Your role is to thoroughly inspect Python Agent SDK applications for correct SDK usage, adherence to official documentation recommendations, and readiness for deployment.

--- a/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
+++ b/plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md
@@ -2,6 +2,7 @@
 name: agent-sdk-verifier-ts
 description: Use this agent to verify that a TypeScript Agent SDK application is properly configured, follows SDK best practices and documentation recommendations, and is ready for deployment or testing. This agent should be invoked after a TypeScript Agent SDK app has been created or modified.
 model: sonnet
+tools: Bash, Read, WebFetch
 ---
 
 You are a TypeScript Agent SDK application verifier. Your role is to thoroughly inspect TypeScript Agent SDK applications for correct SDK usage, adherence to official documentation recommendations, and readiness for deployment.


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Bug

Both `plugins/agent-sdk-dev/agents/agent-sdk-verifier-ts.md` and `agent-sdk-verifier-py.md` have **no `tools:` declaration** in their frontmatter, but their bodies explicitly require tools:

- `agent-sdk-verifier-ts.md` step 3 instructs: _"Run `npx tsc --noEmit` to check for type errors"_ → requires **Bash**. Step 2 instructs: _"Use WebFetch to reference the official TypeScript SDK docs"_ → requires **WebFetch**. Reading project files requires **Read**.
- `agent-sdk-verifier-py.md` steps instruct reading `requirements.txt`, `pyproject.toml`, etc. → requires **Read**. Checking SDK docs → requires **WebFetch**. Running `pip`/`python` validation commands → requires **Bash**.

## Impact

Without a `tools:` declaration, Claude Code does not grant the agent access to any tools. The verification steps that call Bash or WebFetch silently produce no output or an error, making the agent appear to complete but actually skip its most critical checks (type-checking, dependency validation, SDK doc comparison).

## Fix

Add `tools: Bash, Read, WebFetch` to the frontmatter of both verifier agents — the minimal set required by their documented verification procedures.