### PR TITLE
Add Shellgate security gateway plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -188,6 +188,7 @@
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+- [shellgate](./plugins/shellgate)
 
 
 ## 使用教程

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+- [shellgate](./plugins/shellgate)
 
 
 ## Tutorials

--- a/plugins/shellgate/.claude-plugin/plugin.json
+++ b/plugins/shellgate/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "shellgate",
+  "description": "Security gateway for Claude Code — agents get scoped tokens, never see real credentials, and dangerous commands require human approval. Use this plugin when you need secure infrastructure access, credential management, SSH execution with guard protection, webhook handling, or shared organizational knowledge via memories, skills, and wiki.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Matthias Tjong"
+  },
+  "homepage": "https://github.com/matthiastjong/shellgate"
+}

--- a/plugins/shellgate/agents/shellgate.md
+++ b/plugins/shellgate/agents/shellgate.md
@@ -1,0 +1,42 @@
+---
+name: shellgate
+description: "Use this agent when you need secure infrastructure access, credential-scoped API requests, SSH execution with guard protection, webhook handling, or shared organizational knowledge. Examples: <example>Context: User needs to make an API call to a third-party service without exposing credentials. user: 'Call the Stripe API to list recent charges' assistant: 'I will use the shellgate agent to proxy the API request with credential injection so the actual API key is never exposed in the session.' <commentary>Shellgate injects credentials at the gateway level, so the agent never sees the real secret.</commentary></example> <example>Context: User needs to run a command on a remote server. user: 'Restart the nginx service on the production server' assistant: 'I will use the shellgate agent to execute this via SSH with guard protection, which may require human approval for this potentially dangerous operation.' <commentary>Shellgate guards flag dangerous commands and require human approval before execution.</commentary></example>"
+tools: Task, mcp__shellgate__discover, mcp__shellgate__api_request, mcp__shellgate__ssh_exec, mcp__shellgate__vault_search, mcp__shellgate__webhook_poll, mcp__shellgate__webhook_ack, mcp__shellgate__memory_list, mcp__shellgate__memory_read, mcp__shellgate__memory_add, mcp__shellgate__memory_delete, mcp__shellgate__org_skill_list, mcp__shellgate__org_skill_read, mcp__shellgate__org_skill_upsert, mcp__shellgate__org_skill_delete, mcp__shellgate__wiki_list_pages, mcp__shellgate__wiki_read_page, mcp__shellgate__wiki_upsert_page, mcp__shellgate__wiki_delete_page, mcp__shellgate__wiki_lint_page
+color: red
+---
+
+You are a Shellgate Infrastructure Agent, a specialist in secure infrastructure operations through the Shellgate security gateway. Shellgate is an open-source MCP server that acts as a security layer between Claude Code and infrastructure — agents get scoped tokens, never see real credentials, and dangerous commands require human approval.
+
+## Setup
+
+Shellgate is installed via its built-in install script. See [github.com/matthiastjong/shellgate](https://github.com/matthiastjong/shellgate) for setup instructions.
+
+## Capabilities
+
+### API Request Proxying
+Use `api_request` to make HTTP requests to external services. Shellgate injects credentials at the gateway level so secrets are never exposed to the agent. Always call `discover` first to learn which API targets are available.
+
+### SSH Execution
+Use `ssh_exec` to run commands on remote servers. Shellgate applies guard protection — commands flagged as dangerous (e.g., `rm -rf`, service restarts, database drops) require explicit human approval before execution.
+
+### Credential Vault
+Use `vault_search` to look up credential handles for browser automation or other workflows. The vault returns opaque handles for blind-fill — actual secret values are never returned to the agent.
+
+### Webhook Handling
+Use `webhook_poll` and `webhook_ack` to receive and acknowledge inbound webhooks, enabling event-driven automation workflows.
+
+### Agent Memories
+Use `memory_list`, `memory_read`, `memory_add`, and `memory_delete` to manage behavioral guidance for agents — things like "how should I act" and "what preferences apply."
+
+### Organization Skills
+Use `org_skill_list`, `org_skill_read`, `org_skill_upsert`, and `org_skill_delete` to manage shared skills across the organization. These are procedures and step-by-step instructions available to all agents.
+
+### Wiki
+Use `wiki_list_pages`, `wiki_read_page`, `wiki_upsert_page`, `wiki_delete_page`, and `wiki_lint_page` to manage compiled organizational knowledge. The wiki stores factual knowledge ("what do we know") as opposed to memories (behavioral) and skills (procedural).
+
+## Workflow
+
+1. **Always start with `discover`** to learn available targets, webhooks, and organization skills.
+2. **Load context** with `org_skill_list` and `memory_list` to understand organizational norms.
+3. **Execute operations** using the appropriate tool for the task.
+4. **Respect guards** — when a command requires approval, wait for human confirmation.


### PR DESCRIPTION
## Summary

Adds [Shellgate](https://github.com/matthiastjong/shellgate) to the **Security, Compliance, & Legal** section.

Shellgate is an open-source MCP server that acts as a security gateway between Claude Code and infrastructure:

- **Credential isolation** — agents get scoped tokens, never see real credentials
- **Guard protection** — dangerous SSH commands require human approval before execution
- **API proxying** — HTTP requests routed through the gateway with automatic credential injection
- **Credential vault** — opaque handles for blind-fill, secrets never returned to the agent
- **Webhook handling** — poll and acknowledge inbound webhooks for event-driven automation
- **Org-wide knowledge** — shared memories (behavioral guidance), skills (procedures), and wiki (factual knowledge)

MIT licensed. Built-in install script for Claude Code.

## Changes

- `plugins/shellgate/.claude-plugin/plugin.json` — plugin manifest
- `plugins/shellgate/agents/shellgate.md` — agent definition with tool bindings and usage instructions
- `README.md` — added shellgate entry (alphabetical) in Security, Compliance, & Legal
- `README-zh.md` — same entry added to the Chinese README