### PR TITLE
Add Artel — multi-agent infrastructure plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [security-guidance](./plugins/security-guidance)
 
 ### Workflow Orchestration
+- [artel](https://github.com/NicolasPrimeau/artel) - Infrastructure for AI teams: shared semantic memory, tasks, agent-to-agent messages, and session handoffs across machines and LLM providers.
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Workflow Orchestration
 - [agent-triforce](https://github.com/ArtemioPadilla/agent-triforce) - 3-agent PM/Dev/QA system with WHO checklist methodology. Prometeo (PM), Forja (Dev), Centinela (QA) with 24 checklists, 6 skills, and auto-generated HTML dashboard.
 - [angelos-symbo](./plugins/angelos-symbo)
+- [artel](https://github.com/NicolasPrimeau/artel) - Infrastructure for AI teams: shared semantic memory, tasks, agent-to-agent messages, and session handoffs across machines and LLM providers.
 - **[claude-brain](https://github.com/toroleapinc/claude-brain)** — Sync and evolve your Claude Code brain across machines. Auto-syncs memory, skills, agents, rules, and CLAUDE.md via Git with LLM-powered semantic merge.
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.


### PR DESCRIPTION
## Summary

- Adds [Artel](https://github.com/NicolasPrimeau/artel) to the **Workflow Orchestration** section
- Artel is a Claude Code plugin + MCP server (29 tools) for AI agent fleet coordination: shared semantic memory, tasks, agent-to-agent messages, and session handoffs across machines and LLM providers
- Install: `/plugin marketplace add NicolasPrimeau/artel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)