### PR TITLE
feat: add The Stall — x402 MCP server (201 pay-per-call data capabilities, Data Analytics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
 - [trend-researcher](./plugins/trend-researcher)
+- **[The Stall — x402 MCP Server](https://the-stall.intuitek.ai)** — 201 pay-per-call data capabilities: DeFi/crypto analytics, real-time market data, on-chain intelligence, financial metrics. Free preflight checks; USDC-per-call via x402 on Base.
 
 ### Design UX
 - [brand-guardian](./plugins/brand-guardian)


### PR DESCRIPTION
## Summary

Add **The Stall** — a production-ready x402 pay-per-call MCP server with 201 data capabilities.

**Why Data Analytics:** The Stall provides real-time financial intelligence: DeFi analytics, on-chain wallet scoring, crypto market data, equity/options metrics, and macro indicators — all queryable by Claude Code agents per-call without subscriptions.

**Integration:** Standard MCP (Streamable HTTP). Works with any Claude Code setup pointing to `https://the-stall.intuitek.ai/mcp`.

**Pricing model:** x402 on Base — free preflight checks (`/probe`), USDC micropayments per call (avg $0.001–$0.003). No API key, no subscription.

**Links:**
- MCP endpoint: `https://the-stall.intuitek.ai/mcp`
- Health/caps: `https://the-stall.intuitek.ai/health`
- Listed on: Glama, Smithery, punkpeye/awesome-mcp-servers (PR pending), MCP Registry

**Capabilities (201 total):** DeFi state, wallet reputation, crypto price/momentum, options analytics, earnings intelligence, macro/PMI indicators, Wayback Machine queries, and more.