### PR TITLE
Add ux plugin to Design UX section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [mobile-ux-optimizer](./plugins/mobile-ux-optimizer)
 - [onomastophes](./plugins/onomastophes)
 - [ui-designer](./plugins/ui-designer)
+- [ux](https://github.com/Laith0003/ux-skill)
 - [ux-researcher](./plugins/ux-researcher)
 - [visual-storyteller](./plugins/visual-storyteller)
 - [whimsy-injector](./plugins/whimsy-injector)


### PR DESCRIPTION
## What's being added

**Plugin name:** `ux`
**Repository:** https://github.com/Laith0003/ux-skill
**Live:** https://uxskill.laithjunaidy.com
**License:** MIT
**Section:** Design UX (perfect fit)

External plugin, full URL — added alphabetically between `ui-designer` and `ux-researcher`.

## Description

Design intelligence for Claude Code that produces frontend work which doesn't read as AI-generated.

- 18 slash commands across Frame / Audit / Generate / Apply
- 5 specialized sub-agents (frontend-engineer, motion-engineer, copy-writer, research-synthesizer, design-system-architect)
- 30+ Polaris-style reference files
- Deterministic regex linter (`/ux-lint`) — no LLM, CI-friendly, 30 anti-pattern rules
- 72 brand DESIGN.md specs — Apple, Stripe, Linear, Notion, Figma, Tesla, BMW and 65 more
- Mandatory 10-field discovery protocol before any generation
- SEO foundation baked into every public-web output
- Cross-stack: React, Next.js, Vue, Blade, Astro, vanilla

## Install

```
/plugin marketplace add https://github.com/Laith0003/ux-skill.git
/plugin install ux@ux-skill
```

Also submitted to the official Anthropic marketplace ([PR #2010](https://github.com/anthropics/claude-plugins-official/pull/2010)).