### PR TITLE
Add founder-os plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [founder-os](./plugins/founder-os)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/plugins/founder-os/.claude-plugin/plugin.json
+++ b/plugins/founder-os/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "founder-os",
+  "version": "8.2.2",
+  "description": "Multi-agent primitives for Claude Code: consensus, debate, fanout research, skill building, and measured optimization.",
+  "author": {
+    "name": "Jacob Rhinehart",
+    "email": "rhinehart514@gmail.com"
+  }
+}

--- a/plugins/founder-os/README.md
+++ b/plugins/founder-os/README.md
@@ -1,0 +1,31 @@
+# founder-os
+
+Multi-agent primitives for Claude Code: consensus, debate, fanout research, skill building, and measured optimization.
+
+## Overview
+
+`founder-os` gives Claude Code reusable coordination patterns when one pass is not enough:
+
+- `/stochastic` polls N agents with the same prompt and aggregates consensus, divergences, and outliers.
+- `/model-chat` runs a multi-agent debate room.
+- `/fanout` runs parallel research and synthesizes findings.
+- `/skillbuilder` helps create stronger Claude Code skills.
+- `/autoresearch` runs measured hill-climb optimization loops.
+
+## Install
+
+```bash
+claude plugin install rhinehart514/founder-os
+```
+
+Marketplace install:
+
+```bash
+claude plugin marketplace add rhinehart514/founder-os
+claude plugin install founder-os@founder-os
+```
+
+## Links
+
+- Repository: https://github.com/rhinehart514/founder-os
+- npm: https://www.npmjs.com/package/@rhinehart514/founder-os


### PR DESCRIPTION
Adds founder-os to Workflow Orchestration.\n\nfounder-os is a Claude Code plugin with multi-agent coordination primitives: stochastic consensus, debate rooms, fanout research, skill building, and measured optimization loops.\n\nRepo: https://github.com/rhinehart514/founder-os\nPackage: https://www.npmjs.com/package/@rhinehart514/founder-os