### PR TITLE
Add supply-chain-gate plugin to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+- [supply-chain-gate](./plugins/supply-chain-gate)
 
 
 ## Tutorials

--- a/plugins/supply-chain-gate/.claude-plugin/plugin.json
+++ b/plugins/supply-chain-gate/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "supply-chain-gate",
+  "description": "Supply chain security gate — audit dependencies for behavioral risk and install IDE hooks that block CRITICAL packages",
+  "version": "1.0.0",
+  "author": {
+    "name": "piiiico",
+    "url": "https://github.com/piiiico/proof-of-commitment"
+  },
+  "homepage": "https://getcommit.dev"
+}

--- a/plugins/supply-chain-gate/commands/supply-chain-audit.md
+++ b/plugins/supply-chain-gate/commands/supply-chain-audit.md
@@ -1,0 +1,25 @@
+---
+allowed-tools: Bash(npx:*), Bash(poc:*), Bash(cat:*)
+description: Audit project dependencies for supply chain risk using behavioral signals
+---
+
+## Context
+
+- Lock files: !`ls package-lock.json yarn.lock pnpm-lock.yaml bun.lock Cargo.toml go.sum requirements.txt 2>/dev/null || echo "none found"`
+
+## Your task
+
+Run a supply chain security audit on this project using [Proof of Commitment](https://github.com/piiiico/proof-of-commitment).
+
+This scores dependencies on **behavioral commitment signals** — publisher depth, release consistency, maintenance patterns — that predict supply chain risk. Both axios and chalk scored CRITICAL *before* their 2026 compromises.
+
+```bash
+npx -y proof-of-commitment $ARGUMENTS
+```
+
+If `$ARGUMENTS` is empty, the CLI auto-detects the best manifest in the current directory (package-lock.json > yarn.lock > pnpm-lock.yaml > package.json > requirements.txt > Cargo.toml > go.sum).
+
+After running:
+1. Report CRITICAL and HIGH packages with their risk flags
+2. For CRITICAL packages: explain what "single npm publisher" means as a risk
+3. Suggest `poc hook` to install a pre-install gate that blocks CRITICAL packages automatically


### PR DESCRIPTION
Adds a supply-chain-gate plugin to the Security, Compliance & Legal section.

**What it provides:**
- `/supply-chain-audit` slash command — runs `npx proof-of-commitment` to audit project dependencies for behavioral risk signals (publisher depth, release consistency, maintenance patterns)
- Suggests `poc hook` to install a PreToolUse hook that blocks CRITICAL packages before they execute

**Why it matters for Claude Code users:** The Shai-Hulud worm (May 2026) specifically targeted AI coding assistants, planting persistence hooks in `.claude/settings.json`. When Claude Code installs dependencies autonomously, behavioral signals catch compromised packages that vulnerability databases miss. Both axios and chalk scored CRITICAL before their attacks.

Built on [proof-of-commitment](https://github.com/piiiico/proof-of-commitment) (npm, PyPI, Cargo, Go support).