### PR TITLE
Add Diffmode Growth Tactics (Marketing Growth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
 - [twitter-engager](./plugins/twitter-engager)
+- [Diffmode Growth Tactics](https://github.com/acogood/diffmode_free) — free plugin + marketplace that runs a growth-strategy pipeline: a competitor read, a buyer jobs-to-be-done map, and 7–9 unconventional acquisition tactics for bootstrapped founders. Claude Code + Codex, Apache-2.0.
 
 ### Project & Product Management
 - [discuss](./plugins/discuss)


### PR DESCRIPTION
Adds **Diffmode Growth Tactics** under *Marketing Growth* — a free Claude Code + Codex plugin (and its own marketplace, `acogood/diffmode_free`) that runs a growth-strategy research pipeline.

Point it at a product URL and ~90 min later you have a competitor read, a buyer jobs-to-be-done map, and **7–9 unconventional acquisition tactics** built for a founder's budget/stage/team — each fuses 2–3 growth mechanisms mined fresh from public case studies.

```
claude plugin marketplace add acogood/diffmode_free
claude plugin install diffmode-growth-tactics@diffmode-free
```
Apache-2.0, no account/API key, Perplexity-optional. Added as an external marketplace link per CONTRIBUTING ("submit your own marketplace"). Repo: https://github.com/acogood/diffmode_free