### PR TITLE
Add bleu under Project & Product Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [twitter-engager](./plugins/twitter-engager)
 
 ### Project & Product Management
+- [bleu](https://github.com/Nirvaan05/Bleu-plugin)
 - [discuss](./plugins/discuss)
 - [explore](./plugins/explore)
 - [plan](./plugins/plan)


### PR DESCRIPTION
Adds **bleu** under **Project & Product Management**, inserted alphabetically before `discuss`.

[Bleu](https://github.com/Nirvaan05/Bleu-plugin) is a planning plugin for Claude Code that turns an idea into a file-backed markdown wiki (vision, architecture, ADRs, action points) which survives /clear and hands off to GSD, Superpowers, or raw Claude Code.

Note: the plugin lives in its own external repository, so this entry links to the GitHub repo rather than a local `./plugins/bleu` folder. If you'd prefer a vendored `./plugins/bleu` folder to match the other entries, let me know and I'll add one. Open source, MIT licensed, v1.0.0 released.