### PR TITLE
Add onboard, forge, notify plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)
 - [monitoring-observability-specialist](./plugins/monitoring-observability-specialist)
 - [n8n-workflow-builder](./plugins/n8n-workflow-builder)
+- [notify](https://github.com/ApurvBazari/claude-plugins)
 
 ### Business Sales
 - [b2b-project-shipper](./plugins/b2b-project-shipper)
@@ -132,6 +133,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
+- [forge](https://github.com/ApurvBazari/claude-plugins)
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)
@@ -142,6 +144,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [generate-api-docs](./plugins/generate-api-docs)
 - [openapi-expert](./plugins/openapi-expert)
 - [update-claudemd](./plugins/update-claudemd)
+- [onboard](https://github.com/ApurvBazari/claude-plugins)
 
 ### Git Workflow
 - [analyze-issue](./plugins/analyze-issue)


### PR DESCRIPTION
## What

Adds three plugins to the curated list:

- **[onboard](https://github.com/ApurvBazari/claude-plugins)** — Analyzes existing codebases and generates tailored Claude tooling: CLAUDE.md, path-scoped rules, skills, agents, hooks, and CI/CD. Added to **Documentation** alongside analyze-codebase and update-claudemd.
- **[forge](https://github.com/ApurvBazari/claude-plugins)** — Greenfield project scaffolder. 4-phase wizard, stack-agnostic via web search, walking-skeleton mode, session resume. Added to **Development Engineering** alongside rapid-prototyper.
- **[notify](https://github.com/ApurvBazari/claude-plugins)** — Cross-platform system notifications for Claude Code hooks. macOS (terminal-notifier) and Linux (notify-send). Added to **Automation DevOps**.

## Why

- **onboard** produces actual Claude artifacts from codebase analysis (most existing tools only recommend).
- **forge** is an end-to-end greenfield scaffolder that fills a gap in the ecosystem.
- **notify** is a simple, reliable cross-platform notification helper for hooks.

All three are v1.0+, MIT licensed, documented, and live at https://github.com/ApurvBazari/claude-plugins

## Format

Submitted as **external-link entries** (`- [name](url)`), matching the pattern used by PR #145 (AgentLint). Happy to vendor the plugins under `./plugins/` instead if that's preferred — let me know.

## Checklist

- [x] Entries match existing terse README format
- [x] One entry per plugin, placed in most appropriate category
- [x] MIT licensed
- [x] Tested on macOS and Linux