### PR TITLE
Add Thoth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
 - [studio-coach](./plugins/studio-coach)
+- [thoth](./plugins/thoth)
 - [ultrathink](./plugins/ultrathink)
 
 ### Automation DevOps

--- a/plugins/thoth/.claude-plugin/plugin.json
+++ b/plugins/thoth/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "thoth",
+  "version": "0.2.0",
+  "description": "Dashboard-centric Agent Project OS for auditable AI execution, persistent project state, and human-visible workflow orchestration.",
+  "author": {
+    "name": "SeeleAI",
+    "url": "https://github.com/SeeleAI"
+  },
+  "homepage": "https://github.com/SeeleAI/Thoth",
+  "repository": "https://github.com/SeeleAI/Thoth",
+  "license": "MIT",
+  "keywords": [
+    "research",
+    "project-management",
+    "dashboard",
+    "autonomous",
+    "audit",
+    "execution"
+  ]
+}

--- a/plugins/thoth/LICENSE
+++ b/plugins/thoth/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 SeeleAI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/thoth/README.md
+++ b/plugins/thoth/README.md
@@ -1,0 +1,285 @@
+[English](./README.md) | [简体中文](./README.zh-CN.md)
+
+<div align="center">
+  <h1>🐦 Thoth — Dashboard-First Runtime for Autoresearch</h1>
+  <img src="assets/thoth.png" width="80%" alt="Thoth logo" />
+  <p><strong>Dashboard-first orchestration runtime for autoresearch.</strong></p>
+  <p>Turn drifting agent work into durable runs, locked work items, and reviewable verdicts.</p>
+  <p>
+    <img alt="Runtime Dashboard First" src="https://img.shields.io/badge/runtime-dashboard--first-4B5563?style=for-the-badge&labelColor=3F3F46&color=0F766E" />
+    <img alt="Mode Autoresearch" src="https://img.shields.io/badge/mode-autoresearch-4B5563?style=for-the-badge&labelColor=3F3F46&color=B45309" />
+    <img alt="Engine Orchestration" src="https://img.shields.io/badge/engine-orchestration-4B5563?style=for-the-badge&labelColor=3F3F46&color=2563EB" />
+    <img alt="Trust Work Locked" src="https://img.shields.io/badge/trust-work--locked-4B5563?style=for-the-badge&labelColor=3F3F46&color=6D28D9" />
+  </p>
+  <p>
+    <img alt="Claude Code Plugin" src="https://img.shields.io/badge/Claude%20Code-plugin-4B5563?style=flat-square&labelColor=3F3F46&color=0284C7" />
+    <img alt="Codex Plugin" src="https://img.shields.io/badge/Codex-plugin-4B5563?style=flat-square&labelColor=3F3F46&color=65A30D" />
+    <img alt="Ready Work --work-id" src="https://img.shields.io/badge/work-strict%20--work--id-4B5563?style=flat-square&labelColor=3F3F46&color=7C3AED" />
+    <img alt="Version 0.2.0" src="https://img.shields.io/badge/version-0.2.0-4B5563?style=flat-square&labelColor=3F3F46&color=0369A1" />
+    <img alt="License MIT" src="https://img.shields.io/badge/license-MIT-4B5563?style=flat-square&labelColor=3F3F46&color=84CC16" />
+  </p>
+  <h2>🚀 What's New</h2>
+  <p><strong>v0.2.0 stable release</strong> · compact work-item authority with <code>work_id</code> · Claude Code and Codex plugin parity</p>
+  <img src="assets/thoth-teaser-figure-v2.png" width="100%" alt="Thoth concept banner" />
+</div>
+
+## Control Plane At A Glance
+
+```text
+                               THOTH CONTROL PLANE
+
+                    Claude Code surfaces      Codex surfaces
+                 /thoth:* command set        $thoth command set
+                              \                 /
+                               \               /
+                                +-------------+
+                                              |
+                                              v
+
++----------------------------------------------------------------------------+
+| Layer 1. Host Surface                                                      |
+|                                                                            |
+|  init   discuss   run   loop   review   auto   status                      |
+|  doctor dashboard                                                       |
++----------------------------------------------------------------------------+
+                                              |
+                                              v
++----------------------------------------------------------------------------+
+| Layer 2. Planning Authority                                                |
+|                                                                            |
+|  init      -> bootstrap, migrate, or resync .thoth authority               |
+|  discuss   -> record discussions, decisions, and work items                |
+|                                                                            |
+|  Discuss -> Decision -> Work Item Object Graph                             |
+|                                         |                                  |
+|                                         v                                  |
+|                               Ready Work (--work-id)                      |
++----------------------------------------------------------------------------+
+                                              |
+                                              v
++----------------------------------------------------------------------------+
+| Layer 3. Execution Runtime                                                 |
+|                                                                            |
+|  run      -> one durable execution packet                                  |
+|  loop     -> one durable recoverable loop packet                           |
+|  review   -> structured findings through the same protocol                 |
+|  auto     -> priority-driven child loops for actionable work               |
+|                                                                            |
+|                           +---------------------------+                    |
+|                           | Ready Work (--work-id)   |                    |
+|                           +-------------+-------------+                    |
+|                                         |                                  |
+|                              +----------+----------+                       |
+|                              |                     |                       |
+|                              v                     v                       |
+|                            Run                   Loop                      |
+|                              |                     |                       |
+|                              +----------+----------+                       |
+|                                         |                                  |
+|                                         v                                  |
+|                 Run Ledger / Events / Artifacts / Result                   |
+|                                         |                                  |
+|                                         v                                  |
+|                  Mechanical Validation / Acceptance                        |
+|                                                                            |
+|  attach   watch   resume   stop                                            |
++----------------------------------------------------------------------------+
+                                              |
+                                              v
++----------------------------------------------------------------------------+
+| Layer 4. Read Surfaces                                                     |
+|                                                                            |
+|  dashboard -> human-visible runtime workbench                              |
+|  status    -> active / stale / attachable run summaries                    |
+|  doctor    -> strict health, projection, and runtime-shape audit           |
+|  report    -> available through status --report                           |
+|                                                                            |
+|                     +-----------+-----------+-----------+-----------+      |
+|                     |           |           |           |                  |
+|                     v           v           v           v                  |
+|                 Dashboard    Status      Report      Doctor                |
++----------------------------------------------------------------------------+
+
+Key invariants:
+- .thoth is the shared machine/runtime authority
+- .agent-os is the human governance layer
+- run and loop are strict --work-id surfaces
+- auto executes only actionable ready/active/failed work; blocked and draft work require human decisions
+- dashboard, status, report, and doctor are read surfaces, not authority writers
+- run, loop, and auto progress through the RuntimeDriver until terminal or paused
+```
+
+## Why Thoth
+
+Thoth is a dashboard-first orchestration runtime for autoresearch. It assumes chat alone is not an operating system: truth must survive the session, progress must stay visible, and completion must be mechanically testable.
+
+## Failure Modes Table
+
+| Problem | Why it matters |
+| --- | --- |
+| Work is not persistent | Long-running work dies with the session, so the agent cannot keep working while you sleep and there is no durable state to resume or audit. |
+| Parallel work is invisible | Multiple threads or delegated runs drift apart, and humans cannot see what is actually active. |
+| Agents can claim completion too early | A fluent summary can hide that nothing mechanical passed. |
+| Docs and state rot over time | Discussions, decisions, work items, and runtime facts drift until nobody knows which layer is authoritative. |
+
+## Thoth Response Table
+
+| Mechanism | What it does | Counters |
+| --- | --- | --- |
+| Hooks + watchdog + runtime | Keep execution attached to durable ledgers and observable lifecycle events. | Work is not persistent |
+| Dashboard-first visibility | Show live, stale, attachable, and host-specific runtime truth in one read surface. | Parallel work is invisible |
+| Mechanical yes/no acceptance | Force validators, ledgers, and result payloads to decide whether work really passed. | Agents can claim completion too early |
+| Object graph + execution system + locked work items | Freeze what is allowed, compile it into runnable work items, and keep authority layers from drifting. | Docs and state rot over time |
+
+## System At A Glance
+
+Humans should not spend their attention tracking every grain of sand in the funnel. Thoth lets AI own the middle of the hourglass, while the dashboard shows the gold that survives: decisions, work items, runs, results, and the current verdict.
+
+## Architecture Flow Table
+
+| Stage | Purpose | Input | Output |
+| --- | --- | --- | --- |
+| Intent | Capture the user request and operating boundary. | Human goals, constraints, repo context | Direction for planning |
+| Decision | Lock key choices before execution drifts. | Intent, open questions, policy constraints | Recorded decisions |
+| Work Item | Freeze goal, constraints, execution plan, eval, runtime policy, and decisions. | Discussion, decisions, requirements, acceptance rules | Ready or blocked work item |
+| Run | Execute one frozen `work_id@revision` through phase results. | Work item, controller policy, host surface | `.thoth/objects/run` plus `.thoth/runs/<run_id>` ledger |
+| Result | Produce a mechanical verdict instead of narration alone. | Validator outputs, artifacts, runtime checks | Structured result and acceptance evidence |
+| Dashboard | Let humans read the final state without replaying the chat. | Ledgers, read models, derived summaries | Inspectable project truth |
+
+## Quick Start
+
+1. Install Thoth on the host surfaces you use.
+
+```bash
+claude plugin marketplace add SeeleAI/Thoth --scope user
+claude plugin install thoth@thoth --scope user
+codex plugin marketplace add SeeleAI/Thoth
+```
+
+For Codex, adding the marketplace is the source step. Then install or enable the `thoth` plugin from the Codex plugin directory.
+
+After the plugin is installed, two different entry layers exist on purpose:
+
+- Public plugin surface: `Claude /thoth:*`, `Codex $thoth <command>`, and the plugin-provided shell wrapper `thoth <command>`
+- Source-repo development fallback: `python -m thoth.cli <command>`
+
+Use the plugin-installed `thoth` wrapper in fresh repos or empty directories. Use `python -m thoth.cli` only when you are intentionally running against a checked-out Thoth source tree and want execution pinned to that exact checkout.
+
+2. Initialize the repository you want Thoth to manage.
+
+```text
+/thoth:init
+$thoth init
+```
+
+3. Start the first strict run from a compiled task.
+
+```text
+/thoth:run --work-id task-1
+$thoth run --work-id task-1
+```
+
+4. Open the read surface.
+
+```text
+/thoth:dashboard
+$thoth dashboard
+```
+
+## Host Install And Upgrade
+
+| Host | First install | Stable upgrade | Important note |
+| --- | --- | --- | --- |
+| Claude Code | `claude plugin marketplace add SeeleAI/Thoth --scope user` then `claude plugin install thoth@thoth --scope user` | `claude plugin marketplace update thoth` then `claude plugin update thoth@thoth --scope user` | Restart Claude Code after `plugin update` so the new version is applied. |
+| Codex | `codex plugin marketplace add SeeleAI/Thoth`, then install or enable `thoth` from the Codex plugin directory | `codex plugin marketplace upgrade thoth` | `add` takes a source such as `SeeleAI/Thoth`; `upgrade` takes the configured marketplace name, which is `thoth` in this repo. |
+
+## Verification
+
+Default development verification is intentionally targeted-only. Broad or full sweeps are not the normal workflow.
+
+### Atomic selftest
+
+- The public selftest entrypoint is now atomic-only:
+
+```bash
+python -m thoth.selftest --case plan.discuss.compile --case runtime.run.live
+```
+
+- `python -m thoth.selftest` without any `--case` fails on purpose and prints the available case catalog.
+- Every case runs in its own workdir and artifact directory, writes a per-case report entry keyed by `case_id`, and must not depend on side effects from an earlier case.
+- Release, regression, and closeout gates must record explicit case IDs instead of broad aliases such as `hard` or `heavy`.
+- The current catalog is split into repo-local capability probes such as `plan.discuss.compile`, `runtime.run.live`, `runtime.loop.sleep`, `review.exact_match`, `observe.dashboard`, `hooks.codex`, plus host-surface probes such as `surface.codex.run.live_prepare` and `surface.claude.loop.stop`.
+
+### Targeted pytest
+
+- Allowed developer entrypoints:
+
+```bash
+python -m pytest -q tests/unit/test_selftest_registry.py
+python -m pytest -q tests/unit/test_selftest_helpers.py::test_validate_pytest_invocation
+python -m pytest -q --thoth-target selftest-core
+```
+
+- Blocked by default: bare `pytest`, directory-wide invocations such as `pytest tests/unit`, and broad tier sweeps such as `pytest --thoth-tier heavy`.
+- Broad runs are reserved for explicit release or CI situations and require `--thoth-allow-broad` or `THOTH_ALLOW_BROAD_TESTS=1`.
+- `--thoth-tier` is retained only as an explicit override path for those exempted broad runs; it is not the default development interface.
+- The target manifest lives in `thoth/test_targets.py`.
+- Use the helper below to translate changed paths into recommended pytest targets and atomic selftest cases:
+
+```bash
+python scripts/recommend_tests.py thoth/observe/selftest/runner.py tests/conftest.py
+```
+
+## Command Matrix
+
+| Command | Host Surface | Purpose | Input | Result |
+| --- | --- | --- | --- | --- |
+| `init` | `Claude: /thoth:init`<br>`Codex: $thoth init` | Audit, initialize, migrate, or resync canonical Thoth authority. | `--sync`, `--migrate preview`, `--migrate apply`, `--migrate --preview`, `--migrate --apply`, or optional config payload | `.thoth` authority, migration ledger, generated projections, dashboard scaffolding, scripts, and tests |
+| `discuss` | `Claude: /thoth:discuss`<br>`Codex: $thoth discuss` | Record planning decisions without entering code execution. | Topic, decision payload, or work payload | Updated discussion, decision, or work_item objects plus generated docs view |
+| `run` | `Claude: /thoth:run`<br>`Codex: $thoth run` | Execute one ready work item through a durable runtime packet. | `--work-id`, optional host or executor controls, optional attach/watch/stop | Durable run ledger with state, events, phase results, artifacts, and terminal result |
+| `loop` | `Claude: /thoth:loop`<br>`Codex: $thoth loop` | Iterate on one ready work item through a controller service. | `--work-id`, optional resume or sleep controls | Controller object, child run lineage, and bounded iteration history |
+| `review` | `Claude: /thoth:review`<br>`Codex: $thoth review` | Produce structured findings without modifying source code. | Review target, optional `--work-id`, optional executor controls | Structured review result recorded through the shared protocol |
+| `auto` | `Claude: /thoth:auto`<br>`Codex: $thoth auto` | Run the priority queue while the user is away. | Optional `--sleep`, `--rounds`, `--scope`, or explicit `--work-id` | Auto controller, child loop lineage, monitor events, and terminal or paused summary |
+| `status` | `Claude: /thoth:status`<br>`Codex: $thoth status` | Show project health, active durable runs, doctor, report, or dashboard views. | Optional `--json`, `--doctor`, `--report`, or `--dashboard` | Shared status snapshot and read-only derived views |
+| `doctor` | `Claude: /thoth:doctor`<br>`Codex: $thoth doctor` | Alias for `status --doctor`; strictly audit health and runtime shape. | Optional `--quick` or `--json` | Health report with validation findings |
+| `dashboard` | `Claude: /thoth:dashboard`<br>`Codex: $thoth dashboard` | Alias for `status --dashboard`; manage the local dashboard runtime. | Optional action: `start`, `stop`, or `rebuild` | Local dashboard process and read endpoints backed by `.thoth` ledgers |
+
+## Why Trust It
+
+| Signal | What you can inspect |
+| --- | --- |
+| Durable runtime truth | `.thoth/runs/*` keeps run, state, events, artifacts, and result payloads. |
+| Locked planning authority | ``.thoth/objects/discussion/`, `.thoth/objects/decision/`, and `.thoth/objects/work_item/` define what execution is allowed to do. |
+| Script-backed verification | Validators, doctor checks, and selftests decide pass or fail mechanically. |
+| Shared read model | `status`, `report`, and `dashboard` all read from the same authority instead of chat memory. |
+
+## Who It Is For
+
+| Good fit | Why |
+| --- | --- |
+| Research and experimentation repos | They need durable memory, replayable results, and visible long-running work. |
+| Engineering teams using AI for real changes | They need code execution, review, and acceptance to stay auditable. |
+| Teams that want Claude Code and Codex parity | They need one host-neutral command model rather than two drifting workflows. |
+
+## Current Limitations
+
+| Current boundary | Implication |
+| --- | --- |
+| `run` and `loop` are strict `--work-id` surfaces | Free-form execution is intentionally rejected. |
+| Host parity is semantic, not identical UX | Claude and Codex still need their own install and local runtime wiring. |
+| Dashboard is a local service, not a hosted control plane | Operators need a machine that can run the backend and frontend assets. |
+| The hero logo currently ships as a raster PNG | A clean SVG and icon-family refinement is still useful for smaller surfaces and plugin packaging. |
+
+---
+
+## Contributors
+
+Built in public by contributors who want AI work to remain inspectable.
+
+[![Contributors](https://contrib.rocks/image?repo=SeeleAI/Thoth)](https://github.com/SeeleAI/Thoth/graphs/contributors)
+
+Contribution path: [open a pull request](https://github.com/SeeleAI/Thoth/pulls) or [start a discussion](https://github.com/SeeleAI/Thoth/discussions).
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/plugins/thoth/commands/auto.md
+++ b/plugins/thoth/commands/auto.md
@@ -1,0 +1,64 @@
+---
+name: thoth:auto
+description: Run the highest-priority actionable work queue until ready/active/failed work is closed, paused, or stopped.
+argument-hint: "[--sleep] [--rounds <n>] [--scope all-open|ready|priority-top] [--work-id <work_id> ...] [--watch <controller_id>] [--stop <controller_id>]"
+disable-model-invocation: false
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash, Task, Monitor
+---
+
+# /thoth:auto
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" auto --host claude $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this command invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If `run` or `loop` is missing `--work-id`, show the returned candidate work items exactly as provided and stop.
+- If `run` or `loop` is missing `--work-id`, do not invent, create, compile, or guess a work item.
+- If `bridge_success` is `true` and runtime events are present, summarize progress, terminal status, and risk from those events only.
+- Do not hand-edit `.thoth` or manually call runtime protocol commands; the Thoth RuntimeDriver advances phases.
+- If `packet.dispatch_mode` is `external_worker`, do not duplicate the work locally; report the run id, worker mode, and the correct follow-up only.
+- If you only describe what should happen next instead of reporting the executed runtime result, treat that as failure.
+- If `packet.executor == codex`, the substantive execution must really flow through Codex rather than being silently done by Claude.
+- Runtime lifecycle is `plan -> execute -> validate -> reflect`; auto runs selected work through child loops.
+- Prefer running `packet.strict_task.eval_entrypoint.command` exactly as provided rather than inventing a parallel validator lifecycle.
+- If the bridge payload exposes `body.monitor_command`, observe that command instead of executing work directly in the Claude session.
+- Prefer the Claude Monitor tool with `persistent=true` for `body.monitor_command` when available; otherwise use Bash to run the same watch command in the foreground.
+- Treat the monitor/watch JSONL stream as the only live progress authority; summarize progress and risks from those events only.
+- If the live observer is interrupted, do not stop the auto controller unless the user explicitly requests `/thoth:auto --stop <controller_id>`.
+
+## Authority Summary
+
+### Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `phase_controller`
+
+### Objective
+
+Run actionable work items by scheduling priority through child loops until none remain, budget pauses, or stop is requested.
+
+### Hard Stops
+
+- Do not execute blocked or draft work.
+- Do not auto-abandon work items.
+- Do not bypass execution-safety doctor preflight.
+
+### Reply Contract
+
+- reply_budget_utf8: `120`
+- result_style: start or reuse the durable controller, then stream JSONL watch events until terminal or observer interruption
+- validator_policy: controller cursor, child loop results, and auto watch events define queue state

--- a/plugins/thoth/commands/dashboard.md
+++ b/plugins/thoth/commands/dashboard.md
@@ -1,0 +1,55 @@
+---
+name: thoth:dashboard
+description: Alias for `status --dashboard`; manage the local dashboard backed by .thoth ledgers.
+argument-hint: "[start|stop|rebuild]"
+disable-model-invocation: true
+---
+
+# /thoth:dashboard
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" dashboard $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If stdout starts with `version=`, repeat stdout exactly and output nothing else.
+- If `bridge_success` is `true`, report only the real command result in one short receipt.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the bridge payload.
+- Do not launch broad Explore, Task, cache/source scans, or background investigation after the bridge result.
+- If the result exposes blockers or asks for human decisions, use AskUserQuestion to ask only the unresolved questions and stop.
+- Do not expand into runtime explanation, walkthroughs, or extra command execution.
+
+## Authority Summary
+
+### Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+### Objective
+
+Report endpoint, failure point, and one notable runtime delta only.
+
+### Hard Stops
+
+- Do not narrate the whole UI.
+- Do not restate healthy panels.
+
+### Reply Contract
+
+- reply_budget_utf8: `56`
+- result_style: brief operator receipt
+- validator_policy: dashboard is read-only over .thoth ledgers

--- a/plugins/thoth/commands/discuss.md
+++ b/plugins/thoth/commands/discuss.md
@@ -1,0 +1,69 @@
+---
+name: thoth:discuss
+description: Discuss or record planning decisions without entering implementation execution.
+argument-hint: "<topic>"
+disable-model-invocation: false
+---
+
+# /thoth:discuss
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+THOTH_DISCUSS_ARGUMENTS_FILE="$(mktemp -t thoth-discuss-arguments.XXXXXX)"
+trap 'rm -f "$THOTH_DISCUSS_ARGUMENTS_FILE"' EXIT
+cat > "$THOTH_DISCUSS_ARGUMENTS_FILE" <<'THOTH_DISCUSS_ARGUMENTS_EOF'
+$ARGUMENTS
+THOTH_DISCUSS_ARGUMENTS_EOF
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" discuss --thoth-arguments-file "$THOTH_DISCUSS_ARGUMENTS_FILE"
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this command invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If `run` or `loop` is missing `--work-id`, show the returned candidate work items exactly as provided and stop.
+- If `run` or `loop` is missing `--work-id`, do not invent, create, compile, or guess a work item.
+- If `bridge_success` is `true` and runtime events are present, summarize progress, terminal status, and risk from those events only.
+- Do not hand-edit `.thoth` or manually call runtime protocol commands; the Thoth RuntimeDriver advances phases.
+- If `packet.dispatch_mode` is `external_worker`, do not duplicate the work locally; report the run id, worker mode, and the correct follow-up only.
+- If you only describe what should happen next instead of reporting the executed runtime result, treat that as failure.
+- Use AskUserQuestion until goals, non-goals, constraints, accepted decisions, rejected options, acceptance, context evidence, risks, run instructions, and open questions are explicit.
+- On major semantic changes, write a draft authority checkpoint through `packet.protocol_commands.checkpoint_authority`.
+- When no material assumptions remain, write a semantic-lossless closure through `packet.protocol_commands.close_authority`.
+- Do not create ready work if any open_questions remain in the authority capsule.
+
+## Authority Summary
+
+### Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `command_packet`
+
+### Objective
+
+Interrogate the user's idea until goals, constraints, success criteria, risks, and authority are explicit; preserve semantic decisions as draft checkpoints and close only when no material assumptions remain.
+
+### Hard Stops
+
+- Do not modify source code.
+- Do not assume unanswered goals, constraints, success metrics, resources, timing, or authority.
+- Ask about every material ambiguity; use AskUserQuestion and continue discussion until no meaningful assumptions remain.
+- When a major semantic decision changes, checkpoint a compact authority event through the packet protocol command.
+- When closing, translate the discussion into semantic-lossless authority: goal, non-goals, constraints, accepted decisions, rejected options, acceptance, context evidence, risks, run instructions, and open questions.
+- Do not fabricate ready execution work items from unresolved decisions.
+- Do not repeat the packet or decision payload verbatim.
+
+### Reply Contract
+
+- reply_budget_utf8: `240`
+- result_style: question-driven planning dialogue or brief receipt when closed
+- validator_policy: planning authority plus compiler output decide completion

--- a/plugins/thoth/commands/doctor.md
+++ b/plugins/thoth/commands/doctor.md
@@ -1,0 +1,58 @@
+---
+name: thoth:doctor
+description: Alias for `status --doctor`; strictly audit project health without writing authority.
+argument-hint: "[--quick] [--json] [--fix preview|apply] [--version]"
+disable-model-invocation: true
+---
+
+# /thoth:doctor
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" doctor $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If stdout starts with `version=`, repeat stdout exactly and output nothing else.
+- If `bridge_success` is `true`, report only the real command result in one short receipt.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the bridge payload.
+- Do not launch broad Explore, Task, cache/source scans, or background investigation after the bridge result.
+- If the result exposes blockers or asks for human decisions, use AskUserQuestion to ask only the unresolved questions and stop.
+- Do not expand into runtime explanation, walkthroughs, or extra command execution.
+
+## Authority Summary
+
+### Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+### Objective
+
+Report only failing, drifting, missing checks, and any user decisions required to unblock authority.
+
+### Hard Stops
+
+- Do not pad with passing checks.
+- Do not claim repo health without checks.
+- Do not launch broad Explore, Task, plugin-cache/source scans, or background investigation after the doctor result.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the doctor payload.
+- If work items are blocked or migration decisions are unresolved, ask with AskUserQuestion instead of guessing or fixing.
+
+### Reply Contract
+
+- reply_budget_utf8: `64`
+- result_style: brief defect receipt
+- validator_policy: authority and generated surfaces decide health

--- a/plugins/thoth/commands/init.md
+++ b/plugins/thoth/commands/init.md
@@ -1,0 +1,59 @@
+---
+name: thoth:init
+description: Initialize, migrate, or resync canonical .thoth authority without taking ownership of repo-root `.codex`.
+argument-hint: "[--sync] [--migrate preview|apply] [--migrate --preview|--apply]"
+disable-model-invocation: true
+---
+
+# /thoth:init
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" init $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If stdout starts with `version=`, repeat stdout exactly and output nothing else.
+- If `bridge_success` is `true`, report only the real command result in one short receipt.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the bridge payload.
+- Do not launch broad Explore, Task, cache/source scans, or background investigation after the bridge result.
+- If the result exposes blockers or asks for human decisions, use AskUserQuestion to ask only the unresolved questions and stop.
+- Do not expand into runtime explanation, walkthroughs, or extra command execution.
+
+## Authority Summary
+
+### Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+### Objective
+
+Report audit-first adopt/init outcome, generated artifacts, blockers, and user decisions required before continuing.
+
+### Hard Stops
+
+- Do not assume the repo is blank.
+- Do not assume goals, project identity, migration intent, work priority, unblock policy, or acceptance criteria.
+- Do not launch broad Explore, Task, plugin-cache/source scans, or background investigation after the init result.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the init payload.
+- If the preview/apply result leaves blocked work or unresolved migration choices, ask with AskUserQuestion and stop.
+- Do not narrate the full migration procedure.
+
+### Reply Contract
+
+- reply_budget_utf8: `60`
+- result_style: brief outcome receipt
+- validator_policy: preview and generated artifacts define success

--- a/plugins/thoth/commands/loop.md
+++ b/plugins/thoth/commands/loop.md
@@ -1,0 +1,62 @@
+---
+name: thoth:loop
+description: Start one bounded controller service whose parent creates four-phase child runs.
+argument-hint: "[--executor claude|codex] [--host claude|codex] [--sleep] [--attach <run_id>] [--resume <run_id>] [--watch <run_id>] [--stop <run_id>] --work-id <work_id>"
+disable-model-invocation: false
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash, Task
+---
+
+# /thoth:loop
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" loop --host claude $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this command invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If `run` or `loop` is missing `--work-id`, show the returned candidate work items exactly as provided and stop.
+- If `run` or `loop` is missing `--work-id`, do not invent, create, compile, or guess a work item.
+- If `bridge_success` is `true` and runtime events are present, summarize progress, terminal status, and risk from those events only.
+- Do not hand-edit `.thoth` or manually call runtime protocol commands; the Thoth RuntimeDriver advances phases.
+- If `packet.dispatch_mode` is `external_worker`, do not duplicate the work locally; report the run id, worker mode, and the correct follow-up only.
+- If you only describe what should happen next instead of reporting the executed runtime result, treat that as failure.
+- If `packet.executor == codex`, the substantive execution must really flow through Codex rather than being silently done by Claude.
+- Runtime lifecycle is `plan -> execute -> validate -> reflect`; auto runs selected work through child loops.
+- Prefer running `packet.strict_task.eval_entrypoint.command` exactly as provided rather than inventing a parallel validator lifecycle.
+- Use `packet.strict_task.goal_statement`, `packet.strict_task.authority_context`, `packet.strict_task.implementation_recipe`, and `packet.strict_task.eval_entrypoint` as the only task authority.
+- If plan reports `authority_complete=false` or `reason=needs_input`, stop and route the user back to `/thoth:discuss` instead of guessing.
+
+## Authority Summary
+
+### Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `phase_controller`
+
+### Objective
+
+Advance the current bounded loop through foreground or sleeping RuntimeDriver monitoring.
+
+### Hard Stops
+
+- Do not decide extra iterations outside the recorded loop budget.
+- Do not skip validator output when judging success.
+- Do not expand into iteration diaries or runtime narration.
+
+### Reply Contract
+
+- reply_budget_utf8: `40`
+- result_style: terminal receipt only
+- validator_policy: parent loop budget controls retries; each child runs plan -> execute -> validate -> reflect

--- a/plugins/thoth/commands/review.md
+++ b/plugins/thoth/commands/review.md
@@ -1,0 +1,61 @@
+---
+name: thoth:review
+description: Prepare a structured live review packet through the shared Thoth surface.
+argument-hint: "[--executor claude|codex] [--host claude|codex] [--work-id <work_id>] <target>"
+disable-model-invocation: false
+allowed-tools: Read, Glob, Grep, Bash, Task
+---
+
+# /thoth:review
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" review --host claude $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this command invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If `run` or `loop` is missing `--work-id`, show the returned candidate work items exactly as provided and stop.
+- If `run` or `loop` is missing `--work-id`, do not invent, create, compile, or guess a work item.
+- If `bridge_success` is `true` and runtime events are present, summarize progress, terminal status, and risk from those events only.
+- Do not hand-edit `.thoth` or manually call runtime protocol commands; the Thoth RuntimeDriver advances phases.
+- If `packet.dispatch_mode` is `external_worker`, do not duplicate the work locally; report the run id, worker mode, and the correct follow-up only.
+- If you only describe what should happen next instead of reporting the executed runtime result, treat that as failure.
+- For `review`, inspect `packet.target`, produce structured findings matching `packet.required_review_shape`, and finish through the review protocol rather than free-form prose.
+- If `packet.review_mode` is `exact_match`, reproduce that exact structured result and do not add prose or extra findings.
+- If `packet.protocol_commands.complete_exact` exists, execute that exact completion command rather than deriving your own variant.
+
+## Authority Summary
+
+### Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `review_packet`
+
+### Objective
+
+Produce the best possible review output: understand user intent, apply professional judgment and first-principles reasoning, and return structured findings without modifying code.
+
+### Hard Stops
+
+- Do not modify project code or write fixes.
+- Do not reduce the review to a checklist; infer the user's intent from evidence and reason from first principles.
+- If the target, intent, or acceptance bar is ambiguous, ask with AskUserQuestion before judging instead of assuming.
+- If review_expectation or complete_exact exists, follow it exactly.
+
+### Reply Contract
+
+- reply_budget_utf8: `160`
+- result_style: short summary plus structured findings
+- validator_policy: exact-match route is protocol_fast; open-ended route stays live but still structured

--- a/plugins/thoth/commands/run.md
+++ b/plugins/thoth/commands/run.md
@@ -1,0 +1,62 @@
+---
+name: thoth:run
+description: Start one strict run bound to `work_id@revision`; live runs foreground and `--sleep` detaches the same runtime driver.
+argument-hint: "[--executor claude|codex] [--host claude|codex] [--sleep] [--attach <run_id>] [--watch <run_id>] [--stop <run_id>] --work-id <work_id>"
+disable-model-invocation: false
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash, Task
+---
+
+# /thoth:run
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" run --host claude $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this command invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If `run` or `loop` is missing `--work-id`, show the returned candidate work items exactly as provided and stop.
+- If `run` or `loop` is missing `--work-id`, do not invent, create, compile, or guess a work item.
+- If `bridge_success` is `true` and runtime events are present, summarize progress, terminal status, and risk from those events only.
+- Do not hand-edit `.thoth` or manually call runtime protocol commands; the Thoth RuntimeDriver advances phases.
+- If `packet.dispatch_mode` is `external_worker`, do not duplicate the work locally; report the run id, worker mode, and the correct follow-up only.
+- If you only describe what should happen next instead of reporting the executed runtime result, treat that as failure.
+- If `packet.executor == codex`, the substantive execution must really flow through Codex rather than being silently done by Claude.
+- Runtime lifecycle is `plan -> execute -> validate -> reflect`; auto runs selected work through child loops.
+- Prefer running `packet.strict_task.eval_entrypoint.command` exactly as provided rather than inventing a parallel validator lifecycle.
+- Use `packet.strict_task.goal_statement`, `packet.strict_task.authority_context`, `packet.strict_task.implementation_recipe`, and `packet.strict_task.eval_entrypoint` as the only task authority.
+- If plan reports `authority_complete=false` or `reason=needs_input`, stop and route the user back to `/thoth:discuss` instead of guessing.
+
+## Authority Summary
+
+### Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `phase_controller`
+
+### Objective
+
+Finish the current strict task through the four-phase RuntimeDriver.
+
+### Hard Stops
+
+- Do not invent or compile a new work item when --work-id is missing.
+- Do not stop after starting the runtime; monitor RuntimeDriver events until terminal.
+- Do not hand-edit .thoth ledgers.
+
+### Reply Contract
+
+- reply_budget_utf8: `36`
+- result_style: terminal receipt only
+- validator_policy: plan first, validate decides completion, reflect always summarizes evidence and risk

--- a/plugins/thoth/commands/status.md
+++ b/plugins/thoth/commands/status.md
@@ -1,0 +1,55 @@
+---
+name: thoth:status
+description: Show repo status and active durable runs from the shared ledger.
+argument-hint: "[--json] [--doctor] [--report] [--dashboard start|stop|rebuild]"
+disable-model-invocation: true
+---
+
+# /thoth:status
+
+## Generated Surface
+
+This file is generated from `thoth.command_specs.COMMAND_SPECS`. Do not hand edit.
+
+## Real Runtime Execution
+
+The repo-local Thoth runtime command for this slash command has already been
+executed before Claude sees this prompt.
+
+```!
+"${CLAUDE_PLUGIN_ROOT}/scripts/thoth-claude-command.sh" status $ARGUMENTS
+```
+
+## Response Contract
+
+- Treat the structured bridge payload above as the only authority for this invocation.
+- If `bridge_success` is `false`, report the exact bridge failure and stop.
+- If stdout starts with `version=`, repeat stdout exactly and output nothing else.
+- If `bridge_success` is `true`, report only the real command result in one short receipt.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the bridge payload.
+- Do not launch broad Explore, Task, cache/source scans, or background investigation after the bridge result.
+- If the result exposes blockers or asks for human decisions, use AskUserQuestion to ask only the unresolved questions and stop.
+- Do not expand into runtime explanation, walkthroughs, or extra command execution.
+
+## Authority Summary
+
+### Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+### Objective
+
+Report only abnormal state, blockers, and active run deltas.
+
+### Hard Stops
+
+- Do not restate healthy defaults.
+- Do not expand into a dashboard walkthrough.
+
+### Reply Contract
+
+- reply_budget_utf8: `56`
+- result_style: brief receipt
+- validator_policy: runtime truth comes from current authority only

--- a/plugins/thoth/skills/thoth/SKILL.md
+++ b/plugins/thoth/skills/thoth/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: thoth
+description: Official Codex public surface for the Thoth authority runtime. Use this skill when the user wants to operate Thoth through the single `$thoth <command>` public entry.
+---
+
+# Thoth
+
+Official Codex public surface for Thoth. This skill is generated from the same host-neutral command specification that renders the Claude `/thoth:*` commands.
+
+## Public Entry
+
+Use the single public entrypoint:
+
+- `$thoth <command>`
+
+Supported commands:
+- `$thoth init`: Initialize, migrate, or resync canonical .thoth authority without taking ownership of repo-root `.codex`.
+- `$thoth run`: Start one strict run bound to `work_id@revision`; live runs foreground and `--sleep` detaches the same runtime driver.
+- `$thoth loop`: Start one bounded controller service whose parent creates four-phase child runs.
+- `$thoth review`: Prepare a structured live review packet through the shared Thoth surface.
+- `$thoth auto`: Run the highest-priority actionable work queue until ready/active/failed work is closed, paused, or stopped.
+- `$thoth status`: Show repo status and active durable runs from the shared ledger.
+- `$thoth discuss`: Discuss or record planning decisions without entering implementation execution.
+- `$thoth doctor`: Alias for `status --doctor`; strictly audit project health without writing authority.
+- `$thoth dashboard`: Alias for `status --dashboard`; manage the local dashboard backed by .thoth ledgers.
+
+## Dispatcher
+
+- `.thoth` is the only runtime authority.
+- Parse the requested `$thoth <command>`, then open only the matching micro prompt under `./commands/<command>.md`.
+- Execute the literal shell command immediately; do not replace it with explanation.
+- If `thoth` is not on PATH, use the installed Codex plugin cache or marketplace-root runtime entrypoint described by the micro prompt; do not use a local checkout as fallback.
+- If neither PATH nor the installed Codex plugin cache / marketplace root contains the runtime entrypoint, treat that as host install drift.
+- Do not create alternative public Codex variants such as `run:codex` or `loop:codex`.
+
+## Route Table
+
+- `init` -> `mechanical_fast` / `none` / `result_envelope`
+- `run` -> `live_intelligent` / `high` / `phase_controller`
+- `loop` -> `live_intelligent` / `high` / `phase_controller`
+- `review` -> `live_intelligent` / `high` / `review_packet`
+- `auto` -> `live_intelligent` / `high` / `phase_controller`
+- `status` -> `mechanical_fast` / `none` / `result_envelope`
+- `discuss` -> `live_intelligent` / `high` / `command_packet`
+- `doctor` -> `mechanical_fast` / `none` / `result_envelope`
+- `dashboard` -> `mechanical_fast` / `none` / `result_envelope`
+
+## Shared Rules
+
+- `init`, `status`, `doctor`, and `dashboard` are mechanical fast-path commands and should return only short receipts.
+- `discuss`, `run`, `loop`, `auto`, and open-ended `review` are high-intelligence paths.
+- `review` exact-match/probe flows are protocol-fast: if the packet exposes an exact result, do not improvise.
+- `run` and `loop` use one RuntimeDriver: lifecycle is `plan -> execute -> validate -> reflect`; live is foreground monitor, `--sleep` is detached monitor.
+- Host hooks and subagents may improve throughput but are never correctness requirements.

--- a/plugins/thoth/skills/thoth/agents/openai.yaml
+++ b/plugins/thoth/skills/thoth/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "thoth"
+  short_description: "Official Codex public surface for the Thoth authority runtime."
+  default_prompt: "Use $thoth as the single public entrypoint for Thoth and operate the shared .thoth runtime through $thoth <command>."

--- a/plugins/thoth/skills/thoth/commands/auto.md
+++ b/plugins/thoth/skills/thoth/commands/auto.md
@@ -1,0 +1,30 @@
+# $thoth auto
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `phase_controller`
+
+## Objective
+
+Run actionable work items by scheduling priority through child loops until none remain, budget pauses, or stop is requested.
+
+## Hard Stops
+
+- Do not execute blocked or draft work.
+- Do not auto-abandon work items.
+- Do not bypass execution-safety doctor preflight.
+
+## Reply Contract
+
+- reply_budget_utf8: `120`
+- result_style: start or reuse the durable controller, then stream JSONL watch events until terminal or observer interruption
+- validator_policy: controller cursor, child loop results, and auto watch events define queue state
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth auto`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth auto`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=live_intelligent. intelligence_tier=high. packet_authority_mode=phase_controller. Objective: Run actionable work items by scheduling priority through child loops until none remain, budget pauses, or stop is requested. Hard stop: Do not execute blocked or draft work. Hard stop: Do not auto-abandon work items. Hard stop: Do not bypass execution-safety doctor preflight. If the command streams runtime events, report progress and risks from those events only. Stay in the same session until the RuntimeDriver reaches terminal state unless --sleep was requested. Runtime lifecycle is plan -> execute -> validate -> reflect; auto advances selected work through child loops. Do not hand-edit `.thoth`; let the Thoth runtime driver advance phases. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/dashboard.md
+++ b/plugins/thoth/skills/thoth/commands/dashboard.md
@@ -1,0 +1,29 @@
+# $thoth dashboard
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+## Objective
+
+Report endpoint, failure point, and one notable runtime delta only.
+
+## Hard Stops
+
+- Do not narrate the whole UI.
+- Do not restate healthy panels.
+
+## Reply Contract
+
+- reply_budget_utf8: `56`
+- result_style: brief operator receipt
+- validator_policy: dashboard is read-only over .thoth ledgers
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth dashboard`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth dashboard`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=mechanical_fast. intelligence_tier=none. packet_authority_mode=result_envelope. Objective: Report endpoint, failure point, and one notable runtime delta only. Hard stop: Do not narrate the whole UI. Hard stop: Do not restate healthy panels. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/discuss.md
+++ b/plugins/thoth/skills/thoth/commands/discuss.md
@@ -1,0 +1,34 @@
+# $thoth discuss
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `command_packet`
+
+## Objective
+
+Interrogate the user's idea until goals, constraints, success criteria, risks, and authority are explicit; preserve semantic decisions as draft checkpoints and close only when no material assumptions remain.
+
+## Hard Stops
+
+- Do not modify source code.
+- Do not assume unanswered goals, constraints, success metrics, resources, timing, or authority.
+- Ask about every material ambiguity; use AskUserQuestion and continue discussion until no meaningful assumptions remain.
+- When a major semantic decision changes, checkpoint a compact authority event through the packet protocol command.
+- When closing, translate the discussion into semantic-lossless authority: goal, non-goals, constraints, accepted decisions, rejected options, acceptance, context evidence, risks, run instructions, and open questions.
+- Do not fabricate ready execution work items from unresolved decisions.
+- Do not repeat the packet or decision payload verbatim.
+
+## Reply Contract
+
+- reply_budget_utf8: `240`
+- result_style: question-driven planning dialogue or brief receipt when closed
+- validator_policy: planning authority plus compiler output decide completion
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth discuss`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth discuss`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=live_intelligent. intelligence_tier=high. packet_authority_mode=command_packet. Objective: Interrogate the user's idea until goals, constraints, success criteria, risks, and authority are explicit; preserve semantic decisions as draft checkpoints and close only when no material assumptions remain. Hard stop: Do not modify source code. Hard stop: Do not assume unanswered goals, constraints, success metrics, resources, timing, or authority. Hard stop: Ask about every material ambiguity; use AskUserQuestion and continue discussion until no meaningful assumptions remain. Hard stop: When a major semantic decision changes, checkpoint a compact authority event through the packet protocol command. Hard stop: When closing, translate the discussion into semantic-lossless authority: goal, non-goals, constraints, accepted decisions, rejected options, acceptance, context evidence, risks, run instructions, and open questions. Hard stop: Do not fabricate ready execution work items from unresolved decisions. Hard stop: Do not repeat the packet or decision payload verbatim. If the command returns a command packet, use that packet as the only authority for the follow-up action. Checkpoint major semantic changes through packet.protocol_commands.checkpoint_authority. Close only by translating the discussion into semantic-lossless authority and executing packet.protocol_commands.close_authority. Do not restate packet fields or expand into teaching prose. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/doctor.md
+++ b/plugins/thoth/skills/thoth/commands/doctor.md
@@ -1,0 +1,32 @@
+# $thoth doctor
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+## Objective
+
+Report only failing, drifting, missing checks, and any user decisions required to unblock authority.
+
+## Hard Stops
+
+- Do not pad with passing checks.
+- Do not claim repo health without checks.
+- Do not launch broad Explore, Task, plugin-cache/source scans, or background investigation after the doctor result.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the doctor payload.
+- If work items are blocked or migration decisions are unresolved, ask with AskUserQuestion instead of guessing or fixing.
+
+## Reply Contract
+
+- reply_budget_utf8: `64`
+- result_style: brief defect receipt
+- validator_policy: authority and generated surfaces decide health
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth doctor`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth doctor`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=mechanical_fast. intelligence_tier=none. packet_authority_mode=result_envelope. Objective: Report only failing, drifting, missing checks, and any user decisions required to unblock authority. Hard stop: Do not pad with passing checks. Hard stop: Do not claim repo health without checks. Hard stop: Do not launch broad Explore, Task, plugin-cache/source scans, or background investigation after the doctor result. Hard stop: If extra evidence is required, inspect only the smallest artifact explicitly named by the doctor payload. Hard stop: If work items are blocked or migration decisions are unresolved, ask with AskUserQuestion instead of guessing or fixing. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/init.md
+++ b/plugins/thoth/skills/thoth/commands/init.md
@@ -1,0 +1,33 @@
+# $thoth init
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+## Objective
+
+Report audit-first adopt/init outcome, generated artifacts, blockers, and user decisions required before continuing.
+
+## Hard Stops
+
+- Do not assume the repo is blank.
+- Do not assume goals, project identity, migration intent, work priority, unblock policy, or acceptance criteria.
+- Do not launch broad Explore, Task, plugin-cache/source scans, or background investigation after the init result.
+- If extra evidence is required, inspect only the smallest artifact explicitly named by the init payload.
+- If the preview/apply result leaves blocked work or unresolved migration choices, ask with AskUserQuestion and stop.
+- Do not narrate the full migration procedure.
+
+## Reply Contract
+
+- reply_budget_utf8: `60`
+- result_style: brief outcome receipt
+- validator_policy: preview and generated artifacts define success
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth init`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth init`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=mechanical_fast. intelligence_tier=none. packet_authority_mode=result_envelope. Objective: Report audit-first adopt/init outcome, generated artifacts, blockers, and user decisions required before continuing. Hard stop: Do not assume the repo is blank. Hard stop: Do not assume goals, project identity, migration intent, work priority, unblock policy, or acceptance criteria. Hard stop: Do not launch broad Explore, Task, plugin-cache/source scans, or background investigation after the init result. Hard stop: If extra evidence is required, inspect only the smallest artifact explicitly named by the init payload. Hard stop: If the preview/apply result leaves blocked work or unresolved migration choices, ask with AskUserQuestion and stop. Hard stop: Do not narrate the full migration procedure. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/loop.md
+++ b/plugins/thoth/skills/thoth/commands/loop.md
@@ -1,0 +1,30 @@
+# $thoth loop
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `phase_controller`
+
+## Objective
+
+Advance the current bounded loop through foreground or sleeping RuntimeDriver monitoring.
+
+## Hard Stops
+
+- Do not decide extra iterations outside the recorded loop budget.
+- Do not skip validator output when judging success.
+- Do not expand into iteration diaries or runtime narration.
+
+## Reply Contract
+
+- reply_budget_utf8: `40`
+- result_style: terminal receipt only
+- validator_policy: parent loop budget controls retries; each child runs plan -> execute -> validate -> reflect
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth loop`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth loop`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=live_intelligent. intelligence_tier=high. packet_authority_mode=phase_controller. Objective: Advance the current bounded loop through foreground or sleeping RuntimeDriver monitoring. Hard stop: Do not decide extra iterations outside the recorded loop budget. Hard stop: Do not skip validator output when judging success. Hard stop: Do not expand into iteration diaries or runtime narration. If the command streams runtime events, report progress and risks from those events only. Stay in the same session until the RuntimeDriver reaches terminal state unless --sleep was requested. Runtime lifecycle is plan -> execute -> validate -> reflect; auto advances selected work through child loops. Do not hand-edit `.thoth`; let the Thoth runtime driver advance phases. Plan must prove coverage of strict_task.authority_context before execute; needs_input routes back to discuss. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/review.md
+++ b/plugins/thoth/skills/thoth/commands/review.md
@@ -1,0 +1,31 @@
+# $thoth review
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `review_packet`
+
+## Objective
+
+Produce the best possible review output: understand user intent, apply professional judgment and first-principles reasoning, and return structured findings without modifying code.
+
+## Hard Stops
+
+- Do not modify project code or write fixes.
+- Do not reduce the review to a checklist; infer the user's intent from evidence and reason from first principles.
+- If the target, intent, or acceptance bar is ambiguous, ask with AskUserQuestion before judging instead of assuming.
+- If review_expectation or complete_exact exists, follow it exactly.
+
+## Reply Contract
+
+- reply_budget_utf8: `160`
+- result_style: short summary plus structured findings
+- validator_policy: exact-match route is protocol_fast; open-ended route stays live but still structured
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth review`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth review`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=live_intelligent. intelligence_tier=high. packet_authority_mode=review_packet. Objective: Produce the best possible review output: understand user intent, apply professional judgment and first-principles reasoning, and return structured findings without modifying code. Hard stop: Do not modify project code or write fixes. Hard stop: Do not reduce the review to a checklist; infer the user's intent from evidence and reason from first principles. Hard stop: If the target, intent, or acceptance bar is ambiguous, ask with AskUserQuestion before judging instead of assuming. Hard stop: If review_expectation or complete_exact exists, follow it exactly. If the command returns a review packet, stay inside that review protocol only. If `packet.review_mode` is `exact_match`, reproduce that exact structured result. If `packet.protocol_commands.complete_exact` exists, execute that exact completion command. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/run.md
+++ b/plugins/thoth/skills/thoth/commands/run.md
@@ -1,0 +1,30 @@
+# $thoth run
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `live_intelligent`
+- intelligence_tier: `high`
+- packet_authority_mode: `phase_controller`
+
+## Objective
+
+Finish the current strict task through the four-phase RuntimeDriver.
+
+## Hard Stops
+
+- Do not invent or compile a new work item when --work-id is missing.
+- Do not stop after starting the runtime; monitor RuntimeDriver events until terminal.
+- Do not hand-edit .thoth ledgers.
+
+## Reply Contract
+
+- reply_budget_utf8: `36`
+- result_style: terminal receipt only
+- validator_policy: plan first, validate decides completion, reflect always summarizes evidence and risk
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth run`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth run`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=live_intelligent. intelligence_tier=high. packet_authority_mode=phase_controller. Objective: Finish the current strict task through the four-phase RuntimeDriver. Hard stop: Do not invent or compile a new work item when --work-id is missing. Hard stop: Do not stop after starting the runtime; monitor RuntimeDriver events until terminal. Hard stop: Do not hand-edit .thoth ledgers. If the command streams runtime events, report progress and risks from those events only. Stay in the same session until the RuntimeDriver reaches terminal state unless --sleep was requested. Runtime lifecycle is plan -> execute -> validate -> reflect; auto advances selected work through child loops. Do not hand-edit `.thoth`; let the Thoth runtime driver advance phases. Plan must prove coverage of strict_task.authority_context before execute; needs_input routes back to discuss. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.

--- a/plugins/thoth/skills/thoth/commands/status.md
+++ b/plugins/thoth/skills/thoth/commands/status.md
@@ -1,0 +1,29 @@
+# $thoth status
+
+Generated micro prompt for the Thoth Codex dispatcher.
+
+## Route
+
+- route_class: `mechanical_fast`
+- intelligence_tier: `none`
+- packet_authority_mode: `result_envelope`
+
+## Objective
+
+Report only abnormal state, blockers, and active run deltas.
+
+## Hard Stops
+
+- Do not restate healthy defaults.
+- Do not expand into a dashboard walkthrough.
+
+## Reply Contract
+
+- reply_budget_utf8: `56`
+- result_style: brief receipt
+- validator_policy: runtime truth comes from current authority only
+
+## Execution String
+
+Operate only on this repo. Use the installed skill named thoth. The Codex public surface is `$thoth status`, but in the workspace shell you must execute it literally as `bash -lc 'set -euo pipefail; if [ -n "${THOTH_SELFTEST_RUNTIME_ROOT:-}" ]; then if [ -x "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" ]; then exec "$THOTH_SELFTEST_RUNTIME_ROOT/bin/thoth" "$@"; fi; if [ -f "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" ]; then exec python3 "$THOTH_SELFTEST_RUNTIME_ROOT/scripts/thoth-cli-entry.py" "$@"; fi; fi; if command -v thoth >/dev/null 2>&1; then exec thoth "$@"; fi; candidates="$(ls -td "$HOME"/.codex/plugins/cache/thoth/thoth/* 2>/dev/null || true)"; marketplace="$HOME/.codex/.tmp/marketplaces/thoth"; if [ -d "$marketplace" ]; then candidates="$candidates
+$marketplace"; fi; for candidate in $candidates; do if [ -x "$candidate/bin/thoth" ]; then exec "$candidate/bin/thoth" "$@"; fi; if [ -f "$candidate/scripts/thoth-cli-entry.py" ]; then if command -v python3 >/dev/null 2>&1; then exec python3 "$candidate/scripts/thoth-cli-entry.py" "$@"; else exec python "$candidate/scripts/thoth-cli-entry.py" "$@"; fi; fi; done; echo '"'"'thoth installed runtime not found'"'"' >&2; exit 127' thoth status`. Execute that shell command immediately as your first meaningful action. Do not explain the command before executing it. Do not replace execution with prose. If neither PATH nor the installed Codex plugin cache or marketplace root contains the runtime entrypoint, report host install drift instead of inventing another entrypoint. route_class=mechanical_fast. intelligence_tier=none. packet_authority_mode=result_envelope. Objective: Report only abnormal state, blockers, and active run deltas. Hard stop: Do not restate healthy defaults. Hard stop: Do not expand into a dashboard walkthrough. Reply with `THOTH_DONE` only after the command path reaches its terminal outcome.


### PR DESCRIPTION
## Summary

Adds Thoth to the Workflow Orchestration section as a Claude Code plugin.

Thoth is a dashboard-first Claude Code and Codex runtime for autoresearch, turning drifting agent work into durable runs, locked work items, visible ledgers, and reviewable verdicts.

## Validation

- `python -m json.tool plugins/thoth/.claude-plugin/plugin.json >/dev/null`
- `git diff --check`

## Notes

The plugin folder includes the Claude command surface, the Thoth skill surface, README, LICENSE, and `.claude-plugin/plugin.json`.
