### PR TITLE
Add weft to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [security-guidance](./plugins/security-guidance)
 
 ### Workflow Orchestration
+- [weft](./plugins/weft)
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)

--- a/plugins/weft/.claude-plugin/marketplace.json
+++ b/plugins/weft/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "dioptx-weft",
+  "owner": {
+    "name": "dioptx"
+  },
+  "plugins": [
+    {
+      "name": "weft",
+      "source": "./",
+      "description": "Deterministic workflow tracking with event-sourced logs for Claude Code"
+    }
+  ]
+}

--- a/plugins/weft/.claude-plugin/plugin.json
+++ b/plugins/weft/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "weft",
+  "version": "0.3.0",
+  "description": "Deterministic workflow tracking with event-sourced logs for Claude Code"
+}

--- a/plugins/weft/LICENSE
+++ b/plugins/weft/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 dioptx
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/weft/README.md
+++ b/plugins/weft/README.md
@@ -1,0 +1,23 @@
+# weft
+
+**Deterministic workflow tracking for Claude Code — event-sourced state machine, smart skills, template management.**
+
+→ [dioptx/weft](https://github.com/dioptx/weft) (MIT, Python stdlib only, 191 tests)
+
+## Install
+
+```
+/plugin marketplace add dioptx/weft
+/plugin install weft@dioptx-weft
+```
+
+## What it gives you
+
+- 11 slash commands (`/wf-start`, `/wf-step`, `/wf-status`, `/wf-rebuild`, `/wf-compose`, `/wf-dashboard`, etc.)
+- 4 hooks (`SessionStart`, `PreToolUse`, `PreCompact`, `Stop`)
+- 2 bundled templates (`generic`, `feature-workflow`) + custom-template authoring via heredoc
+- Event-sourced state under `.claude/weft/events.jsonl` — fully reconstructible after compaction or restart
+
+## Demos
+
+See [the upstream README](https://github.com/dioptx/weft#readme) for 5 reproducible asciinema GIFs covering pitch, walkthrough, compose, extend, and audit.

--- a/plugins/weft/core/__init__.py
+++ b/plugins/weft/core/__init__.py
@@ -1,0 +1,24 @@
+"""Weft — deterministic workflow tracking for Claude Code."""
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def weft_dir(project_dir: str | None = None) -> Path:
+    """Return the weft data directory for the given project."""
+    base = project_dir or os.environ.get("CLAUDE_PROJECT_DIR", ".")
+    return Path(base) / ".claude" / "weft"
+
+
+def now_iso() -> str:
+    """ISO 8601 UTC timestamp with millisecond precision."""
+    now = datetime.now(timezone.utc)
+    return now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+
+
+def now_dt_and_iso() -> tuple[datetime, str]:
+    """Return both the datetime and ISO string from a single now() call."""
+    now = datetime.now(timezone.utc)
+    iso = now.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now.microsecond // 1000:03d}Z"
+    return now, iso

--- a/plugins/weft/core/cli.py
+++ b/plugins/weft/core/cli.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python3
+"""Unified CLI entry point for weft.
+
+Usage:
+    python3 cli.py start <template> [--steps step1,step2,...]
+    python3 cli.py step <complete|fail|skip|retry> [reason]
+    python3 cli.py status [--json]
+    python3 cli.py abort [reason]
+    python3 cli.py rebuild [workflow_id]
+    python3 cli.py query [--type TYPE] [--tool TOOL] [--last N] [--workflow ID]
+    python3 cli.py guard          # reads hook JSON from stdin
+    python3 cli.py gate           # reads hook JSON from stdin (stop hook)
+    python3 cli.py context        # outputs context.md to stdout
+"""
+
+import json
+import os
+import sys
+
+# Ensure the core package is importable
+sys.path.insert(0, str(__import__("pathlib").Path(__file__).parent.parent))
+
+from core import event_store, state_machine, projections, templates
+
+
+def _session_id() -> str:
+    return os.environ.get("CLAUDE_SESSION_ID", "unknown")
+
+
+def _project_dir() -> str | None:
+    return os.environ.get("CLAUDE_PROJECT_DIR") or None
+
+
+def cmd_start(args: list[str]) -> None:
+    """Start a new workflow."""
+    if not args:
+        available = templates.list_templates(_project_dir())
+        print("Available templates:")
+        for t in available:
+            print(f"  {t['name']} — {t['description']} ({t['steps']} steps)")
+        return
+
+    name = args[0]
+
+    # Check if it's comma-separated step names
+    if "," in name:
+        step_names = [s.strip() for s in name.split(",")]
+        tmpl = templates.template_from_steps(step_names)
+    else:
+        tmpl = templates.load_template(name, _project_dir())
+        if not tmpl:
+            print(f"Template not found: {name}", file=sys.stderr)
+            print("Available:", file=sys.stderr)
+            for t in templates.list_templates(_project_dir()):
+                print(f"  {t['name']}", file=sys.stderr)
+            sys.exit(1)
+
+    state = state_machine.start_workflow(tmpl, _session_id(), _project_dir())
+    projections.write_context_md(state, _project_dir())
+
+    print(f"Workflow started: {state['workflow_id']}")
+    print(f"Steps: {len(state['steps'])}")
+    print(f"Current: {state['steps'][0]['name']}")
+    print()
+    print(projections.generate_context_md(state, _project_dir()))
+
+
+def cmd_step(args: list[str]) -> None:
+    """Transition the current step."""
+    if not args:
+        print("Usage: step <complete|fail|skip|retry> [reason]", file=sys.stderr)
+        sys.exit(1)
+
+    action = args[0]
+    reason = " ".join(args[1:]) if len(args) > 1 else ""
+    sid = _session_id()
+    pdir = _project_dir()
+
+    state = state_machine.load_state(pdir)
+    if not state:
+        print("No active workflow", file=sys.stderr)
+        sys.exit(1)
+
+    if state["status"] not in ("running", "failed"):
+        print(f"Workflow is {state['status']}, cannot transition steps", file=sys.stderr)
+        sys.exit(1)
+
+    actions = {
+        "complete": state_machine.step_complete,
+        "fail": state_machine.step_fail,
+        "skip": state_machine.step_skip,
+        "retry": state_machine.step_retry,
+        "loop-continue": state_machine.step_loop_back,
+        "loop-done": state_machine.step_loop_done,
+    }
+
+    fn = actions.get(action)
+    if not fn:
+        print(f"Unknown action: {action}. Use: complete|fail|skip|retry|loop-continue|loop-done", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        state = fn(state, reason, sid, pdir)
+    except ValueError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+    projections.write_context_md(state, pdir)
+    print(projections.generate_context_md(state, pdir))
+
+
+def cmd_status(args: list[str]) -> None:
+    """Show current workflow status."""
+    pdir = _project_dir()
+    state = state_machine.load_state(pdir)
+
+    if not state:
+        print("No active workflow.")
+        return
+
+    if "--json" in args:
+        print(json.dumps(state, indent=2))
+    else:
+        print(projections.format_status(state, pdir))
+
+
+def cmd_abort(args: list[str]) -> None:
+    """Abort the current workflow."""
+    reason = " ".join(args) if args else "user aborted"
+    pdir = _project_dir()
+    state = state_machine.load_state(pdir)
+
+    if not state:
+        print("No active workflow.", file=sys.stderr)
+        sys.exit(1)
+
+    state = state_machine.abort_workflow(state, reason, _session_id(), pdir)
+    projections.write_context_md(state, pdir)
+    print(f"Workflow '{state['name']}' aborted: {reason}")
+
+
+def cmd_rebuild(args: list[str]) -> None:
+    """Rebuild state.json from the event log."""
+    workflow_id = args[0] if args else None
+    pdir = _project_dir()
+
+    state = state_machine.rebuild_from_events(pdir, workflow_id)
+    if state:
+        projections.write_context_md(state, pdir)
+        print(f"Rebuilt state for: {state['workflow_id']}")
+        print(projections.generate_context_md(state, pdir))
+    else:
+        print("No workflow events found to rebuild from.", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_query(args: list[str]) -> None:
+    """Query the event log."""
+    kwargs = {}
+    i = 0
+    while i < len(args):
+        if args[i] == "--type" and i + 1 < len(args):
+            kwargs["event_type"] = args[i + 1]
+            i += 2
+        elif args[i] == "--tool" and i + 1 < len(args):
+            kwargs["tool"] = args[i + 1]
+            i += 2
+        elif args[i] == "--last" and i + 1 < len(args):
+            try:
+                kwargs["last_n"] = int(args[i + 1])
+            except ValueError:
+                print(f"--last requires integer, got: {args[i + 1]}", file=sys.stderr)
+                sys.exit(1)
+            i += 2
+        elif args[i] == "--workflow" and i + 1 < len(args):
+            kwargs["workflow_id"] = args[i + 1]
+            i += 2
+        elif args[i] == "--session" and i + 1 < len(args):
+            kwargs["session_id"] = args[i + 1]
+            i += 2
+        else:
+            # Treat bare arg as event_type filter
+            kwargs["event_type"] = args[i]
+            i += 1
+
+    events = event_store.query(_project_dir(), **kwargs)
+
+    if not events:
+        # No filter results, show summary
+        all_events = event_store.read_all(_project_dir())
+        if not all_events:
+            print("No events recorded yet.")
+            return
+        counts: dict[str, int] = {}
+        for e in all_events:
+            et = e.get("event_type", "unknown")
+            counts[et] = counts.get(et, 0) + 1
+        print(f"Total events: {len(all_events)}")
+        for et, c in sorted(counts.items()):
+            print(f"  {et}: {c}")
+        return
+
+    for ev in events:
+        ts = ev.get("ts", "?")[:19]
+        et = ev.get("event_type", "?")
+        data = ev.get("data", {})
+        parts = [f"{ts} {et}"]
+        if data.get("tool"):
+            parts.append(f"tool={data['tool']}")
+        if data.get("step_name"):
+            parts.append(f"step={data['step_name']}")
+        if data.get("to_status"):
+            parts.append(f"→ {data['to_status']}")
+        if data.get("reason"):
+            parts.append(f"({data['reason'][:80]})")
+        print("  ".join(parts))
+
+
+def cmd_guard(_args: list[str]) -> None:
+    """Guard check for PreToolUse hook. Reads stdin."""
+    from core import guard_engine
+    guard_engine.main()
+
+
+def cmd_gate(_args: list[str]) -> None:
+    """Completion gate for Stop hook. Reads stdin."""
+    raw = sys.stdin.read()
+    try:
+        hook_input = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    # If this is a stop_hook re-entry, allow
+    if hook_input.get("stop_hook_active"):
+        sys.exit(0)
+
+    pdir = _project_dir()
+    state = state_machine.load_state(pdir)
+
+    if not state:
+        sys.exit(0)
+
+    status = state.get("status", "idle")
+    if status in ("idle", "complete", "aborted"):
+        sys.exit(0)
+
+    # Session isolation — only block the session that owns the workflow.
+    # "unknown" means no session tracking; treat as wildcard (block all sessions).
+    state_session = state.get("session_id", "")
+    hook_session = hook_input.get("session_id", "")
+    if (state_session and state_session != "unknown"
+            and hook_session and hook_session != "unknown"
+            and state_session != hook_session):
+        sys.exit(0)
+
+    incomplete = [
+        s["name"] for s in state["steps"]
+        if s["status"] not in ("complete", "skipped")
+    ]
+
+    if incomplete:
+        print(
+            f"Workflow '{state['name']}' has incomplete steps: {', '.join(incomplete)}. "
+            f"Use /weft:wf-step to advance or /weft:wf-abort to cancel.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+def cmd_context(_args: list[str]) -> None:
+    """Output context.md to stdout for hook injection."""
+    pdir = _project_dir()
+    state = state_machine.load_state(pdir)
+
+    if not state or state.get("status") in ("idle",):
+        sys.exit(0)
+
+    print(projections.generate_context_md(state, pdir))
+
+
+def cmd_preview(args: list[str]) -> None:
+    """Show detailed template preview."""
+    if not args:
+        print("Usage: preview <template-name>", file=sys.stderr)
+        print("Use 'start' with no args to list templates.", file=sys.stderr)
+        sys.exit(1)
+
+    detail = templates.template_detail(args[0], _project_dir())
+    if not detail:
+        print(f"Template not found: {args[0]}", file=sys.stderr)
+        sys.exit(1)
+
+    print(detail)
+
+
+def cmd_save_template(_args: list[str]) -> None:
+    """Save a template from JSON on stdin."""
+    raw = sys.stdin.read()
+    try:
+        tmpl = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"Invalid JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if "name" not in tmpl or "steps" not in tmpl:
+        print("Template must have 'name' and 'steps' fields", file=sys.stderr)
+        sys.exit(1)
+
+    path = templates.save_template(tmpl, _project_dir())
+    print(f"Template saved: {path}")
+
+
+def cmd_dashboard(_args: list[str]) -> None:
+    """Launch the interactive TUI dashboard."""
+    from core.dashboard import WeftDashboard
+    app = WeftDashboard(project_dir=_project_dir())
+    app.run()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: cli.py <command> [args...]", file=sys.stderr)
+        print("Commands: start, step, status, abort, rebuild, query, preview, save-template, dashboard, guard, gate, context",
+              file=sys.stderr)
+        sys.exit(1)
+
+    commands = {
+        "start": cmd_start,
+        "step": cmd_step,
+        "status": cmd_status,
+        "abort": cmd_abort,
+        "rebuild": cmd_rebuild,
+        "query": cmd_query,
+        "preview": cmd_preview,
+        "save-template": cmd_save_template,
+        "dashboard": cmd_dashboard,
+        "guard": cmd_guard,
+        "gate": cmd_gate,
+        "context": cmd_context,
+    }
+
+    cmd = sys.argv[1]
+    fn = commands.get(cmd)
+    if not fn:
+        print(f"Unknown command: {cmd}", file=sys.stderr)
+        sys.exit(1)
+
+    fn(sys.argv[2:])
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/weft/core/dashboard.py
+++ b/plugins/weft/core/dashboard.py
@@ -1,0 +1,352 @@
+#!/usr/bin/env python3
+"""Weft TUI Dashboard — visual overview of plugin building blocks."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.widgets import Footer, Header, Static
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from core import state_machine, event_store, templates, weft_dir
+
+
+PLUGIN_ROOT = Path(__file__).parent.parent
+
+
+def _load_hooks_json() -> dict:
+    path = PLUGIN_ROOT / "hooks" / "hooks.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return {}
+
+
+def _load_skills() -> list[dict]:
+    skills_dir = PLUGIN_ROOT / "skills"
+    results = []
+    if not skills_dir.exists():
+        return results
+    for skill_dir in sorted(skills_dir.iterdir()):
+        md = skill_dir / "SKILL.md"
+        if not md.exists():
+            continue
+        text = md.read_text()
+        info = {"id": skill_dir.name, "name": skill_dir.name, "description": "", "hint": ""}
+        for line in text.split("\n"):
+            if line.startswith("name:"):
+                info["name"] = line.split(":", 1)[1].strip().strip('"')
+            elif line.startswith("description:"):
+                info["description"] = line.split(":", 1)[1].strip().strip('"')
+            elif line.startswith("argument-hint:"):
+                info["hint"] = line.split(":", 1)[1].strip().strip('"')
+        results.append(info)
+    return results
+
+
+def _load_template_detail(name: str) -> dict | None:
+    path = PLUGIN_ROOT / "templates" / f"{name}.json"
+    if path.exists():
+        return json.loads(path.read_text())
+    return None
+
+
+# ── Panel builders ─────────────────────────────────────────────────
+
+
+def _build_workflow_panel(state: dict | None) -> Panel:
+    if not state:
+        content = Text("No active workflow\n\nStart one with /wf-start <template>", style="dim")
+        return Panel(content, title="[bold green] Workflow [/]", border_style="green")
+
+    status_colors = {
+        "running": "bold green",
+        "complete": "bold blue",
+        "failed": "bold red",
+        "aborted": "bold yellow",
+    }
+    status_style = status_colors.get(state["status"], "bold white")
+
+    lines = Text()
+    lines.append(f"  {state['name']}", style="bold white")
+    lines.append(f"  [{state['status'].upper()}]", style=status_style)
+    lines.append(f"\n  ID: {state['workflow_id']}", style="dim")
+    lines.append(f"  |  Session: {state.get('session_id', '?')}\n\n", style="dim")
+
+    step_icons = {
+        "complete": ("  [bold green]✓[/] ", "green"),
+        "running":  ("  [bold cyan]►[/] ", "bold cyan"),
+        "failed":   ("  [bold red]✗[/] ", "red"),
+        "skipped":  ("  [dim]–[/] ", "dim"),
+        "pending":  ("  [dim]○[/] ", "dim"),
+    }
+
+    for i, step in enumerate(state["steps"]):
+        markup_icon, style = step_icons.get(step["status"], ("  ? ", "white"))
+        is_current = i == state.get("current_step") and state["status"] == "running"
+        pointer = "[bold cyan]→[/]" if is_current else " "
+
+        lines.append(f" {pointer}", style="")
+
+        name_style = "bold cyan" if is_current else style
+        lines.append(f" {step['name']}", style=name_style)
+
+        status_tag = step["status"]
+        if step.get("guards") and step["status"] == "running":
+            status_tag += " | guarded"
+        lines.append(f"  ({status_tag})", style="dim")
+
+        if step.get("on_fail") not in ("block", None):
+            lines.append(f"  on_fail={step['on_fail']}", style="dim yellow")
+
+        lines.append("\n")
+
+    # Active guards inline
+    if state["status"] == "running":
+        current = state["current_step"]
+        if current < len(state["steps"]):
+            guards = state["steps"][current].get("guards", [])
+            if guards:
+                lines.append("\n  [bold red]Active Guards:[/]\n", style="")
+                for g in guards:
+                    if isinstance(g, dict):
+                        pat = g.get("command_pattern", g.get("pattern", "?"))
+                        msg = g.get("message", "blocked")
+                        lines.append(f"    [red]/{pat}/[/]  {msg}\n", style="")
+                    else:
+                        lines.append(f"    [red]{g}[/]\n", style="")
+
+    return Panel(lines, title="[bold green] Workflow [/]", border_style="green")
+
+
+def _build_skills_panel(skills: list[dict]) -> Panel:
+    lines = Text()
+    for s in skills:
+        cmd = f"/weft:{s['name']}"
+        desc = s["description"].split(". Use only")[0]
+        hint = s.get("hint", "")
+
+        lines.append(f"  {cmd:<20}", style="bold green")
+        lines.append(f"{desc}\n", style="")
+        if hint:
+            lines.append(f"  {'':20}", style="")
+            lines.append(f"{hint}\n", style="dim")
+
+    return Panel(lines, title="[bold cyan] Skills [/]", border_style="cyan")
+
+
+def _build_templates_panel(tmpls: list[dict], project_dir: str | None) -> Panel:
+    lines = Text()
+
+    for t in tmpls:
+        lines.append(f"\n  {t['name']}", style="bold green")
+        lines.append(f"  ({t['steps']} steps)\n", style="dim")
+        lines.append(f"  {t['description']}\n", style="")
+
+        detail = _load_template_detail(t["name"])
+        if detail and "steps" in detail:
+            for j, s in enumerate(detail["steps"]):
+                prefix = "├─" if j < len(detail["steps"]) - 1 else "└─"
+                lines.append(f"    {prefix} ", style="dim")
+                lines.append(f"{s['name']}", style="white")
+                policy = s.get("on_fail", "block")
+                if policy != "block":
+                    lines.append(f" [on_fail={policy}]", style="dim yellow")
+                if s.get("guards"):
+                    lines.append(" guarded", style="dim red")
+                if s.get("optional"):
+                    lines.append(" optional", style="dim")
+                lines.append("\n")
+
+    lines.append(f"\n  [dim]ad-hoc[/]", style="")
+    lines.append(f"  [dim](N steps)[/]\n", style="")
+    lines.append(f"  [dim]Pass comma-separated names: /wf-start plan,build,test[/]\n", style="")
+
+    return Panel(lines, title="[bold yellow] Templates [/]", border_style="yellow")
+
+
+def _build_hooks_panel(hooks_json: dict) -> Panel:
+    hook_info = {
+        "SessionStart": ("Context Inject", "Reinjects workflow state on new session"),
+        "PreToolUse":   ("Guard Engine",   "Blocks commands outside current step scope"),
+        "PreCompact":   ("Context Inject", "Reinjects workflow state after compaction"),
+        "Stop":         ("Completion Gate", "Blocks exit with incomplete steps"),
+    }
+
+    lines = Text()
+    for hook_type in hooks_json.get("hooks", {}):
+        label, desc = hook_info.get(hook_type, ("?", "?"))
+        entries = hooks_json["hooks"][hook_type]
+        matcher = "all tools"
+        for entry in entries:
+            if "matcher" in entry:
+                matcher = entry["matcher"]
+
+        lines.append(f"\n  {hook_type}", style="bold magenta")
+        lines.append(f"  [{label}]\n", style="dim")
+        lines.append(f"  {desc}\n", style="")
+        lines.append(f"  Matcher: {matcher}\n", style="dim")
+
+    return Panel(lines, title="[bold magenta] Hooks [/]", border_style="magenta")
+
+
+def _build_events_panel(project_dir: str | None) -> Panel:
+    events = event_store.query(project_dir, last_n=12)
+    if not events:
+        content = Text("  No events recorded yet.", style="dim")
+        return Panel(content, title="[bold blue] Events [/]", border_style="blue")
+
+    type_styles = {
+        "wf.started": "green",
+        "wf.completed": "bold blue",
+        "wf.aborted": "yellow",
+        "wf.step_changed": "cyan",
+    }
+
+    lines = Text()
+    for ev in events:
+        ts = ev.get("ts", "?")[11:19]
+        et = ev.get("event_type", "?")
+        data = ev.get("data", {})
+        style = type_styles.get(et, "white")
+
+        lines.append(f"  {ts} ", style="dim")
+        lines.append(f"{et:<20}", style=style)
+
+        details = []
+        if data.get("step_name"):
+            details.append(data["step_name"])
+        if data.get("to_status"):
+            details.append(f"-> {data['to_status']}")
+        if data.get("reason"):
+            details.append(data["reason"][:35])
+        lines.append(" ".join(details), style="dim")
+        lines.append("\n")
+
+    return Panel(lines, title="[bold blue] Events [/]", border_style="blue")
+
+
+def _build_architecture_panel() -> Panel:
+    lines = Text()
+
+    lines.append("\n  Data Flow\n", style="bold underline")
+    lines.append("  Template ", style="dim")
+    lines.append("->", style="white")
+    lines.append(" start_workflow() ", style="green")
+    lines.append("->", style="white")
+    lines.append(" state.json + events.jsonl\n", style="dim")
+    lines.append("  Hooks read state ", style="dim")
+    lines.append("->", style="white")
+    lines.append(" guard/gate/context ", style="yellow")
+    lines.append("->", style="white")
+    lines.append(" allow/block\n", style="dim")
+    lines.append("  Events = source of truth ", style="dim")
+    lines.append("->", style="white")
+    lines.append(" rebuild_from_events()", style="cyan")
+    lines.append(" recovers state\n", style="dim")
+
+    lines.append("\n  Step Lifecycle\n", style="bold underline")
+    lines.append("  pending", style="dim")
+    lines.append(" -> ", style="white")
+    lines.append("running", style="cyan")
+    lines.append(" -> ", style="white")
+    lines.append("complete", style="green")
+    lines.append(" | ", style="dim")
+    lines.append("failed", style="red")
+    lines.append(" | ", style="dim")
+    lines.append("skipped\n", style="yellow")
+
+    lines.append("\n  on_fail Policies\n", style="bold underline")
+    lines.append("    retry    ", style="cyan")
+    lines.append("auto-retry once, then block\n", style="dim")
+    lines.append("    block    ", style="red")
+    lines.append("halt workflow until manual retry\n", style="dim")
+    lines.append("    continue ", style="yellow")
+    lines.append("mark failed, advance to next step\n", style="dim")
+
+    lines.append("\n  Files\n", style="bold underline")
+    lines.append("  .claude/weft/state.json   ", style="white")
+    lines.append(" derived workflow state\n", style="dim")
+    lines.append("  .claude/weft/events.jsonl ", style="white")
+    lines.append(" append-only event log (truth)\n", style="dim")
+    lines.append("  .claude/weft/context.md   ", style="white")
+    lines.append(" injected into Claude context\n", style="dim")
+
+    return Panel(lines, title="[bold white] Architecture [/]", border_style="white")
+
+
+# ── TUI App ────────────────────────────────────────────────────────
+
+
+class WeftDashboard(App):
+    CSS = """
+    Screen {
+        layout: grid;
+        grid-size: 2 3;
+        grid-columns: 1fr 1fr;
+        grid-rows: auto auto auto;
+        grid-gutter: 1;
+        padding: 1;
+        overflow-y: auto;
+    }
+    .panel { height: auto; }
+    """
+
+    TITLE = "Weft — Workflow Engine for Tracked Flows"
+    BINDINGS = [
+        Binding("q", "quit", "Quit"),
+        Binding("r", "refresh", "Refresh"),
+        Binding("escape", "quit", "Quit"),
+    ]
+
+    def __init__(self, project_dir: str | None = None):
+        super().__init__()
+        self.project_dir = project_dir
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield Static(id="left-top", classes="panel")
+        yield Static(id="right-top", classes="panel")
+        yield Static(id="left-mid", classes="panel")
+        yield Static(id="right-mid", classes="panel")
+        yield Static(id="left-bot", classes="panel")
+        yield Static(id="right-bot", classes="panel")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self._render_panels()
+        self.set_interval(2, self._render_panels)
+
+    def action_refresh(self) -> None:
+        self._render_panels()
+
+    def _render_panels(self) -> None:
+        pdir = self.project_dir
+        state = state_machine.load_state(pdir)
+        skills = _load_skills()
+        tmpls = templates.list_templates(pdir)
+        hooks_json = _load_hooks_json()
+
+        self.query_one("#left-top", Static).update(_build_workflow_panel(state))
+        self.query_one("#right-top", Static).update(_build_skills_panel(skills))
+        self.query_one("#left-mid", Static).update(_build_templates_panel(tmpls, pdir))
+        self.query_one("#right-mid", Static).update(_build_hooks_panel(hooks_json))
+        self.query_one("#left-bot", Static).update(_build_events_panel(pdir))
+        self.query_one("#right-bot", Static).update(_build_architecture_panel())
+
+
+def main():
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or None
+    app = WeftDashboard(project_dir=project_dir)
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/weft/core/dashboard_launcher.sh
+++ b/plugins/weft/core/dashboard_launcher.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Launch the weft TUI dashboard in a new terminal tab.
+# Usage: bash dashboard_launcher.sh [project_dir]
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROJECT_DIR="${1:-${CLAUDE_PROJECT_DIR:-.}}"
+
+export PYTHONPATH="$PLUGIN_ROOT"
+export CLAUDE_PROJECT_DIR="$PROJECT_DIR"
+
+# Detect terminal and open a new tab
+FRONT_APP=$(osascript -e 'tell application "System Events" to get name of first application process whose frontmost is true' 2>/dev/null || echo "unknown")
+
+case "$FRONT_APP" in
+  iTerm2)
+    osascript <<APPLE
+tell application "iTerm"
+  tell current window
+    create tab with default profile
+    tell current session
+      write text "PYTHONPATH='$PLUGIN_ROOT' CLAUDE_PROJECT_DIR='$PROJECT_DIR' python3 '$PLUGIN_ROOT/core/dashboard.py'; exit"
+    end tell
+  end tell
+end tell
+APPLE
+    ;;
+  *)
+    osascript <<APPLE
+tell application "Terminal"
+  do script "PYTHONPATH='$PLUGIN_ROOT' CLAUDE_PROJECT_DIR='$PROJECT_DIR' python3 '$PLUGIN_ROOT/core/dashboard.py'; exit"
+  activate
+end tell
+APPLE
+    ;;
+esac

--- a/plugins/weft/core/event_store.py
+++ b/plugins/weft/core/event_store.py
@@ -1,0 +1,80 @@
+"""Append-only JSONL event store with file locking."""
+
+import fcntl
+import json
+from pathlib import Path
+
+from . import weft_dir, now_iso
+
+
+def _events_path(project_dir: str | None = None) -> Path:
+    return weft_dir(project_dir) / "events.jsonl"
+
+
+def append(event_type: str, data: dict, *,
+           session_id: str = "unknown",
+           workflow_id: str | None = None,
+           project_dir: str | None = None) -> dict:
+    """Append an event to events.jsonl. Returns the envelope."""
+    path = _events_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    envelope = {
+        "v": 1,
+        "ts": now_iso(),
+        "session_id": session_id,
+        "workflow_id": workflow_id,
+        "event_type": event_type,
+        "data": data,
+    }
+
+    line = json.dumps(envelope, separators=(",", ":")) + "\n"
+
+    with open(path, "a") as f:
+        fcntl.flock(f, fcntl.LOCK_EX)
+        try:
+            f.write(line)
+        finally:
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+    return envelope
+
+
+def read_all(project_dir: str | None = None) -> list[dict]:
+    """Read all events."""
+    path = _events_path(project_dir)
+    if not path.exists():
+        return []
+    events = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return events
+
+
+def query(project_dir: str | None = None, *,
+          event_type: str | None = None,
+          workflow_id: str | None = None,
+          session_id: str | None = None,
+          tool: str | None = None,
+          last_n: int | None = None) -> list[dict]:
+    """Query events with optional filters."""
+    events = read_all(project_dir)
+
+    if event_type:
+        events = [e for e in events if e.get("event_type") == event_type]
+    if workflow_id:
+        events = [e for e in events if e.get("workflow_id") == workflow_id]
+    if session_id:
+        events = [e for e in events if e.get("session_id") == session_id]
+    if tool:
+        events = [e for e in events if e.get("data", {}).get("tool") == tool]
+    if last_n:
+        events = events[-last_n:]
+
+    return events

--- a/plugins/weft/core/guard_engine.py
+++ b/plugins/weft/core/guard_engine.py
@@ -1,0 +1,72 @@
+"""Guard engine — evaluate whether a tool call is allowed in the current step."""
+
+import json
+import re
+import sys
+
+from . import state_machine
+
+
+def evaluate(hook_input: dict, project_dir: str | None = None) -> dict | None:
+    """Check if the tool call is blocked by a guard from a non-current step.
+
+    Returns None if allowed, or a dict with {blocked: True, reason: str} if blocked.
+    """
+    state = state_machine.load_state(project_dir)
+    if not state or state.get("status") != "running":
+        return None
+
+    tool_name = hook_input.get("tool_name", "")
+    command = ""
+    if tool_name == "Bash":
+        command = hook_input.get("tool_input", {}).get("command", "")
+    elif tool_name in ("Edit", "Write"):
+        command = hook_input.get("tool_input", {}).get("file_path", "")
+
+    if not command:
+        return None
+
+    current_id = state["current_step"]
+
+    for step in state["steps"]:
+        if step["id"] == current_id:
+            continue
+        for guard in step.get("guards", []):
+            pattern = guard if isinstance(guard, str) else guard.get("command_pattern", guard.get("pattern", ""))
+            if not pattern:
+                continue
+            try:
+                if re.search(pattern, command):
+                    step_name = step["name"]
+                    current_name = state["steps"][current_id]["name"]
+                    msg = f"Blocked: command matches guard for step '{step_name}' " \
+                          f"(current step: '{current_name}')"
+                    if isinstance(guard, dict) and guard.get("message"):
+                        msg = guard["message"]
+                    return {"blocked": True, "reason": msg}
+            except re.error as e:
+                print(f"[weft] Warning: invalid guard pattern '{pattern}': {e}", file=sys.stderr)
+                continue
+
+    return None
+
+
+def main():
+    """Entry point for hook script. Reads stdin, evaluates guards."""
+    raw = sys.stdin.read()
+    try:
+        hook_input = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    result = evaluate(hook_input)
+
+    if result and result.get("blocked"):
+        print(result["reason"], file=sys.stderr)
+        sys.exit(2)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/weft/core/projections.py
+++ b/plugins/weft/core/projections.py
@@ -1,0 +1,97 @@
+"""Projections — derived views from state and events."""
+
+from . import weft_dir, event_store
+
+
+def generate_context_md(state: dict, project_dir: str | None = None) -> str:
+    """Generate a compact context summary for injection into Claude's context."""
+    name = state["name"]
+    status = state["status"]
+    steps = state["steps"]
+    current = state["current_step"]
+    total = len(steps)
+
+    current_name = steps[current]["name"] if current < total else "done"
+
+    lines = [
+        f"# Workflow: {name} [{status}]",
+        f"Step {current + 1}/{total}: {current_name}",
+        "",
+    ]
+
+    for s in steps:
+        mark = {
+            "complete": "x",
+            "running": "~",
+            "failed": "!",
+            "skipped": "-",
+        }.get(s["status"], " ")
+        suffix = ""
+        if s["status"] == "running" and s.get("on_fail") != "block":
+            suffix = f" (on_fail: {s['on_fail']})"
+        if s["status"] == "failed":
+            suffix = f" (on_fail: {s['on_fail']}, retries: {s.get('retry_count', 0)})"
+        opt = " [optional]" if s.get("optional") else ""
+        skill = f" → invoke: {s['skill']}" if s.get("skill") else ""
+        loop = ""
+        if s.get("loop_back_to"):
+            loop = f" ↻ loops to {s['loop_back_to']} ({s.get('loop_count', 0)}/{s.get('max_iterations', 3)})"
+        lines.append(f"- [{mark}] {s['name']} ({s['status']}){suffix}{opt}{skill}{loop}")
+
+    if status == "running" and current < total:
+        cur_step = steps[current]
+        guards = cur_step.get("guards", [])
+        if guards:
+            lines.append("")
+            lines.append("Active guards (current step):")
+            for g in guards:
+                if isinstance(g, dict):
+                    lines.append(f"  - {g.get('command_pattern', g.get('pattern', '?'))}: {g.get('message', 'blocked')}")
+                else:
+                    lines.append(f"  - {g}")
+        if cur_step.get("exit_condition"):
+            lines.append("")
+            lines.append(f"Loop exit condition: {cur_step['exit_condition']}")
+
+    lines += [
+        "",
+        "Use /weft:wf-step to advance. /weft:wf-status for details. /weft:ev-query for events.",
+    ]
+
+    return "\n".join(lines)
+
+
+def write_context_md(state: dict, project_dir: str | None = None) -> None:
+    """Write context.md to the weft directory."""
+    content = generate_context_md(state, project_dir)
+    path = weft_dir(project_dir) / "context.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def format_status(state: dict, project_dir: str | None = None) -> str:
+    """Format a human-readable status view."""
+    lines = [generate_context_md(state, project_dir)]
+
+    events = event_store.query(
+        project_dir,
+        workflow_id=state.get("workflow_id"),
+        last_n=10,
+    )
+    if events:
+        lines.append("")
+        lines.append("Recent events:")
+        for ev in events:
+            ts = ev.get("ts", "?")[:19]
+            et = ev.get("event_type", "?")
+            data_str = ""
+            data = ev.get("data", {})
+            if data.get("step_name"):
+                data_str = f" → {data['step_name']}"
+                if data.get("to_status"):
+                    data_str += f" ({data['to_status']})"
+            elif data.get("reason"):
+                data_str = f" — {data['reason']}"
+            lines.append(f"  {ts} {et}{data_str}")
+
+    return "\n".join(lines)

--- a/plugins/weft/core/state_machine.py
+++ b/plugins/weft/core/state_machine.py
@@ -1,0 +1,459 @@
+"""Workflow state machine — pure state transitions + persistence."""
+
+import json
+from pathlib import Path
+
+from . import weft_dir, now_iso, now_dt_and_iso, event_store
+
+
+def _state_path(project_dir: str | None = None) -> Path:
+    return weft_dir(project_dir) / "state.json"
+
+
+def load_state(project_dir: str | None = None) -> dict | None:
+    """Load current workflow state. Returns None if no active workflow."""
+    path = _state_path(project_dir)
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_state(state: dict, project_dir: str | None = None) -> None:
+    """Atomic write of state.json via tmp+rename."""
+    path = _state_path(project_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(state, indent=2))
+    tmp.rename(path)
+
+
+def delete_state(project_dir: str | None = None) -> None:
+    """Remove state.json (workflow finished or aborted)."""
+    path = _state_path(project_dir)
+    if path.exists():
+        path.unlink()
+
+
+def start_workflow(template: dict, session_id: str = "unknown",
+                   project_dir: str | None = None) -> dict:
+    """Initialize a new workflow from a template. Returns the new state."""
+    if "name" not in template or "steps" not in template:
+        raise ValueError("Template must have 'name' and 'steps' fields")
+    if not template["steps"]:
+        raise ValueError("Template must have at least one step")
+
+    now_dt, now = now_dt_and_iso()
+    date_slug = now_dt.strftime("%Y%m%d")
+    name = template["name"]
+    workflow_id = f"{name}-{date_slug}"
+
+    steps = []
+    for i, step_def in enumerate(template["steps"]):
+        step = {
+            "id": i,
+            "name": step_def["name"],
+            "status": "running" if i == 0 else "pending",
+            "context": step_def.get("context", "inline"),
+            "on_fail": step_def.get("on_fail", "block"),
+            "guards": step_def.get("guards", []),
+            "optional": step_def.get("optional", False),
+            "requires_skill": step_def.get("requires_skill"),
+            "skill": step_def.get("skill"),
+            "loop_back_to": step_def.get("loop_back_to"),
+            "max_iterations": step_def.get("max_iterations", 3),
+            "exit_condition": step_def.get("exit_condition"),
+            "started_at": now if i == 0 else None,
+            "completed_at": None,
+            "retry_count": 0,
+            "loop_count": 0,
+        }
+        steps.append(step)
+
+    state = {
+        "workflow_id": workflow_id,
+        "name": name,
+        "status": "running",
+        "current_step": 0,
+        "created_at": now,
+        "session_id": session_id,
+        "template": name,
+        "steps": steps,
+        "version": 1,
+    }
+
+    save_state(state, project_dir)
+
+    event_store.append(
+        "wf.started",
+        {"workflow_id": workflow_id, "name": name, "step_count": len(steps),
+         "steps": template["steps"]},
+        session_id=session_id,
+        workflow_id=workflow_id,
+        project_dir=project_dir,
+    )
+
+    return state
+
+
+def _advance_to_next(state: dict) -> None:
+    """Move current_step to the next non-skipped pending step."""
+    now = now_iso()
+    idx = state["current_step"] + 1
+    steps = state["steps"]
+
+    # Skip optional steps that should be auto-skipped
+    while idx < len(steps):
+        step = steps[idx]
+        if step.get("optional") and step.get("requires_skill"):
+            step["status"] = "skipped"
+            step["completed_at"] = now
+            idx += 1
+            continue
+        break
+
+    if idx < len(steps):
+        state["current_step"] = idx
+        steps[idx]["status"] = "running"
+        steps[idx]["started_at"] = now
+    else:
+        state["status"] = "complete"
+
+
+def _current_step(state: dict) -> dict:
+    """Get current step with bounds check."""
+    idx = state["current_step"]
+    if idx < 0 or idx >= len(state["steps"]):
+        raise ValueError(f"Invalid current_step: {idx} (workflow has {len(state['steps'])} steps)")
+    return state["steps"][idx]
+
+
+def step_complete(state: dict, reason: str = "",
+                  session_id: str = "unknown",
+                  project_dir: str | None = None) -> dict:
+    """Mark current step as complete and advance."""
+    step = _current_step(state)
+    from_status = step["status"]
+    step["status"] = "complete"
+    step["completed_at"] = now_iso()
+
+    event_store.append(
+        "wf.step_changed",
+        {"step_id": step["id"], "step_name": step["name"],
+         "from_status": from_status, "to_status": "complete", "reason": reason},
+        session_id=session_id,
+        workflow_id=state["workflow_id"],
+        project_dir=project_dir,
+    )
+
+    _advance_to_next(state)
+
+    if state["status"] == "complete":
+        event_store.append(
+            "wf.completed",
+            {"workflow_id": state["workflow_id"], "name": state["name"]},
+            session_id=session_id,
+            workflow_id=state["workflow_id"],
+            project_dir=project_dir,
+        )
+
+    save_state(state, project_dir)
+    return state
+
+
+def step_fail(state: dict, reason: str = "",
+              session_id: str = "unknown",
+              project_dir: str | None = None) -> dict:
+    """Mark current step as failed, apply on_fail policy."""
+    step = _current_step(state)
+    policy = step["on_fail"]
+    from_status = step["status"]
+
+    if policy == "retry" and step["retry_count"] < 1:
+        step["retry_count"] += 1
+        to_status = "running"
+        step["status"] = "running"
+    elif policy == "continue":
+        step["status"] = "failed"
+        to_status = "failed"
+        _advance_to_next(state)
+    else:
+        step["status"] = "failed"
+        state["status"] = "failed"
+        to_status = "failed"
+
+    event_store.append(
+        "wf.step_changed",
+        {"step_id": step["id"], "step_name": step["name"],
+         "from_status": from_status, "to_status": to_status,
+         "reason": reason, "policy": policy},
+        session_id=session_id,
+        workflow_id=state["workflow_id"],
+        project_dir=project_dir,
+    )
+
+    save_state(state, project_dir)
+    return state
+
+
+def step_skip(state: dict, reason: str = "",
+              session_id: str = "unknown",
+              project_dir: str | None = None) -> dict:
+    """Skip current step and advance."""
+    step = _current_step(state)
+    from_status = step["status"]
+    step["status"] = "skipped"
+    step["completed_at"] = now_iso()
+
+    event_store.append(
+        "wf.step_changed",
+        {"step_id": step["id"], "step_name": step["name"],
+         "from_status": from_status, "to_status": "skipped", "reason": reason},
+        session_id=session_id,
+        workflow_id=state["workflow_id"],
+        project_dir=project_dir,
+    )
+
+    _advance_to_next(state)
+    save_state(state, project_dir)
+    return state
+
+
+def step_retry(state: dict, reason: str = "",
+               session_id: str = "unknown",
+               project_dir: str | None = None) -> dict:
+    """Retry a failed step."""
+    step = _current_step(state)
+    if step["status"] != "failed":
+        raise ValueError(f"Can only retry failed steps, got: {step['status']}")
+
+    step["retry_count"] += 1
+    step["status"] = "running"
+    step["started_at"] = now_iso()
+    state["status"] = "running"
+
+    event_store.append(
+        "wf.step_changed",
+        {"step_id": step["id"], "step_name": step["name"],
+         "from_status": "failed", "to_status": "running", "reason": reason},
+        session_id=session_id,
+        workflow_id=state["workflow_id"],
+        project_dir=project_dir,
+    )
+
+    save_state(state, project_dir)
+    return state
+
+
+def _find_step_by_name(state: dict, name: str) -> int | None:
+    """Find step index by name. Returns None if not found."""
+    for step in state["steps"]:
+        if step["name"] == name:
+            return step["id"]
+    return None
+
+
+def step_loop_back(state: dict, reason: str = "",
+                   session_id: str = "unknown",
+                   project_dir: str | None = None) -> dict:
+    """Loop back to an earlier step. Used when exit condition is not yet met."""
+    step = _current_step(state)
+
+    target_name = step.get("loop_back_to")
+    if not target_name:
+        raise ValueError(f"Step '{step['name']}' has no loop_back_to field")
+
+    target_idx = _find_step_by_name(state, target_name)
+    if target_idx is None:
+        raise ValueError(f"Loop target step not found: {target_name}")
+
+    max_iter = step.get("max_iterations", 3)
+    if step["loop_count"] >= max_iter:
+        # Max iterations exceeded — apply on_fail policy
+        return step_fail(state, f"Loop exceeded max iterations ({max_iter})",
+                         session_id, project_dir)
+
+    step["loop_count"] += 1
+    now = now_iso()
+
+    # Reset all steps from target to current (inclusive) back to pending
+    current_idx = step["id"]
+    for i in range(target_idx, current_idx + 1):
+        s = state["steps"][i]
+        s["status"] = "pending"
+        s["started_at"] = None
+        s["completed_at"] = None
+
+    # Start the target step
+    state["steps"][target_idx]["status"] = "running"
+    state["steps"][target_idx]["started_at"] = now
+    state["current_step"] = target_idx
+
+    event_store.append(
+        "wf.loop_iteration",
+        {"step_id": step["id"], "step_name": step["name"],
+         "loop_back_to": target_name, "target_step_id": target_idx,
+         "loop_count": step["loop_count"], "max_iterations": max_iter,
+         "reason": reason},
+        session_id=session_id,
+        workflow_id=state["workflow_id"],
+        project_dir=project_dir,
+    )
+
+    save_state(state, project_dir)
+    return state
+
+
+def step_loop_done(state: dict, reason: str = "",
+                   session_id: str = "unknown",
+                   project_dir: str | None = None) -> dict:
+    """Exit a loop — mark current step complete and advance normally."""
+    step = _current_step(state)
+    if not step.get("loop_back_to"):
+        raise ValueError(f"Step '{step['name']}' has no loop — use 'complete' instead")
+
+    return step_complete(state, reason or "loop_exit", session_id, project_dir)
+
+
+def abort_workflow(state: dict, reason: str = "",
+                   session_id: str = "unknown",
+                   project_dir: str | None = None) -> dict:
+    """Abort the entire workflow."""
+    state["status"] = "aborted"
+
+    event_store.append(
+        "wf.aborted",
+        {"workflow_id": state["workflow_id"], "name": state["name"],
+         "reason": reason},
+        session_id=session_id,
+        workflow_id=state["workflow_id"],
+        project_dir=project_dir,
+    )
+
+    save_state(state, project_dir)
+    return state
+
+
+def rebuild_from_events(project_dir: str | None = None,
+                        workflow_id: str | None = None) -> dict | None:
+    """Rebuild state.json by replaying wf.* events."""
+    events = event_store.query(
+        project_dir,
+        workflow_id=workflow_id,
+    )
+
+    wf_events = [e for e in events if e.get("event_type", "").startswith("wf.")]
+    if not wf_events:
+        return None
+
+    state = None
+    for ev in wf_events:
+        et = ev["event_type"]
+        data = ev.get("data", {})
+
+        if et == "wf.started":
+            # Build steps from embedded template definitions if available,
+            # otherwise fall back to placeholders (backward compat with old events).
+            step_defs = data.get("steps")
+            if step_defs:
+                steps = []
+                for i, sd in enumerate(step_defs):
+                    steps.append({
+                        "id": i,
+                        "name": sd["name"],
+                        "status": "running" if i == 0 else "pending",
+                        "context": sd.get("context", "inline"),
+                        "on_fail": sd.get("on_fail", "block"),
+                        "guards": sd.get("guards", []),
+                        "optional": sd.get("optional", False),
+                        "requires_skill": sd.get("requires_skill"),
+                        "skill": sd.get("skill"),
+                        "loop_back_to": sd.get("loop_back_to"),
+                        "max_iterations": sd.get("max_iterations", 3),
+                        "exit_condition": sd.get("exit_condition"),
+                        "started_at": ev["ts"] if i == 0 else None,
+                        "completed_at": None,
+                        "retry_count": 0,
+                        "loop_count": 0,
+                    })
+            else:
+                steps = [{"id": i, "name": f"step-{i}", "status": "pending",
+                           "on_fail": "block", "guards": [], "optional": False,
+                           "started_at": None, "completed_at": None, "retry_count": 0}
+                          for i in range(data.get("step_count", 0))]
+                if steps:
+                    steps[0]["status"] = "running"
+                    steps[0]["started_at"] = ev["ts"]
+
+            state = {
+                "workflow_id": data.get("workflow_id", "unknown"),
+                "name": data.get("name", "unknown"),
+                "status": "running",
+                "current_step": 0,
+                "created_at": ev["ts"],
+                "session_id": ev.get("session_id", "unknown"),
+                "template": data.get("name", "unknown"),
+                "steps": steps,
+                "version": 1,
+            }
+
+        elif et == "wf.step_changed" and state:
+            sid = data.get("step_id", 0)
+            if 0 <= sid < len(state["steps"]):
+                step = state["steps"][sid]
+                step["status"] = data.get("to_status", step["status"])
+                step["name"] = data.get("step_name", step["name"])
+                if data.get("to_status") in ("complete", "skipped"):
+                    step["completed_at"] = ev["ts"]
+                if data.get("to_status") == "running":
+                    step["started_at"] = ev["ts"]
+
+        elif et == "wf.loop_iteration" and state:
+            # Reset steps in the loop range back to pending
+            step_id = data.get("step_id", 0)
+            target_id = data.get("target_step_id", 0)
+            loop_count = data.get("loop_count", 1)
+            for i in range(target_id, min(step_id + 1, len(state["steps"]))):
+                s = state["steps"][i]
+                s["status"] = "pending"
+                s["started_at"] = None
+                s["completed_at"] = None
+            # Start the target step
+            if 0 <= target_id < len(state["steps"]):
+                state["steps"][target_id]["status"] = "running"
+                state["steps"][target_id]["started_at"] = ev["ts"]
+            # Preserve loop_count on the originating step
+            if 0 <= step_id < len(state["steps"]):
+                state["steps"][step_id]["loop_count"] = loop_count
+
+        elif et == "wf.completed" and state:
+            state["status"] = "complete"
+
+        elif et == "wf.aborted" and state:
+            state["status"] = "aborted"
+
+    # Infer current_step from step statuses (instead of relying on
+    # wf.step_changed "running" events, which _advance_to_next never emits).
+    if state:
+        if state["status"] == "running":
+            inferred = 0
+            for i, s in enumerate(state["steps"]):
+                if s["status"] in ("pending", "running"):
+                    inferred = i
+                    if s["status"] == "pending":
+                        s["status"] = "running"
+                        s["started_at"] = s.get("started_at") or now_iso()
+                    break
+            else:
+                inferred = len(state["steps"]) - 1
+            state["current_step"] = inferred
+        elif state["status"] in ("complete", "aborted", "failed"):
+            # For terminal workflows, cursor should point to the last step
+            state["current_step"] = len(state["steps"]) - 1
+
+    if state:
+        save_state(state, project_dir)
+
+    return state

--- a/plugins/weft/core/templates.py
+++ b/plugins/weft/core/templates.py
@@ -1,0 +1,136 @@
+"""Template loading and discovery."""
+
+import json
+import os
+from pathlib import Path
+
+
+def _plugin_templates_dir() -> Path:
+    """Templates bundled with the plugin."""
+    return Path(__file__).parent.parent / "templates"
+
+
+def _project_templates_dir(project_dir: str | None = None) -> Path:
+    """Project-local templates."""
+    base = project_dir or os.environ.get("CLAUDE_PROJECT_DIR", ".")
+    return Path(base) / ".claude" / "weft" / "templates"
+
+
+def _user_templates_dir() -> Path:
+    """User-global templates. Override with WEFT_USER_TEMPLATES_DIR."""
+    override = os.environ.get("WEFT_USER_TEMPLATES_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".weft" / "templates"
+
+
+def list_templates(project_dir: str | None = None) -> list[dict]:
+    """List all available templates (plugin + user-global + project-local)."""
+    templates = []
+    for d in [_plugin_templates_dir(), _user_templates_dir(), _project_templates_dir(project_dir)]:
+        if not d.exists():
+            continue
+        for f in sorted(d.glob("*.json")):
+            try:
+                t = json.loads(f.read_text())
+                templates.append({
+                    "name": t.get("name", f.stem),
+                    "description": t.get("description", ""),
+                    "path": str(f),
+                    "steps": len(t.get("steps", [])),
+                })
+            except (json.JSONDecodeError, OSError):
+                continue
+    return templates
+
+
+def load_template(name: str, project_dir: str | None = None) -> dict | None:
+    """Load a template by name. Project-local > user-global > plugin."""
+    for d in [_project_templates_dir(project_dir), _user_templates_dir(), _plugin_templates_dir()]:
+        path = d / f"{name}.json"
+        if path.exists():
+            try:
+                return json.loads(path.read_text())
+            except (json.JSONDecodeError, OSError):
+                continue
+    return None
+
+
+def template_from_steps(step_names: list[str], name: str = "adhoc") -> dict:
+    """Build an ad-hoc template from comma-separated step names."""
+    return {
+        "name": name,
+        "description": f"Ad-hoc workflow: {', '.join(step_names)}",
+        "steps": [
+            {"name": s.strip(), "context": "inline", "on_fail": "block", "guards": []}
+            for s in step_names
+        ],
+    }
+
+
+def save_template(template: dict, project_dir: str | None = None) -> Path:
+    """Save a template to the project-local templates directory. Returns the path."""
+    name = template.get("name", "unnamed")
+    d = _project_templates_dir(project_dir)
+    d.mkdir(parents=True, exist_ok=True)
+    path = d / f"{name}.json"
+    path.write_text(json.dumps(template, indent=2) + "\n")
+    return path
+
+
+def template_detail(name: str, project_dir: str | None = None) -> str | None:
+    """Return a detailed formatted view of a template's steps."""
+    tmpl = load_template(name, project_dir)
+    if not tmpl:
+        return None
+
+    lines = [
+        f"Template: {tmpl['name']}",
+        f"Description: {tmpl.get('description', '')}",
+        f"Steps: {len(tmpl['steps'])}",
+        "",
+    ]
+
+    for i, step in enumerate(tmpl["steps"]):
+        is_last = i == len(tmpl["steps"]) - 1
+        prefix = "  └─" if is_last else "  ├─"
+
+        parts = [f"{prefix} {step['name']}"]
+
+        policy = step.get("on_fail", "block")
+        if policy != "block":
+            parts.append(f"[on_fail={policy}]")
+
+        if step.get("guards"):
+            guard_pats = []
+            for g in step["guards"]:
+                if isinstance(g, dict):
+                    guard_pats.append(g.get("command_pattern", g.get("pattern", "?")))
+                else:
+                    guard_pats.append(str(g))
+            parts.append(f"guards: {', '.join(guard_pats)}")
+
+        if step.get("optional"):
+            parts.append("[optional]")
+
+        if step.get("requires_skill"):
+            parts.append(f"requires: {step['requires_skill']}")
+
+        if step.get("skill"):
+            parts.append(f"skill: {step['skill']}")
+
+        if step.get("loop_back_to"):
+            max_iter = step.get("max_iterations", 3)
+            parts.append(f"↻ → {step['loop_back_to']} (max {max_iter})")
+
+        lines.append("  ".join(parts))
+
+        if step.get("description"):
+            cont = "  │ " if not is_last else "    "
+            lines.append(f"{cont} {step['description']}")
+
+        if step.get("exit_condition"):
+            cont = "  │ " if not is_last else "    "
+            lines.append(f"{cont} exit: {step['exit_condition']}")
+
+    return "\n".join(lines)

--- a/plugins/weft/hooks/hooks.json
+++ b/plugins/weft/hooks/hooks.json
@@ -1,0 +1,50 @@
+{
+  "description": "Weft — deterministic workflow tracking hooks",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/weft-sessionstart.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/weft-pretooluse.sh\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/weft-precompact.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/weft-stop.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/weft/hooks/weft-precompact.sh
+++ b/plugins/weft/hooks/weft-precompact.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Weft PreCompact — inject workflow state summary into compaction context.
+# Stdout is added to Claude's context after compaction.
+set -euo pipefail
+
+STATE="${CLAUDE_PROJECT_DIR:-.}/.claude/weft/state.json"
+[ -f "$STATE" ] || exit 0
+
+python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" context 2>/dev/null

--- a/plugins/weft/hooks/weft-pretooluse.sh
+++ b/plugins/weft/hooks/weft-pretooluse.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Weft PreToolUse guard — blocks commands guarded to non-current steps.
+# Fast path: exits immediately if no active workflow.
+set -euo pipefail
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || exit 0
+
+STATE="${CLAUDE_PROJECT_DIR:-.}/.claude/weft/state.json"
+[ -f "$STATE" ] || exit 0
+
+INPUT=$(cat)
+echo "$INPUT" | python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" guard 2>&1

--- a/plugins/weft/hooks/weft-sessionstart.sh
+++ b/plugins/weft/hooks/weft-sessionstart.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Weft SessionStart — restore workflow context into Claude's context.
+# Stdout is injected as a systemMessage.
+set -euo pipefail
+
+STATE="${CLAUDE_PROJECT_DIR:-.}/.claude/weft/state.json"
+[ -f "$STATE" ] || exit 0
+
+python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" context 2>/dev/null

--- a/plugins/weft/hooks/weft-stop.sh
+++ b/plugins/weft/hooks/weft-stop.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Weft Stop gate — blocks Claude from stopping if workflow has incomplete steps.
+# Fast path: exits immediately if no active workflow.
+set -euo pipefail
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || exit 0
+
+STATE="${CLAUDE_PROJECT_DIR:-.}/.claude/weft/state.json"
+[ -f "$STATE" ] || exit 0
+
+INPUT=$(cat)
+echo "$INPUT" | python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" gate

--- a/plugins/weft/skills/ev-query/SKILL.md
+++ b/plugins/weft/skills/ev-query/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: ev-query
+description: "Query the weft event log with filters. Use only when user types /ev-query."
+argument-hint: "[event_type] [--tool X] [--last N] [--workflow ID] [--session ID]"
+allowed-tools: [Bash, Read]
+---
+
+# Query Weft Event Log
+
+## Arguments
+$ARGUMENTS
+
+## Instructions
+
+1. Parse filter flags from arguments.
+
+2. Run:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" query $ARGUMENTS
+   ```
+
+3. If no arguments, show a summary (event counts by type).
+
+4. Present results in a readable format, not raw JSON.
+
+## Filter Examples
+- `/ev-query` — count by event type
+- `/ev-query wf.step_changed` — all step transitions
+- `/ev-query --last 20` — last 20 events
+- `/ev-query --tool Bash --last 10` — last 10 Bash tool events
+- `/ev-query --workflow adhoc-20260406` — events for specific workflow

--- a/plugins/weft/skills/wf-abort/SKILL.md
+++ b/plugins/weft/skills/wf-abort/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: wf-abort
+description: "Abort the current weft workflow. Use only when user types /wf-abort."
+argument-hint: "[reason]"
+allowed-tools: [Bash, Read, Write]
+---
+
+# Abort Weft Workflow
+
+## Arguments
+$ARGUMENTS
+
+## Instructions
+
+1. Confirm with the user before aborting (unless they explicitly said to abort).
+
+2. Run:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" abort "<reason>"
+   ```
+
+3. Show the final state.

--- a/plugins/weft/skills/wf-compose/SKILL.md
+++ b/plugins/weft/skills/wf-compose/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: wf-compose
+description: "Propose a weft workflow from conversation context. Scans skills, identifies gaps, builds template with loops."
+argument-hint: "[description] [--from template-name]"
+allowed-tools: [Bash, Read, Write, Glob, Grep]
+---
+
+# Compose a Weft Workflow
+
+Read the conversation context, scan available skills, identify gaps, and propose a v2 workflow template with loops and skill blocks.
+
+## Arguments
+$ARGUMENTS
+
+## Modes
+
+| Usage | Behavior |
+|-------|----------|
+| `/wf-compose "review, fix, iterate until clean"` | One-shot: propose from description |
+| `/wf-compose` (no args) | Interactive: ask "What are you trying to accomplish?" |
+| `/wf-compose --from feature-workflow` | Start from existing template, modify based on context |
+
+## Step 1: Gather Context
+
+Understand what the user is trying to do:
+
+1. Review the recent conversation for intent (what task, what repo, what outcome).
+2. Check git state:
+   ```bash
+   git branch --show-current 2>/dev/null
+   git diff --stat 2>/dev/null | tail -5
+   ```
+3. Check if a weft workflow is already active:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" status 2>/dev/null
+   ```
+4. If `--from <template>` was provided, load it as the starting point:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" preview <template>
+   ```
+
+## Step 2: Scan Skill Registry
+
+Build a map of what skills are available:
+
+1. Read the local skills registry, if any (path varies by setup):
+   ```bash
+   cat "${CLAUDE_SKILLS_REGISTRY:-$HOME/.claude/skills-registry.json}" 2>/dev/null
+   ```
+2. List weft templates:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" start
+   ```
+3. Categorize skills by function (examples — substitute what you have available):
+   - **Review**: staff-review, arch-review, code-review, differential-review
+   - **Fix/Polish**: fix-polish, refactor, simplify
+   - **Test**: infra-test, webapp-testing
+   - **Plan**: aot-plan, spec-first
+   - **Research**: perplexity, context7, research-loop
+   - **Deploy**: deploy-service, pr-ready
+
+## Step 3: Gap Analysis
+
+Compare what the user described against available skills:
+
+1. Extract skill references from the user's description (explicit names like "/staff-review" or implicit like "review code", "test it", "deploy").
+2. For each referenced skill, check if it exists in the registry.
+3. For missing skills, present options:
+   ```
+   Missing skill: /devils-advocate
+   Options:
+   1. Create a stub skill (I'll generate a skeleton)
+   2. Use /staff-review instead (similar purpose)
+   3. Skip this step
+   ```
+4. Wait for user choice on each gap before proceeding.
+
+## Step 4: Generate Template
+
+Build a v2 template JSON:
+
+1. Map each step in the user's described workflow to a template step.
+2. For each step, set:
+   - `name`: kebab-case identifier
+   - `skill`: the matching skill name (e.g., "/staff-review"), or null if manual
+   - `on_fail`: "retry" for review/test steps, "block" for critical gates, "continue" for optional steps
+   - `guards`: add logical guards (e.g., no `git push` before review)
+   - `description`: one-line summary of what the step does
+
+3. For iterative segments (user said "until", "repeat", "loop", "iterate"):
+   - Identify the loop boundary (which steps repeat)
+   - Set `loop_back_to` on the last step of the loop, pointing to the first
+   - Set `max_iterations` (default 3, or what the user specified)
+   - Set `exit_condition` from the user's description (natural language)
+
+4. Add `schema_version: 2` to the template root.
+
+## Step 5: Present to User
+
+Show the proposed workflow in two formats:
+
+### ASCII Diagram
+
+Draw the workflow as a flow diagram showing loops:
+
+```
+  ┌────────────┐     ┌───────────────┐     ┌─────────────┐
+  │   review    │────>│  fix-issues   │────>│  run-tests   │
+  │ /staff-rev  │     │ /fix-polish   │     │              │
+  └────────────┘     └───────────────┘     └──────┬──────┘
+        ^                                         │
+        │        ↻ until clean (max 3)            │
+        └─────────────────────────────────────────┘
+                          │ done
+                          v
+                   ┌─────────────┐
+                   │    ship     │
+                   │  /pr-ready  │
+                   └─────────────┘
+```
+
+For linear segments, use a simple arrow chain:
+```
+  setup ──> plan ──> implement ──> verify
+```
+
+### JSON Preview
+
+Show the full template JSON, formatted for readability.
+
+### Prompt
+
+Ask the user:
+```
+Approve this workflow? (approve / edit / cancel)
+- approve: Save template and optionally start it
+- edit: Describe what to change
+- cancel: Discard
+```
+
+## Step 6: Save and Start
+
+On **approve**:
+1. Save the template:
+   ```bash
+   echo '<json>' | python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" save-template
+   ```
+2. Ask: "Start this workflow now? (y/n)"
+3. If yes: invoke `/wf-start <template-name>`
+
+On **edit**:
+1. Ask what to change
+2. Modify the template
+3. Go back to Step 5 (re-present)
+
+On **cancel**:
+1. Discard and confirm
+
+## Design Rules
+
+- Every step with a matching skill gets a `skill` field. This is metadata — Claude reads it from context.md and knows which skill to invoke.
+- Loops are defined by `loop_back_to` on the last step of the repeating segment. The state machine handles the rest.
+- `exit_condition` is evaluated by Claude (natural language), not by scripts. Keep conditions specific and observable: "no MEDIUM+ issues" not "code is good enough".
+- `max_iterations` defaults to 3. If the user says "until done" without a cap, set it to 5 and note the cap.
+- Guards should prevent premature actions: no `git push` before review, no deploy before tests.
+- Template names are kebab-case. If the user doesn't name it, derive from the description.

--- a/plugins/weft/skills/wf-dashboard/SKILL.md
+++ b/plugins/weft/skills/wf-dashboard/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: wf-dashboard
+description: "Launch the weft TUI dashboard in a new terminal window. Use only when user types /wf-dashboard."
+allowed-tools: [Bash]
+---
+
+# Weft Dashboard
+
+Launch the interactive TUI dashboard in a new terminal tab.
+
+## Instructions
+
+Run this command to open the dashboard in a new iTerm/Terminal tab:
+
+```bash
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/marketplaces/local/plugins/weft}"
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-.}"
+
+osascript -e "
+tell application \"System Events\"
+  set frontApp to name of first application process whose frontmost is true
+end tell
+if frontApp is \"iTerm2\" then
+  tell application \"iTerm\"
+    tell current window
+      create tab with default profile
+      tell current session
+        write text \"PYTHONPATH='$PLUGIN_ROOT' CLAUDE_PROJECT_DIR='$PROJECT_DIR' python3 '$PLUGIN_ROOT/core/dashboard.py'; exit\"
+      end tell
+    end tell
+  end tell
+else
+  tell application \"Terminal\"
+    do script \"PYTHONPATH='$PLUGIN_ROOT' CLAUDE_PROJECT_DIR='$PROJECT_DIR' python3 '$PLUGIN_ROOT/core/dashboard.py'; exit\"
+    activate
+  end tell
+end if
+"
+```
+
+Tell the user: "Dashboard opened in a new tab. Press `r` to refresh, `q` to quit."

--- a/plugins/weft/skills/wf-edit-template/SKILL.md
+++ b/plugins/weft/skills/wf-edit-template/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: wf-edit-template
+description: "Edit an existing weft workflow template. Use only when user types /wf-edit-template."
+argument-hint: "<template-name>"
+allowed-tools: [Bash, Read, Write]
+---
+
+# Edit Weft Template
+
+Load an existing template, modify it interactively, and save.
+
+## Arguments
+$ARGUMENTS
+
+## Instructions
+
+### Step 1: Load
+If no arguments, list templates and ask which to edit:
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" start
+```
+
+Load the template preview:
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" preview <name>
+```
+
+### Step 2: Show current state
+Display the current template with all step details, guards, and policies.
+
+### Step 3: Ask what to change
+Ask: "What would you like to change?"
+
+Supported modifications:
+- **Add a step**: "add a review step after implement" → insert into steps array
+- **Remove a step**: "remove the deploy step" → remove from steps array
+- **Rename a step**: "rename test to verify" → change step name
+- **Change policy**: "make test retry on failure" → set on_fail
+- **Add guard**: "block git push during planning" → add guard to step
+- **Remove guard**: "remove the commit guard from scope-check" → remove guard
+- **Reorder**: "move review before test" → reorder steps array
+- **Change description**: "update the description to ..." → set description
+
+### Step 4: Preview changes
+Show the modified template and ask: "Save these changes?"
+
+### Step 5: Save
+Ask whether to overwrite the original or save as a new name.
+
+If saving to the project-local directory:
+```bash
+echo '<template_json>' | python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" save-template
+```
+
+If the original is a plugin-bundled template, always save as a project-local override (don't modify plugin files).
+
+Tell the user the template was saved and how to start it.

--- a/plugins/weft/skills/wf-new-template/SKILL.md
+++ b/plugins/weft/skills/wf-new-template/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: wf-new-template
+description: "Create a new weft workflow template interactively. Use only when user types /wf-new-template."
+argument-hint: "[template-name]"
+allowed-tools: [Bash, Read, Write]
+---
+
+# Create New Weft Template
+
+Build a custom workflow template through conversation.
+
+## Arguments
+$ARGUMENTS
+
+## Instructions
+
+Walk the user through creating a template step by step:
+
+### Step 1: Name
+If no name in arguments, ask: "What should this workflow be called? (lowercase, hyphens ok)"
+
+### Step 2: Description
+Ask: "One-line description of what this workflow does?"
+
+### Step 3: Steps
+Ask: "List the steps in order. You can describe them naturally and I'll structure them."
+
+Example user input: "first plan the work, then implement it, run tests, do a code review, then push"
+→ Parse into: plan, implement, test, review, push
+
+### Step 4: Policies (for each step)
+For each step, ask if the default `on_fail: block` is ok, or if they want:
+- `retry` — auto-retry once on failure
+- `continue` — skip failed step and move on
+- `block` — halt until manual retry (default)
+
+Suggest sensible defaults: test steps → retry, optional steps → continue.
+
+### Step 5: Guards (optional)
+Ask: "Should any steps block certain commands? For example, blocking `git push` until tests pass."
+
+If yes, collect:
+- Which step the guard applies to
+- The regex pattern to match (e.g., `git push`, `git commit`)
+- The message to show when blocked
+
+### Step 6: Preview and confirm
+Build the template JSON and show a preview using:
+```bash
+echo '<json>' | python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" save-template
+```
+
+Before saving, show the full template and ask: "Look good? Save it?"
+
+### Step 7: Save
+```bash
+echo '<template_json>' | python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" save-template
+```
+
+The template is saved to `.claude/weft/templates/<name>.json` in the project directory.
+
+Tell the user: "Template saved! Start it with `/wf-start <name>`"

--- a/plugins/weft/skills/wf-preview/SKILL.md
+++ b/plugins/weft/skills/wf-preview/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: wf-preview
+description: "Preview a weft workflow template with full step details. Use only when user types /wf-preview."
+argument-hint: "<template-name>"
+allowed-tools: [Bash, Read]
+---
+
+# Preview Weft Template
+
+Show a detailed view of a workflow template's steps, policies, and guards.
+
+## Arguments
+$ARGUMENTS
+
+## Instructions
+
+1. If no arguments, list available templates first:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" start
+   ```
+   Then ask which one to preview.
+
+2. Show the detailed preview:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" preview <template-name>
+   ```
+
+3. Explain the template to the user:
+   - What each step does (from descriptions if available)
+   - Which steps have guards and what they block
+   - Which steps have non-default on_fail policies
+   - Which steps are optional
+   - Total step count and expected flow
+
+4. Suggest: "Use `/wf-start <name>` to start this workflow."

--- a/plugins/weft/skills/wf-rebuild/SKILL.md
+++ b/plugins/weft/skills/wf-rebuild/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: wf-rebuild
+description: "Rebuild weft state.json from the event log. Use only when user types /wf-rebuild."
+argument-hint: "[workflow_id]"
+allowed-tools: [Bash, Read, Write]
+---
+
+# Rebuild Weft State from Events
+
+Proves event sourcing: reconstruct state.json purely from events.jsonl.
+
+## Arguments
+$ARGUMENTS
+
+## Instructions
+
+1. Run:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" rebuild $ARGUMENTS
+   ```
+
+2. Display the rebuilt state.
+
+3. If no workflow_id given, rebuilds the most recent workflow.

--- a/plugins/weft/skills/wf-start/SKILL.md
+++ b/plugins/weft/skills/wf-start/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: wf-start
+description: "Initialize a weft workflow from a template or inline steps. Use only when user types /wf-start."
+argument-hint: "<template-name | step1,step2,step3>"
+allowed-tools: [Bash, Read, Write]
+---
+
+# Start Weft Workflow
+
+Initialize a new deterministic workflow.
+
+## Arguments
+$ARGUMENTS
+
+## Instructions
+
+### If no arguments — guided template picker:
+
+1. List available templates with full details:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" start
+   ```
+
+2. For each template, show a preview of its steps:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" preview <name>
+   ```
+
+3. Present the user with a numbered list like:
+   ```
+   1. generic (3 steps) — plan, implement, verify
+   2. feature-workflow (12 steps) — full-cycle feature development with guards
+   3. Custom — describe your task and I'll build a workflow
+   ```
+
+4. Wait for the user to pick a number, name, or describe their task.
+   - If they pick a template: show the full preview and ask to confirm before starting.
+   - If they describe a task: suggest appropriate steps, confirm, then start as ad-hoc.
+
+### If a template name is given:
+
+1. Preview it first:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" preview <template-name>
+   ```
+
+2. Start it:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" start <template-name>
+   ```
+
+### If comma-separated step names are given (ad-hoc):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" start "step1,step2,step3"
+```
+
+### After starting:
+
+Display the workflow checklist and remind the user:
+- `/wf-step complete` to advance steps
+- `/wf-status` to check progress
+- `/wf-dashboard` to open the live monitoring TUI
+- The Stop hook will prevent finishing with incomplete steps
+- If the current step has guards, explain what commands are blocked and why

--- a/plugins/weft/skills/wf-status/SKILL.md
+++ b/plugins/weft/skills/wf-status/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: wf-status
+description: "Show current weft workflow state and recent events. Use only when user types /wf-status."
+allowed-tools: [Bash, Read]
+---
+
+# Weft Workflow Status
+
+## Instructions
+
+1. Show the current workflow state:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" status
+   ```
+
+2. If `--json` is in $ARGUMENTS, show raw JSON instead:
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" status --json
+   ```
+
+3. If no active workflow, say so and suggest `/weft:wf-start`.

--- a/plugins/weft/skills/wf-step/SKILL.md
+++ b/plugins/weft/skills/wf-step/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: wf-step
+description: "Transition the current weft workflow step. Use only when user types /wf-step."
+argument-hint: "<complete|fail|skip|retry> [reason]"
+allowed-tools: [Bash, Read, Write]
+---
+
+# Advance Weft Workflow Step
+
+Transition the current step to a new status.
+
+## Arguments
+$ARGUMENTS
+
+## Parsing
+
+Parse the arguments flexibly. The user may say:
+- `/wf-step complete "planning done"` — standard form
+- `/wf-step done` or `/wf-step` with no args — treat as `complete`
+- `/wf-step skip not needed` — skip with reason
+- `/wf-step failed, try again` — treat as `retry` if step is failed, or `fail` if running
+- `/wf-step complete 3` or `/wf-step complete next 3` — bulk complete N steps
+
+Map natural language to actions:
+| User says | Action |
+|-----------|--------|
+| done, finished, complete, next | `complete` |
+| skip, not needed, pass | `skip` |
+| failed, broken, error | `fail` |
+| retry, again, redo | `retry` |
+| again, loop, iterate, continue loop, not done yet, issues remain | `loop-continue` |
+| done looping, exit loop, loop done, clean, all clear | `loop-done` |
+
+**Loop disambiguation:** If the current step has a `loop_back_to` field, prefer loop actions over regular ones. "again" on a loop step means `loop-continue`, not `retry`. "done" on a loop step means `loop-done`, not `complete`. If the user explicitly says "complete" or "skip", use those literally even on loop steps.
+
+## Single step transition
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" step <action> <reason>
+```
+
+## Bulk transitions
+
+If the user specifies a count (e.g., "complete 3"), loop:
+```bash
+for i in 1 2 3; do
+  python3 "${CLAUDE_PLUGIN_ROOT}/core/cli.py" step complete "bulk advance"
+done
+```
+
+Stop looping if any step fails or the workflow completes.
+
+## After transition
+
+1. Display the updated workflow checklist.
+2. If the workflow just completed, congratulate and summarize what was accomplished.
+3. If a step failed with `block` policy, explain options: `/wf-step retry` or `/wf-abort`.
+4. If the next step has guards, explain what commands are blocked.
+5. If the next step has a description in the template, mention what it expects.
+
+### After loop-continue
+- Show "Loop iteration N/M" with the current count and max.
+- List which steps were reset back to pending.
+- If the exit condition is defined, remind the user what needs to be true to exit.
+
+### After loop-done
+- Show "Exited loop after N iterations."
+- Show the next step info as normal.
+
+### Loop max exceeded
+- If loop-continue triggers max_iterations, the step fails per its on_fail policy.
+- Explain: "Loop hit max iterations (N). Workflow blocked — use `/wf-step retry` to reset or `/wf-abort`."

--- a/plugins/weft/templates/feature-workflow.json
+++ b/plugins/weft/templates/feature-workflow.json
@@ -1,0 +1,100 @@
+{
+  "name": "feature-workflow",
+  "schema_version": 2,
+  "description": "Full-cycle feature development: ticket to merged PR",
+  "steps": [
+    {
+      "name": "gather-context",
+      "context": "inline",
+      "on_fail": "block",
+      "guards": [],
+      "description": "Read Linear ticket + comments + related PRs/tickets. Use Linear MCP tools."
+    },
+    {
+      "name": "scope-check",
+      "context": "inline",
+      "on_fail": "block",
+      "guards": [
+        {
+          "command_pattern": "git (commit|push)",
+          "message": "No commits until scope is confirmed"
+        }
+      ],
+      "description": "Identify gaps in requirements, prompt user for clarification. Interactive step."
+    },
+    {
+      "name": "generate-context",
+      "context": "inline",
+      "on_fail": "block",
+      "guards": [],
+      "description": "Gather real examples, data, context from web, memory, and available MCP tools."
+    },
+    {
+      "name": "dump-context",
+      "context": "inline",
+      "on_fail": "continue",
+      "guards": [],
+      "description": "Write gathered context to files in .claude/weft/context-files/. May exceed context window."
+    },
+    {
+      "name": "plan-and-worktree",
+      "context": "inline",
+      "skill": "/aot-plan",
+      "on_fail": "block",
+      "guards": [
+        {
+          "command_pattern": "git push",
+          "message": "No push until plan is reviewed"
+        }
+      ],
+      "description": "Create feature plan + worktree + AoT decomposition."
+    },
+    {
+      "name": "review",
+      "context": "fork",
+      "skill": "/staff-review",
+      "on_fail": "retry",
+      "guards": [],
+      "description": "Run /staff-review (and /cursor-review if available) in parallel. Gather findings."
+    },
+    {
+      "name": "apply-fixes",
+      "context": "inline",
+      "skill": "/fix-polish",
+      "on_fail": "retry",
+      "guards": [],
+      "description": "Feed review findings back. Apply fixes."
+    },
+    {
+      "name": "run-tests",
+      "context": "fork",
+      "on_fail": "retry",
+      "guards": [],
+      "loop_back_to": "review",
+      "max_iterations": 3,
+      "exit_condition": "Review passes with no HIGH or MEDIUM issues and tests are green",
+      "description": "Execute test suite. If issues remain, loop back to review."
+    },
+    {
+      "name": "sanitize-push",
+      "context": "inline",
+      "on_fail": "block",
+      "guards": [],
+      "description": "Clean up code, sanitize secrets/company names, push to branch."
+    },
+    {
+      "name": "update-external",
+      "context": "inline",
+      "on_fail": "continue",
+      "guards": [],
+      "description": "Update PR description, Linear ticket status, ping user."
+    },
+    {
+      "name": "final-update",
+      "context": "inline",
+      "on_fail": "continue",
+      "guards": [],
+      "description": "Final summary with all findings. Update user."
+    }
+  ]
+}

--- a/plugins/weft/templates/generic.json
+++ b/plugins/weft/templates/generic.json
@@ -1,0 +1,24 @@
+{
+  "name": "generic",
+  "description": "Simple sequential workflow: plan, implement, verify",
+  "steps": [
+    {
+      "name": "plan",
+      "context": "inline",
+      "on_fail": "block",
+      "guards": []
+    },
+    {
+      "name": "implement",
+      "context": "inline",
+      "on_fail": "retry",
+      "guards": []
+    },
+    {
+      "name": "verify",
+      "context": "inline",
+      "on_fail": "block",
+      "guards": []
+    }
+  ]
+}


### PR DESCRIPTION
Adds [dioptx/weft](https://github.com/dioptx/weft) under **Workflow Orchestration**, with the plugin source copied into `plugins/weft/` to match the existing pattern.

## TL;DR

Event-sourced workflow tracking for Claude Code. Templates with ordered steps, skill bindings, bounded loops, per-step tool guards. Four hooks enforce the contract; state survives compaction. MIT, Python stdlib only.

## Why this fits Workflow Orchestration

Weft is purpose-built for chaining slash commands + agents into a deterministic, auditable flow. Unlike checklist-style TODOs, it writes state to disk (`events.jsonl`), enforces order via `PreToolUse` guards, and refuses session exit while steps are pending via the `Stop` hook.

## Verify the claims

```
/plugin marketplace add dioptx/weft
/plugin install weft@dioptx-weft
/wf-start feature-workflow
```

Five reproducible asciinema GIFs in the README cover structural preview, first run, custom workflow authoring, skill extension, and event-log rebuild. Recording scripts in `docs/demos/` drive the real CLI in mktemp scratch dirs.

## Categorization

Best fit: `Workflow Orchestration` (existing section). If `Project & Product Management` placement is preferred, happy to move.