### PR TITLE
Add: retro-daily — SessionStart hook for daily Claude Code retros

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [infrastructure-maintainer](./plugins/infrastructure-maintainer)
 - [monitoring-observability-specialist](./plugins/monitoring-observability-specialist)
 - [n8n-workflow-builder](./plugins/n8n-workflow-builder)
+- [retro-daily](./plugins/retro-daily)
 
 ### Business Sales
 - [b2b-project-shipper](./plugins/b2b-project-shipper)

--- a/plugins/retro-daily/.claude-plugin/plugin.json
+++ b/plugins/retro-daily/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "retro-daily",
+  "description": "A SessionStart hook that prints a daily retro at the top of every Claude Code session: competency grade (0-100 / A-F), 14-day efficiency sparklines, year-long contributions heatmap, and a detached claude -p background worker that researches your weakest metrics on docs.anthropic.com and GitHub. Reads ~/.claude/projects/*.jsonl; writes state under ~/.claude/metrics. Background workers opt out with RETRO_DAILY_NO_BACKGROUND_WORKERS=1.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Gyanesh Malhotra",
+    "url": "https://github.com/gyanesh-m"
+  },
+  "homepage": "https://github.com/gyanesh-m/retro-daily"
+}


### PR DESCRIPTION
## What this adds

**[retro-daily](https://github.com/gyanesh-m/retro-daily)** — a `SessionStart` hook that prints a daily retro at the top of every Claude Code session: competency grade (0–100 / A–F), 14-day efficiency sparklines, year-long contributions heatmap, and a detached `claude -p` background worker that researches your weakest metrics on docs.anthropic.com and GitHub.

Installs as a single-plugin marketplace:

```
/plugin marketplace add gyanesh-m/retro-daily
/plugin install retro-daily@retro-daily
/reload-plugins
```

- Repo: https://github.com/gyanesh-m/retro-daily
- Demo: https://gyanesh-m.github.io/retro-daily/
- License: MIT

## Where it goes

Added under **Automation DevOps** (alongside `monitoring-observability-specialist`), since retro-daily is observability-flavored. Also added `plugins/retro-daily/.claude-plugin/plugin.json` matching the existing in-repo plugin layout.

## Security and privacy disclosure

Reads local Claude Code session history from `~/.claude/projects/*.jsonl`. Writes derived state, logs, scout results, and session tags under `~/.claude/metrics`. By default, `scout.sh` and `tag-sessions.sh` start detached, sandboxed `claude -p` background workers (scout uses `WebSearch`+`Write`; tag-sessions denies network). Set `RETRO_DAILY_NO_BACKGROUND_WORKERS=1` to disable. Rate-limit with `SCOUT_STALE_DAYS` (default 7).

## Why it fits

Repo description explicitly calls out hooks ("a curated list of slash commands, subagents, MCP servers, and hooks"). retro-daily is hook-driven; the `SessionStart` hook is the entry point.