### PR TITLE
Add reviewer-author loop plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1234,6 +1234,23 @@
       ]
     },
     {
+      "name": "reviewer-author-loop",
+      "source": "./plugins/reviewer-author-loop",
+      "description": "Human-in-the-loop manuscript improvement workflow that cycles through reviewer critique, author revision, verification, and re-review until acceptance or a pause condition.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Han Hu",
+        "url": "https://github.com/hanhuark"
+      },
+      "category": "Workflow Orchestration",
+      "homepage": "https://github.com/hanhuark/reviewer-author-loop-skill",
+      "keywords": [
+        "workflow",
+        "writing",
+        "review"
+      ]
+    },
+    {
       "name": "product-sales-specialist",
       "source": "./plugins/product-sales-specialist",
       "description": "Use this agent when you need to support B2B sales through product design, user research, project management, and creative RFP responses. This agent specializes in creating compelling product demonstrations, design-focused RFP sections, user experience narratives, and project management frameworks that win enterprise deals. Combines product expertise with sales enablement. Examples:",

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)
+- [reviewer-author-loop](./plugins/reviewer-author-loop)
 - [studio-coach](./plugins/studio-coach)
 - [ultrathink](./plugins/ultrathink)
 

--- a/plugins/reviewer-author-loop/.claude-plugin/plugin.json
+++ b/plugins/reviewer-author-loop/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "reviewer-author-loop",
+  "description": "Human-in-the-loop manuscript improvement workflow that cycles through reviewer critique, author revision, verification, and re-review until acceptance or a pause condition.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Han Hu",
+    "url": "https://github.com/hanhuark"
+  },
+  "homepage": "https://github.com/hanhuark/reviewer-author-loop-skill"
+}

--- a/plugins/reviewer-author-loop/commands/reviewer-author-loop.md
+++ b/plugins/reviewer-author-loop/commands/reviewer-author-loop.md
@@ -1,0 +1,15 @@
+# Reviewer-Author Loop
+
+Run an iterative manuscript improvement workflow:
+
+1. Review the manuscript as a skeptical but constructive peer reviewer.
+2. Revise as the author to address actionable comments.
+3. Verify that each comment was resolved without introducing unsupported claims.
+4. Re-review the revised manuscript.
+5. Continue until the manuscript is acceptable or pause when human input is needed.
+
+Pause and ask the researcher when progress requires new experiments, unavailable data, original theory, modeling choices, citation judgment, or confidential author decisions.
+
+Use the full skill when available:
+
+https://github.com/hanhuark/reviewer-author-loop-skill


### PR DESCRIPTION
## Summary
- Adds a reviewer-author-loop plugin entry under Workflow Orchestration.
- Adds a minimal command wrapper for a human-in-the-loop manuscript improvement workflow.
- Updates the marketplace metadata.

## Upstream skill repo
https://github.com/hanhuark/reviewer-author-loop-skill