### PR TITLE
Add Espresso plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [security-guidance](./plugins/security-guidance)
 
 ### Workflow Orchestration
+- [espresso](https://github.com/mirkobozzetto/espresso) - Full token-saving stack. Output compression, global rules, RTK, Caveman, GitNexus auto-config. Detects existing setup, installs only what's missing.
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)


### PR DESCRIPTION
Adds Espresso to Workflow Orchestration section.

Full token-saving stack in one plugin - output compression, global rules, RTK hook, Caveman ultra, GitNexus auto-config. Detection-first: installs only what's missing.

Repo: https://github.com/mirkobozzetto/espresso
License: MIT