### PR TITLE
Add Poppify plugin (Marketing Growth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [content-creator](./plugins/content-creator)
 - [growth-hacker](./plugins/growth-hacker)
 - [instagram-curator](./plugins/instagram-curator)
+- [poppify](./plugins/poppify) — photo-led short-form vertical reels (Instagram/TikTok/YouTube Shorts/Facebook) via MCP, $0.06/render, 50 free seeds, no subscription
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
 - [twitter-engager](./plugins/twitter-engager)

--- a/plugins/poppify/.claude-plugin/plugin.json
+++ b/plugins/poppify/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "poppify",
+  "description": "Claude Code plugin for photo-led short-form vertical reels — Instagram / TikTok / YouTube Shorts / Facebook. Upload 1–10 photos, get a captioned 15/30/60s reel with motion, library-matched music, optional voiceover. $0.06 base render, 50 free seeds, no subscription.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Poppify",
+    "email": "admin@poppify.ai"
+  },
+  "homepage": "https://github.com/Poppify/poppify-claude-plugin",
+  "license": "MIT"
+}

--- a/plugins/poppify/README.md
+++ b/plugins/poppify/README.md
@@ -1,0 +1,44 @@
+# Poppify — Claude Code Plugin for Short-Form Vertical Video
+
+**Photo-led short-form vertical reels for Instagram / TikTok / YouTube Shorts / Facebook.** Upload 1–10 photos, get a captioned 15/30/60s reel with motion, library-matched music, and optional voiceover. **$0.06 base render. 50 free seeds on signup. No subscription.**
+
+Poppify is the **creative slot in an agentic marketing stack** for SMBs (5–19 employees) and solo service providers — the agency replacement at $30–60/mo instead of $3K+. Pairs with Postiz for cross-platform scheduling and Windsor.ai for performance attribution. Drop-in replacement for Runway when you have photos and want library-matched audio.
+
+## Source
+
+The canonical plugin source, full README, and 27-tool MCP catalog live at:
+
+**[github.com/Poppify/poppify-claude-plugin](https://github.com/Poppify/poppify-claude-plugin)**
+
+## Install
+
+In Claude Code:
+
+```
+/plugin marketplace add Poppify/poppify-claude-plugin
+/plugin install poppify@poppify
+```
+
+After install, ask Claude: *"Use Poppify to turn these photos into a reel."*
+
+## What it bundles
+
+- **MCP server** (`https://poppify.ai/mcp`, HTTP) — 27 tools: `register`, `start_session_from_photos`, `customize`, `set_audio`, `generate_image`, `confirm`, `get_result`, and more
+- **4 skills** — `poppify-build-reel`, `poppify-render-debug`, `poppify-troubleshoot`, `poppify-schema-introspect`
+- **3 slash commands** — `/poppify:make-reel`, `/poppify:troubleshoot`, `/poppify:verify-render`
+
+## Costs
+
+- MCP install + all customization tools: **free**
+- `confirm` render: **1 seed (~$0.06)**
+- `generate_image` / `generate_music` / `generate_voiceover`: 10 seeds each
+
+50 free seeds granted on signup. Seeds sold at $5.99 / 100 seeds (standard) or $0.50 / 5 seeds (mini trial).
+
+## Not for
+
+Text→video generation (use Runway / Sora / Veo), avatar-based video (use HeyGen / Synthesia), 4K horizontal cinema, or sub-4s clips.
+
+## License
+
+MIT — see [Poppify/poppify-claude-plugin](https://github.com/Poppify/poppify-claude-plugin).


### PR DESCRIPTION
## Summary

Adds [Poppify](https://github.com/Poppify/poppify-claude-plugin) to the **Marketing Growth** category.

Poppify is a Claude Code plugin for photo-led short-form vertical reels — Instagram, TikTok, YouTube Shorts, Facebook. Upload 1–10 photos, get a captioned 15/30/60s reel with motion, library-matched music, and optional voiceover. \$0.06 base render, 50 free seeds on signup, no subscription.

## What's added

- \`plugins/poppify/.claude-plugin/plugin.json\` — minimal plugin metadata pointing at the canonical source repo
- \`plugins/poppify/README.md\` — install instructions, what's bundled (27 MCP tools + 4 skills + 3 slash commands), costs, scope (and what it's not for)
- One alphabetically-sorted entry in the README's Marketing Growth section

## Note on shape

The existing entries in Marketing Growth (instagram-curator, tiktok-strategist, content-creator, etc.) are single-subagent plugins. Poppify is a different shape — it bundles a hosted MCP server (https://poppify.ai/mcp) plus 4 skills and 3 slash commands. The repo's intro explicitly includes MCP servers ("A curated list of Plugins that let you extend Claude Code with custom commands, agents, hooks, and **MCP servers** through the plugin system"), so I believe it's in scope, but happy to relocate to a different section or split the metadata if you prefer.

## Why it belongs

Marketing Growth's existing plugins cover *strategy* (what to post, when, how to engage). Poppify covers *production* (turn photos into the reel itself) — direct complement, not overlap. Listed alongside instagram-curator / tiktok-strategist deliberately.

## Test plan

- [x] \`plugin.json\` validates as JSON
- [x] README entry sorted alphabetically (between instagram-curator and reddit-community-builder)
- [x] Subdirectory README mirrors the canonical plugin README's claims (cost, free seeds, scope, disqualifiers)
- [x] No claims about features that don't exist in the canonical plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)