### PR TITLE
Add staff-engineer-mode plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -130,6 +130,7 @@
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
 - [react-native-dev](./plugins/react-native-dev)
+- [staff-engineer-mode](https://github.com/sirmarkz/staff-engineer-mode)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
 - [react-native-dev](./plugins/react-native-dev)
+- [staff-engineer-mode](https://github.com/sirmarkz/staff-engineer-mode)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 


### PR DESCRIPTION
Adds Staff Engineer Mode to the Claude Code plugin list in both English and Chinese READMEs.

Staff Engineer Mode packages major-outage lessons as one Claude Code plugin router. It routes architecture, reliability, security, delivery, and operations prompts to 54 specialist references and installs through the upstream plugin marketplace commands.

Validation:
- Checked for an existing Staff Engineer Mode entry
- git diff --check