### PR TITLE
Add adamsreview plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [technical-sales-engineer](./plugins/technical-sales-engineer)
 
 ### Code Quality Testing
+- [adamsreview](./plugins/adamsreview)
 - [api-tester](./plugins/api-tester)
 - [bug-detective](./plugins/bug-detective)
 - [code-review](./plugins/code-review)

--- a/plugins/adamsreview/.claude-plugin/plugin.json
+++ b/plugins/adamsreview/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "adamsreview",
+  "description": "Multi-lens code review pipeline: deep review (Claude or Codex), automated fix loop, interactive walkthrough, manual promote, external-finding injection.",
+  "version": "0.4.0",
+  "author": {
+    "name": "Adam Miller",
+    "url": "https://github.com/adamjgmiller"
+  },
+  "homepage": "https://github.com/adamjgmiller/adamsreview"
+}


### PR DESCRIPTION
Adds adamsreview to Code Quality Testing.

adamsreview is a six-command Claude Code plugin for multi-stage PR review — parallel sub-agent detection, validation passes, persistent JSON state, and an automated fix loop that re-reviews and reverts regressions before committing. On the author's own PRs, it has been catching more real bugs than `/review`, `/ultrareview`, CodeRabbit, Greptile, and Codex's built-in review — with fewer false positives (anecdotal, n=me).

- `/adamsreview:review` (or `:codex-review`) — multi-lens parallel review with score gates
- `/adamsreview:fix` — per-fix-group agents + Opus post-review with revert-on-regression
- `/adamsreview:walkthrough` — interactive driver for findings the fix loop skips
- `/adamsreview:add` — paste-injection of external findings (cloud `/ultrareview`, manual finds) into the same artifact
- `/adamsreview:promote` — single-finding override

Runs against a regular Claude Code subscription (Max plan recommended). Respects your `CLAUDE.md`.

Repo: https://github.com/adamjgmiller/adamsreview