### PR TITLE
docs: add iOS app dev skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
+- [ios-app-dev-skills](https://github.com/JasonColapietro/ios-app-dev-skills)
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)


### PR DESCRIPTION
Adds the public iOS App Dev Skills pack to the Development Engineering section.

The repository contains reusable Claude/Codex skills and slash-command workflows for turning websites, web apps, dashboards, PWAs, and content surfaces into App Store-ready iOS apps with SwiftUI/Capacitor paths, ASO, screenshots, privacy checks, and release gates.

Validation:
- git diff --check