### PR TITLE
Add tldr plugin (short-answer mode)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,21 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "tldr",
+      "source": "./plugins/tldr",
+      "description": "Keeps Claude Code's replies short. Turn it on and every answer stays under five lines until you turn it off.",
+      "version": "1.0.0",
+      "author": {
+        "name": "rodrigooler"
+      },
+      "category": "Development Engineering",
+      "homepage": "https://github.com/rodrigooler/claude-code-tldr",
+      "keywords": [
+        "productivity",
+        "concise"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [python-expert](./plugins/python-expert)
 - [rapid-prototyper](./plugins/rapid-prototyper)
 - [react-native-dev](./plugins/react-native-dev)
+- [tldr](./plugins/tldr)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 

--- a/plugins/tldr/.claude-plugin/plugin.json
+++ b/plugins/tldr/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "tldr",
+  "description": "Keeps Claude Code's replies short. Turn it on and every answer stays under five lines until you turn it off.",
+  "version": "1.0.0",
+  "author": {
+    "name": "rodrigooler",
+    "url": "https://github.com/rodrigooler"
+  },
+  "homepage": "https://github.com/rodrigooler/claude-code-tldr",
+  "keywords": ["productivity", "concise", "output", "brevity"]
+}

--- a/plugins/tldr/commands/tldr.md
+++ b/plugins/tldr/commands/tldr.md
@@ -1,0 +1,28 @@
+---
+description: Turn on short-answer mode. Every reply stays under five lines until you turn it off.
+author: rodrigooler
+author-url: https://github.com/rodrigooler
+version: 1.0.0
+---
+
+# tldr
+
+Turn on a short-answer mode and keep it on for the rest of the session, until I say "tldr off".
+
+While it is on, follow these rules on every reply:
+
+- Keep it to three to five lines. If it does not fit, it is too long, so cut more.
+- Give the result and the next step only. No context, no recap, no preamble.
+- Drop the filler. No "great question", no "let me explain", no summary of what you are about to do. Just do it.
+- Use short bullets, one idea per line.
+- For code or commands, show only the part that changes, not the whole file.
+- If an honest answer needs more (a real decision, a risk, a long set of steps), give the verdict in five lines and offer the detail if I ask for it.
+
+Never shorten these, only the words around them:
+
+- Code I am going to paste or run. It has to be complete and correct.
+- Security or data-loss warnings. Clarity beats brevity.
+
+To stop, I will say "tldr off" and you go back to your normal style.
+
+Source: https://github.com/rodrigooler/claude-code-tldr (MIT)


### PR DESCRIPTION
Adds tldr, a small plugin that keeps Claude Code's replies short. You turn it on and answers stay under five lines until you turn it off. Useful when you just want the result without scrolling through a long explanation. Code you need to run and any security warnings are left intact, only the filler gets trimmed.

What's included:
- plugins/tldr/ with the plugin manifest and the command
- an entry in .claude-plugin/marketplace.json
- a line under Development Engineering in the README

Source repo (MIT): https://github.com/rodrigooler/claude-code-tldr