### PR TITLE
Add automatic-episodic-memory to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Workflow Orchestration
 - [angelos-symbo](./plugins/angelos-symbo)
+- [automatic-episodic-memory](https://github.com/automattf/automatic-episodic-memory) — Episodic memory with automatic recall for Claude Code: captures work across context compactions and surfaces relevant past episodes automatically on prompts, tool calls, and turn end, with no manual logging or lookup.
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [lyra](./plugins/lyra)


### PR DESCRIPTION
Adds automatic-episodic-memory.

Episodic memory with automatic recall for Claude Code: it captures work across context compactions and surfaces relevant past episodes automatically on prompts, tool calls, and turn end, with no manual logging or lookup.

How it differs from other memory plugins: most memory and notes plugins are recall-on-demand or manual-capture, where the agent has to remember to log a memory and to query for it. This one automates both ends. Capture runs automatically when the context window compacts, and recall is hook-driven, surfacing the relevant past episode on its own before the agent reasons. That hands-free automatic recall is the distinguishing feature, so this is not a duplicate of existing memory entries.

Repo: https://github.com/automattf/automatic-episodic-memory
Install: `/plugin marketplace add automattf/claude-plugins` then `/plugin install automatic-episodic-memory@automattf-plugins`