### PR TITLE
Add NotFair to Marketing Growth (SEO, GEO & paid-ads skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [content-creator](./plugins/content-creator)
 - [growth-hacker](./plugins/growth-hacker)
 - [instagram-curator](./plugins/instagram-curator)
+- [notfair](./plugins/notfair)
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
 - [twitter-engager](./plugins/twitter-engager)

--- a/plugins/notfair/.claude-plugin/plugin.json
+++ b/plugins/notfair/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "notfair",
+  "description": "Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.",
+  "version": "1.0.0",
+  "author": {
+    "name": "nowork-studio"
+  },
+  "homepage": "https://github.com/nowork-studio/NotFair"
+}

--- a/plugins/notfair/agents/notfair.md
+++ b/plugins/notfair/agents/notfair.md
@@ -1,0 +1,32 @@
+# NotFair
+
+## Description
+
+NotFair provides Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. It connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — enabling Claude to audit campaigns, find wasted spend, research keywords, optimize meta tags, generate schema markup, and ship fixes directly.
+
+### Skill Areas
+
+1. **SEO / GEO**
+   - Site analysis and keyword research
+   - Meta tags optimization and schema markup generation
+   - GEO (generative engine optimization) for AI search visibility
+   - Content writing and content planning
+   - Broken link checking and site architecture review
+
+2. **Google Ads**
+   - Full account audits and wasted-spend detection
+   - Search-term cleanup and negative keyword management
+   - Keyword and bid management
+
+3. **Meta Ads (Facebook + Instagram)**
+   - ROAS analysis and creative fatigue detection
+   - Audience overlap identification
+   - Campaign and ad set optimization
+
+## System Prompt
+
+You are a marketing specialist with access to live ad and analytics data via the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+
+Use these connections to audit campaigns, surface optimization opportunities, and implement improvements — always backing recommendations with real account data.
+
+Source: https://github.com/nowork-studio/NotFair


### PR DESCRIPTION
Thanks for maintaining this list — it's a great resource for the Claude Code community.

I'd like to add **NotFair** ([nowork-studio/NotFair](https://github.com/nowork-studio/NotFair), MIT, ~2.9k stars) to the **Marketing Growth** section.

NotFair is an open-source set of Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. It connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so Claude can pull real account data, surface issues, and implement fixes directly from the editor.

Skill areas:
- **SEO / GEO** — keyword research, meta tags, schema markup, GEO optimization, content writing
- **Google Ads** — account audits, wasted-spend detection, search-term cleanup, bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap

I've followed the same plugin structure used by other entries (plugin.json + agents stub). Happy to reword the description, move it to a different section, or trim anything that doesn't fit the list's style.