### PR TITLE
Add claude-prompt plugin (Workflow Orchestration)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,23 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "claude-prompt",
+      "source": "./plugins/claude-prompt",
+      "description": "Rewrites your request into an optimized, reasoning-maximizing prompt, then immediately carries it out. Ships the /p command.",
+      "version": "0.1.0",
+      "author": {
+        "name": "Daniel Kremen",
+        "url": "https://github.com/danielkremen818"
+      },
+      "category": "Workflow Orchestration",
+      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/claude-prompt",
+      "keywords": [
+        "prompt-engineering",
+        "prompt-optimizer",
+        "workflow"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -58,6 +58,7 @@
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [claude-prompt](./plugins/claude-prompt)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [claude-prompt](./plugins/claude-prompt)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/plugins/claude-prompt/.claude-plugin/plugin.json
+++ b/plugins/claude-prompt/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "claude-prompt",
+  "description": "Rewrites your request into an optimized, reasoning-maximizing prompt, then immediately carries it out. Ships the /p command.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Daniel Kremen",
+    "url": "https://github.com/danielkremen818"
+  },
+  "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/claude-prompt",
+  "license": "MIT",
+  "keywords": [
+    "prompt-engineering",
+    "prompt-optimizer",
+    "meta-prompting",
+    "extended-thinking",
+    "workflow"
+  ]
+}

--- a/plugins/claude-prompt/commands/p.md
+++ b/plugins/claude-prompt/commands/p.md
@@ -1,0 +1,20 @@
+---
+description: "Prompt optimizer · rewrite this request into an optimized prompt (ultrathink), then carry it out"
+argument-hint: "[your request]"
+---
+
+You are operating in **PROMPT OPTIMIZER** mode for Claude.
+
+**Step 1 — Optimize.** Rewrite the request below into an optimized prompt that maximizes reasoning quality, applying these techniques:
+1. **Structured context** — add explicit reasoning frameworks and step-by-step structure.
+2. **Specificity** — turn vague asks into detailed, actionable requirements with clear success criteria.
+3. **Meta-instructions** — add guidance that leverages extended thinking and planning.
+4. **Skip-comments** — do NOT alter any text inside double quotes ("like this").
+
+**Step 2 — Show it.** Output the rewritten prompt under a short `**Optimized prompt:**` heading.
+
+**Step 3 — Execute.** Immediately carry out the optimized prompt in full.
+
+Request to optimize and execute:
+
+$ARGUMENTS


### PR DESCRIPTION
Adds **claude-prompt** — a single `/p` command that rewrites your request into an optimized, reasoning-maximizing prompt (structured context, specificity, meta-instructions for extended thinking, and skip-comments that preserve any text inside double quotes), then immediately carries it out.

Listed under **Workflow Orchestration** (alongside other prompt/orchestration plugins like `lyra`).

Changes:
- `plugins/claude-prompt/` — `.claude-plugin/plugin.json` + `commands/p.md`
- `.claude-plugin/marketplace.json` — new entry
- `README.md` + `README-zh.md` — listing under Workflow Orchestration

Source repo: https://github.com/danielkremen818/claude-prompt (MIT, zero dependencies, no code/hooks — just the command).