### PR TITLE
Add ai-divination-skills plugin (Lifestyle & Entertainment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [tool-evaluator](./plugins/tool-evaluator)
 - [workflow-optimizer](./plugins/workflow-optimizer)
 
+### Lifestyle & Entertainment
+- [ai-divination-skills](./plugins/ai-divination-skills)
+
 ### Security, Compliance, & Legal
 - [ai-ethics-governance-specialist](./plugins/ai-ethics-governance-specialist)
 - [audit](./plugins/audit)

--- a/plugins/ai-divination-skills/.claude-plugin/plugin.json
+++ b/plugins/ai-divination-skills/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "ai-divination-skills",
+  "description": "Audited tarot, I Ching (Yijing), and Xiao Liu Ren (小六壬) divination skill. Calls local seeded-or-system-entropy Python tools that emit deterministic JSON; the model never invents the result, it only interprets the JSON output.",
+  "version": "0.6.1",
+  "author": {
+    "name": "sapuyou45-bit",
+    "url": "https://github.com/sapuyou45-bit"
+  },
+  "homepage": "https://github.com/sapuyou45-bit/ai-divination-skills"
+}

--- a/plugins/ai-divination-skills/skills/ai-divination-skills/SKILL.md
+++ b/plugins/ai-divination-skills/skills/ai-divination-skills/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: ai-divination-skills
+description: Use this skill when the user asks for a tarot reading, I Ching (Yijing) hexagram cast, or Chinese Xiao Liu Ren (小六壬) divination. Calls audited local Python tools that produce deterministic JSON output; the model never invents the result, it only interprets the JSON.
+---
+
+# AI Divination Skills
+
+This skill wraps `ai-divination-skills` — an MCP server + Python package providing auditable tarot, I Ching, and Xiao Liu Ren divination tools.
+
+## When to use
+- User asks for a tarot reading (e.g. 3-card, Celtic Cross)
+- User asks for an I Ching / 易经 hexagram with moving lines
+- User asks for a 小六壬 / Xiao Liu Ren / Six Yao reading
+- User wants reproducible / auditable divination (seed-based) instead of model-imagined cards
+
+## Install
+```bash
+pip install ai-divination-skills
+```
+
+## Workflow
+1. Run the CLI for the requested method:
+   - Tarot: `ai-divination tarot --spread three-card`
+   - I Ching: `ai-divination iching --method coin`
+   - Xiao Liu Ren: `ai-divination xiaoliuren`
+2. The CLI prints structured JSON (cards/lines, positions, names, keywords)
+3. Interpret the JSON in natural language. **Do not** invent additional cards, swap positions, or change the result; only interpret what the JSON contains.
+
+## MCP alternative
+If the user is in Claude Desktop, register `ai-divination-mcp` (stdio JSON-RPC 2.0) and use tools: `tarot.draw`, `iching.cast`, `xiaoliuren.cast`, `interpretation_template`.
+
+## Links
+- Repo: https://github.com/sapuyou45-bit/ai-divination-skills
+- PyPI: https://pypi.org/project/ai-divination-skills/


### PR DESCRIPTION
Adds a new Claude Code plugin: `ai-divination-skills`.

## What it is
A skill that performs audited tarot, I Ching (Yijing), and Xiao Liu Ren (小六壬) divination by calling local `ai-divination-skills` Python tools. The tools use seeded-or-system entropy and return deterministic JSON; the model never invents the result — it only interprets the JSON output.

## Files added
- `plugins/ai-divination-skills/.claude-plugin/plugin.json`
- `plugins/ai-divination-skills/skills/ai-divination-skills/SKILL.md`
- Listed in README under a new `### Lifestyle & Entertainment` category (no existing category fit, similar to how Security/Legal got its own section)

## Upstream package
- Repo: https://github.com/sapuyou45-bit/ai-divination-skills
- PyPI: https://pypi.org/project/ai-divination-skills/
- MIT licensed, 61 tests across 4 Python versions