### PR TITLE
Add Chinese Claude Code skills resource

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -190,6 +190,10 @@
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
 
 
+## 资源
+
+- [Claude Code Skills 中文精选集](https://claude-skills.bt199.com/) - 中文 Claude Code Skills / Agents / Plugins / 工作流精选目录。
+
 ## 使用教程
 
 你可以使用一个包含 `.claude-plugin/marketplace.json` 文件的 Git 仓库，托管并共享你自己的插件市场（plugin marketplace）。

--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
 
 
+## Resources
+
+- [Claude Code Skills 中文精选集](https://claude-skills.bt199.com/) - Chinese curated directory of Claude Code Skills, Agents, Plugins, and workflows.
+
 ## Tutorials
 
 You can host and share your own curated plugin marketplace using a simple Git repository with a `.claude-plugin/marketplace.json` file.


### PR DESCRIPTION
## Summary\n- Add a small Resources section with Claude Code Skills 中文精选集.\n- Update both English and Chinese README files to keep them aligned.\n\n## Why it fits\nThis repository lists Claude Code plugins and marketplace resources. The added site is a Chinese curated directory for Claude Code Skills, Agents, Plugins, and workflows, useful for Chinese-speaking Claude Code users discovering related resources.\n\n## Checks\n- README-only change.\n- Ran git diff --check.\n- Added one focused resource, no bulk links.