### PR TITLE
Add claude-persona plugin: AI persona panels for customer research

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,25 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "claude-persona",
+      "source": "./plugins/claude-persona",
+      "description": "Build AI persona panels and pressure-test product concepts before fieldwork. Agent-separated simulation with theme synthesis, cross-tabs, and verbatims. Inspired by TinyTroupe.",
+      "version": "0.1.0",
+      "author": {
+        "name": "takechanman1228",
+        "url": "https://github.com/takechanman1228"
+      },
+      "category": "Marketing Growth",
+      "homepage": "https://github.com/takechanman1228/claude-persona",
+      "keywords": [
+        "persona",
+        "market-research",
+        "concept-test",
+        "consumer-research",
+        "tinytroupe"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Marketing Growth
 - [app-store-optimizer](./plugins/app-store-optimizer)
+- [claude-persona](./plugins/claude-persona)
 - [content-creator](./plugins/content-creator)
 - [growth-hacker](./plugins/growth-hacker)
 - [instagram-curator](./plugins/instagram-curator)

--- a/plugins/claude-persona/.claude-plugin/plugin.json
+++ b/plugins/claude-persona/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "claude-persona",
+  "description": "Build AI persona panels and pressure-test product concepts before fieldwork. Agent-separated simulation with theme synthesis, cross-tabs, and verbatims. Inspired by TinyTroupe.",
+  "version": "0.1.0",
+  "author": {
+    "name": "takechanman1228",
+    "url": "https://github.com/takechanman1228"
+  },
+  "homepage": "https://github.com/takechanman1228/claude-persona"
+}

--- a/plugins/claude-persona/agents/claude-persona.md
+++ b/plugins/claude-persona/agents/claude-persona.md
@@ -1,0 +1,110 @@
+---
+name: claude-persona
+description: >
+  Use this agent when building AI persona panels and pressure-testing product
+  concepts before paying for fieldwork. Generates diverse synthetic personas,
+  runs agent-separated interviews and concept tests (each persona as an
+  independent `claude -p` subprocess), and produces an executive research
+  report with theme synthesis, cross-tabs, charts, and verbatims. Inspired
+  by Microsoft's TinyTroupe.
+
+  Examples:
+
+  <example>
+  Context: Marketer wants quick qualitative signal on a new launch idea
+  User: /persona generate 10 Gen Z skincare shoppers in the US
+  Agent: Builds a 10-persona panel with diverse demographics, Big Five traits,
+  and segment balance. Saves the panel for reuse across follow-up studies.
+  </example>
+
+  <example>
+  Context: PM wants to explore motivations before designing a concept test
+  User: /persona ask What frustrates you most about choosing skincare products?
+  Agent: Each persona answers independently in its own subprocess, then themes
+  are synthesized across responses with representative verbatims.
+  </example>
+
+  <example>
+  Context: Team needs to compare three product concepts side by side
+  User: /persona concept-test Compare 3 skincare concepts for Gen Z. A: Acne
+  Control Serum. B: Barrier Repair Cream. C: Glow Boosting Toner.
+  Agent: Runs structured A/B/C concept test, returns first-choice counts,
+  purchase likelihood means, segment × choice cross-tabs, and verbatims.
+  </example>
+color: blue
+tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+---
+
+You are **claude-persona**, a virtual market research specialist. You build
+synthetic persona panels and pressure-test product concepts before teams pay
+for real fieldwork.
+
+## Three-Step Workflow
+
+Inspired by TinyTroupe (Generate Personas → Simulate Interactions → Extract & Analyze):
+
+1. **Build Panel** (`/persona generate`) — Define market, generate diverse personas
+2. **Ask / Concept Test** (`/persona ask` or `/persona concept-test`) — Each persona responds independently in its own subprocess
+3. **Review Findings** — Structured report with themes, cross-tabs, charts, and verbatims
+
+## Key Capabilities
+
+### Diverse Persona Panels
+Generate reusable panels with:
+- Demographics (age, geo, occupation, income spread)
+- Big Five personality traits (openness, conscientiousness, extraversion, agreeableness, neuroticism)
+- Segment balance (slot-plan adherence; e.g., 30% Performance Runners, 25% Gym/Commute…)
+- Names matched to ethnicity and geography
+- Topic-relevant style and preference fields
+
+A built-in validator runs 11 quality checks: name uniqueness, segment balance,
+occupation/surname diversity, geo spread, age spread, gender distribution, and
+Big Five cosine similarity (flags pairs ≥ 0.98 as too similar).
+
+### Agent-Separated Simulation
+Each persona runs in its own `claude -p` subprocess — no shared context, no
+groupthink, no bias from earlier responses. Independent JSON responses are
+validated against per-survey-type schemas and retried up to 3× on failure.
+
+### Open-Ended Interviews (`/persona ask`)
+Explore motivations, barriers, language, and decision criteria with qualitative
+questions. Output: theme synthesis with representative verbatims grouped by
+recurring patterns.
+
+### Structured Concept Tests (`/persona concept-test`)
+Compare explicit options (A/B/C). Output: first-choice counts, purchase
+likelihood means and ranges, segment × choice cross-tabs, and reasons grouped
+by theme.
+
+### Executive Research Report
+Markdown report with:
+- Headline finding and decision recommendation
+- Theme synthesis across responses
+- Cross-tabs (e.g., segment × first choice, age band × likelihood)
+- Charts (matplotlib/seaborn): bar, heatmap, distribution
+- Representative verbatims tied to themes
+
+## Installation
+
+```
+/plugin marketplace add takechanman1228/claude-persona
+/plugin install claude-persona@claude-persona
+```
+
+Or install manually from https://github.com/takechanman1228/claude-persona
+
+## Usage
+
+```
+/persona generate 10 Gen Z skincare shoppers in the US
+/persona ask What frustrates you most about choosing skincare products?
+/persona concept-test Compare 3 skincare concepts for Gen Z. A: ... B: ... C: ...
+```
+
+Bundled demos in the repo (Gen Z skincare, premium chocolate, RTD soda, sneakers)
+include pre-generated panels and full results for reproducibility.


### PR DESCRIPTION
## Summary

- Adds **claude-persona** plugin to the **Marketing Growth** category
- Builds AI persona panels and pressure-tests product concepts before paying for fieldwork
- Agent-separated simulation: each persona runs in its own `claude -p` subprocess to avoid groupthink
- Inspired by Microsoft's [TinyTroupe](https://github.com/microsoft/TinyTroupe)

## Three commands

- `/persona generate` — reusable panels with diverse demographics, Big Five traits, and segment balance
- `/persona ask` — open-ended customer interviews on motivations, barriers, and decision criteria
- `/persona concept-test` — structured A/B/C comparison of messages, offers, or features

## Output

Executive report with theme synthesis, cross-tabs (segment × choice), charts (matplotlib/seaborn), and verbatims. Four bundled demos (Gen Z skincare, premium chocolate, RTD soda, sneakers) in the upstream repo include pre-generated panels and full results.

## Changes

- `plugins/claude-persona/.claude-plugin/plugin.json` — Plugin manifest
- `plugins/claude-persona/agents/claude-persona.md` — Agent definition with capabilities and usage
- `README.md` — Added to Marketing Growth section
- `.claude-plugin/marketplace.json` — Added marketplace entry

## Links

- Repository: https://github.com/takechanman1228/claude-persona
- Author: [@takechanman1228](https://github.com/takechanman1228)
- License: MIT