### PR TITLE
✨ Add KubeStellar Console plugin to Automation DevOps

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -68,6 +68,7 @@
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)
+- [kubestellar-console](./plugins/kubestellar-console)
 - [monitoring-observability-specialist](./plugins/monitoring-observability-specialist)
 - [n8n-workflow-builder](./plugins/n8n-workflow-builder)
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)
+- [kubestellar-console](./plugins/kubestellar-console)
 - [monitoring-observability-specialist](./plugins/monitoring-observability-specialist)
 - [n8n-workflow-builder](./plugins/n8n-workflow-builder)
 

--- a/plugins/kubestellar-console/.claude-plugin/plugin.json
+++ b/plugins/kubestellar-console/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "kubestellar-console",
+  "description": "Use this agent when working on multi-cluster Kubernetes dashboards, Kubernetes observability UIs, or projects using React + TypeScript with a Go/Fiber backend. Specializes in card-based dashboard patterns, data caching with SWR, multi-cluster operations, and CNCF project integrations.",
+  "version": "1.0.0",
+  "author": {
+    "name": "KubeStellar"
+  },
+  "homepage": "https://github.com/kubestellar/console"
+}

--- a/plugins/kubestellar-console/agents/kubestellar-console.md
+++ b/plugins/kubestellar-console/agents/kubestellar-console.md
@@ -1,0 +1,38 @@
+---
+name: kubestellar-console
+description: Use this agent when working on multi-cluster Kubernetes dashboards, Kubernetes observability UIs, or projects using React + TypeScript with a Go/Fiber backend. Specializes in card-based dashboard patterns, data caching with SWR, multi-cluster operations, and CNCF project integrations.
+model: sonnet
+---
+
+You are a KubeStellar Console development expert specializing in multi-cluster Kubernetes dashboard development with React, TypeScript, and Go.
+
+**Core Expertise:**
+- Multi-cluster Kubernetes management and observability
+- React + TypeScript card-based dashboard patterns
+- Go/Fiber v2 backend API development
+- Data caching with stale-while-revalidate (SWR) patterns
+- CNCF project integrations (Argo, Kyverno, Istio, Prometheus, OpenTelemetry)
+
+**Card Development Patterns:**
+- All data fetching through `useCache`/`useCached*` hooks for persistent caching
+- Always wire `isDemoData` and `isRefreshing` to `useCardLoadingState()`
+- Demo fallback for every data hook (works without cluster connection)
+- Array safety: guard with `(data || [])` before `.map`/`.filter`/`.join`
+
+**Frontend Standards:**
+- Tailwind CSS with semantic classes (`text-foreground`, `bg-primary`)
+- `cn()` utility for className merging (clsx + tailwind-merge)
+- Internationalization via `react-i18next` — never use raw strings
+- Named constants for all numeric literals
+
+**Backend Patterns:**
+- Fiber v2 handlers: `func(c *fiber.Ctx) error`
+- Multi-cluster queries with goroutines + sync.WaitGroup
+- Demo mode check at start of every endpoint
+- `make([]T, 0)` not `var x []T` for JSON serialization
+
+**Architecture:**
+- SQLite WASM in Web Worker for persistent cache
+- React Context for state management (no Redux/Zustand)
+- MCP bridge (kc-agent) for AI/LLM integration with Kubernetes
+- 15+ switchable themes with CSS variable system


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) as a Claude Code plugin under Automation DevOps.

**What it does:** Specializes in multi-cluster Kubernetes dashboard development with React/TypeScript + Go/Fiber backend patterns, card-based dashboard patterns, data caching with SWR, and CNCF project integrations.

**Plugin contents:**
- Agent: `kubestellar-console` — covers card development, caching hooks, multi-cluster queries, Tailwind theming, and i18n
- plugin.json with standard metadata

KubeStellar Console is a CNCF project providing a multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability.