### PR TITLE
Add Synder Importer MCP plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
 - **Hooks** — Extensions that modify Claude Code’s behavior at key workflow points
 
 Install or disable them dynamically with the `/plugin` command — enabling you to keep your system context focused and lightweight.
+- [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 
 ## Use Cases
 


### PR DESCRIPTION
Adds the **Synder Importer MCP** to the plugin listings section (matches the inline format used by recent PRs #269, #270 for external MCP servers).

**What**
Official Synder plugin: import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools + the `gl-importer` agent skill.

**Verification**
- npm: https://www.npmjs.com/package/@cloudbusiness/gl-importer-mcp (v0.1.1, npm provenance + `mcpName` field)
- Official MCP Registry: `com.synder/gl-importer-mcp` (DNS-authenticated under synder.com)
- Repo: https://github.com/SynderAccounting/gl-importer-plugin
- License: MIT

**Install**
\`\`\`bash
npx -y @cloudbusiness/gl-importer-mcp
\`\`\`