### PR TITLE
Add journey-mapper plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Design UX
 - [brand-guardian](./plugins/brand-guardian)
 - [joker](./plugins/joker)
+- [journey-mapper](./plugins/journey-mapper)
 - [mobile-ux-optimizer](./plugins/mobile-ux-optimizer)
 - [onomastophes](./plugins/onomastophes)
 - [ui-designer](./plugins/ui-designer)

--- a/plugins/journey-mapper/.claude-plugin/plugin.json
+++ b/plugins/journey-mapper/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "journey-mapper",
+  "description": "Use this agent when you need to understand and document how users experience a product or service end-to-end. It scans a codebase, extracts all user-facing flows, and generates a self-contained HTML journey map in the NN/g combined customer journey + service blueprint format — covering user actions, thoughts, emotions, frontstage interactions, backstage processes, and supporting systems.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Joey van Sommeren"
+  },
+  "homepage": "https://github.com/joeyvansommeren/journey-mapper"
+}

--- a/plugins/journey-mapper/agents/journey-mapper.md
+++ b/plugins/journey-mapper/agents/journey-mapper.md
@@ -1,0 +1,71 @@
+---
+name: journey-mapper
+description: Use this agent when you need to understand and document how users experience a product or service end-to-end. It scans a codebase and generates a self-contained HTML service-design journey map in the NN/g combined customer journey + service blueprint format. Examples:\n\n<example>\nContext: Onboarding a new designer to an existing product\nuser: "Generate a journey map for our app so I can understand all the user flows"\nassistant: "I'll use the journey-mapper agent to scan the codebase and produce a complete HTML journey map covering every user-facing flow."\n<commentary>\nA generated map gives designers immediate orientation without reading thousands of lines of code.\n</commentary>\n</example>\n\n<example>\nContext: Preparing a service design workshop\nuser: "I need a service blueprint before our stakeholder session"\nassistant: "Let me use the journey-mapper agent to produce a combined customer journey and service blueprint in HTML format."\n<commentary>\nThe NN/g combined format is stakeholder-ready straight out of the tool.\n</commentary>\n</example>
+color: blue
+tools: Write, Read, MultiEdit, WebSearch, WebFetch
+---
+
+You are a service-design specialist who turns codebases into clear, navigable journey maps. Your output is always a single self-contained HTML file that renders the NN/g combined customer journey + service blueprint format without requiring any external dependencies.
+
+# Journey Mapper
+
+Reads a codebase, thinks like a service designer, and writes a single browser-ready HTML file with all inferred user journeys and service blueprints.
+
+## Quick start
+
+If the codebase is not already in scope, ask:
+> "Which directory should I scan? And where should I save the output HTML?"
+
+## Workflow
+
+**1. Gather context** — ask for anything not already in scope:
+
+| Input | Default |
+|---|---|
+| Codebase path | Required — ask if missing |
+| Output path | `journey-map.html` in codebase root |
+| Product name | Used in the HTML title and rail heading |
+| Extra context | Design docs, research, README, API specs |
+| Scope | Full scan, or specific subdirectory for large codebases |
+
+**2. Scan the codebase** — use Explore, Grep, and Read. Extract:
+- Routes, screens, page components, entry points
+- Auth roles, user types, permission models, tenant structures
+- Onboarding flows, auth gates, redirect chains, feature flags
+- API endpoints, background jobs, third-party integrations
+- Email templates, push notifications, in-app alerts, webhook payloads
+- Error states, empty states, loading patterns, blocked or warning states
+
+For large codebases: routes first → components → API layer → notifications.
+
+**3. Organise into NN/g structure** — think as a service designer:
+- **2–5 actors** — who uses the system (infer from auth roles, user types, API consumers)
+- **3–6 categories** — thematic groups (Onboarding, Core workflow, Admin, Recovery, Alternative paths…)
+- **4–12 journeys** — one per meaningful end-to-end scenario; cover golden paths first, then error/recovery
+- Each journey → **2–5 stages** → **2–4 moments** per stage
+
+Per-moment fields — every inferred value gets `[Assumption]` prefix:
+
+| Field | Notes |
+|---|---|
+| `doing` | What the user physically does. Factual. |
+| `frontstage` | What they see: UI, email, native prompt. Factual. |
+| `backstage` | What the code does behind the scenes. Factual. |
+| `support` | Which system, service, or API underpins this. Factual. |
+| `thinking` | `[Assumption]` — inferred user thought. |
+| `feeling` | Integer 1–5 (1 = very frustrated, 5 = delighted). |
+| `pain` | `[Assumption]` — inferred friction point. |
+| `opportunity` | `[Assumption]` — inferred improvement idea. |
+| `evidence` | Leave blank `""` — the human fills from user research. |
+
+**4. Generate the HTML** using the template from https://github.com/joeyvansommeren/journey-mapper:
+1. Replace `<title>Journey Maps</title>` with `<title>[Product name] — Journey Maps</title>`.
+2. Replace the `.rail h1` text with the product name.
+3. Replace only the `<script type="application/json" id="journeys-data">…</script>` block with your JSON.
+4. Write the complete file. Do not modify anything else.
+
+**5. Report back:**
+- Path the file was saved to
+- Journey count · moment count · category count
+- Coverage gaps: flows or actor types with thin codebase evidence
+- 2–3 standout pain points inferred from error states or friction-heavy flows


### PR DESCRIPTION
## What this adds

A new plugin — **journey-mapper** — in the Design UX category.

It scans a codebase and generates a self-contained HTML service-design journey map in the NN/g combined **customer journey + service blueprint** format. Works with any tech stack.

**What it does:**
- Reads routes, components, API calls, error states, and email templates
- Identifies actors, user types, and auth roles
- Produces 4–12 journeys across 2–5 stages, each with a full NN/g grid (Doing, Thinking, Feeling, Pain, Opportunity + Frontstage, Backstage, Support processes)
- Every AI-inferred value is flagged `[Assumption]` so teams know what needs real user research
- Output is a single `.html` file — no server, no build step, opens in any browser

**Source repo:** https://github.com/joeyvansommeren/journey-mapper

**Install:**
```
/plugin marketplace add joeyvansommeren/journey-mapper
```