### PR TITLE
Add click-to-mcp plugin: wrap any Click/typer CLI as MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ultrathink](./plugins/ultrathink)
 
 ### Automation DevOps
+- [click-to-mcp](./plugins/click-to-mcp)
 - [deployment-engineer](./plugins/deployment-engineer)
 - [devops-automator](./plugins/devops-automator)
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)

--- a/plugins/click-to-mcp/.claude-plugin/plugin.json
+++ b/plugins/click-to-mcp/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "click-to-mcp",
+  "description": "Use this agent when you need to expose existing CLI tools as MCP servers for AI assistants. This plugin wraps any Click/typer CLI application into a Model Context Protocol server automatically, making CLI tools accessible to Claude Code and other AI agents without manual integration.\n\n<example>\nContext: User wants to make a CLI tool available to Claude\nuser: \"I have a typer CLI that manages our deployment pipeline, can Claude use it?\"\nassistant: \"I'll use the click-to-mcp plugin to automatically wrap your typer CLI as an MCP server, making all its commands available to Claude Code.\"\n<commentary>\nWrapping CLIs as MCP servers enables AI assistants to invoke CLI commands through the standardized protocol.\n</commentary>\n</example>\n\n<example>\nContext: User needs to integrate multiple CLIs\nuser: \"We have 5 internal CLI tools that our team uses daily\"\nassistant: \"I'll use click-to-mcp to wrap all 5 CLIs as MCP servers, giving Claude Code access to your entire toolchain.\"\n<commentary>\nBatch-wrapping CLIs provides comprehensive tool access for AI-assisted development workflows.\n</commentary>\n</example>\n\n<example>\nContext: User wants to share CLI tools across the team\nuser: \"How can I make our custom CLI tools available to everyone's Claude Code?\"\nassistant: \"click-to-mcp converts your CLIs into MCP servers that can be configured in Claude Code's MCP settings, making them available to your whole team.\"\n<commentary>\nMCP server configuration can be shared across team members for consistent tool access.\n</commentary>\n</example>",
+  "version": "1.0.0",
+  "author": {
+    "name": "Coding Dev Tools"
+  },
+  "homepage": "https://github.com/Coding-Dev-Tools/click-to-mcp"
+}

--- a/plugins/click-to-mcp/agents/click-to-mcp.md
+++ b/plugins/click-to-mcp/agents/click-to-mcp.md
@@ -1,0 +1,40 @@
+Use this agent when you need to expose existing CLI tools as MCP servers for AI
+assistants. click-to-mcp automatically wraps any Click or typer CLI application into
+a Model Context Protocol (MCP) server, making all CLI commands available to Claude
+Code and other AI agents through the standardized protocol.
+
+This includes tasks like:
+- Wrapping a Click CLI as an MCP server
+- Converting typer applications to MCP servers
+- Making existing CLI tools accessible to AI coding agents
+- Integrating command-line tools into Claude Code's MCP workflow
+- Sharing CLI tools across a team via MCP server configuration
+
+Examples:
+
+- <example>
+  Context: User wants to make a CLI tool available to Claude
+  user: "I have a typer CLI that manages our deployment pipeline, can Claude use it?"
+  assistant: "I'll use the click-to-mcp plugin to automatically wrap your typer CLI as an MCP server, making all its commands available to Claude Code."
+  <commentary>
+  Wrapping CLIs as MCP servers enables AI assistants to invoke CLI commands through the standardized protocol.
+  </commentary>
+  </example>
+
+- <example>
+  Context: User needs to integrate multiple CLIs
+  user: "We have 5 internal CLI tools that our team uses daily"
+  assistant: "I'll use click-to-mcp to wrap all 5 CLIs as MCP servers, giving Claude Code access to your entire toolchain."
+  <commentary>
+  Batch-wrapping CLIs provides comprehensive tool access for AI-assisted development workflows.
+  </commentary>
+  </example>
+
+- <example>
+  Context: User wants to share CLI tools across the team
+  user: "How can I make our custom CLI tools available to everyone's Claude Code?"
+  assistant: "click-to-mcp converts your CLIs into MCP servers that can be configured in Claude Code's MCP settings, making them available to your whole team."
+  <commentary>
+  MCP server configuration can be shared across team members for consistent tool access.
+  </commentary>
+  </example>


### PR DESCRIPTION
## click-to-mcp — Auto-wrap CLIs as MCP Servers

This plugin adds [click-to-mcp](https://github.com/Coding-Dev-Tools/click-to-mcp) to the Automation DevOps section.

### What it does
click-to-mcp automatically wraps any Click or typer CLI application into a Model Context Protocol (MCP) server. This makes CLI tools accessible to Claude Code and other AI agents through the standardized protocol — no manual integration needed.

### Why it fits this list
- **MCP Server**: Directly provides MCP server functionality for Claude Code
- **DevOps use case**: Teams can expose their deployment, infrastructure, and ops CLIs to AI assistants
- **Zero-config**: Auto-discovers CLI commands and exposes them as MCP tools

### Plugin structure
Follows the established format:
- `plugins/click-to-mcp/.claude-plugin/plugin.json` — Plugin metadata with description and examples
- `plugins/click-to-mcp/agents/click-to-mcp.md` — Agent instructions with usage examples
- Listed in README under **Automation DevOps** section

### Links
- GitHub: https://github.com/Coding-Dev-Tools/click-to-mcp
- Install: `pip install click-to-mcp` or `brew tap Coding-Dev-Tools/tap && brew install click-to-mcp`