### PR TITLE
Add Imagine — Gemini for Claude Code & Codex (Development Engineering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [react-native-dev](./plugins/react-native-dev)
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
+- [Imagine](https://github.com/freestyler-arb/imagine-gemini-for-claude-codex) - Brings Google Gemini into Claude Code & Codex: delegate reasoning, independent code review, deep research, and automatic prompt-engineering. Runs on your Google AI Pro subscription, not your agent's tokens.
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)


### PR DESCRIPTION
Adds Imagine under Development Engineering. MIT plugin/skill pack that lets Claude Code & Codex delegate to Google Gemini: gemini-pro (reasoning), gemini-review (independent code review), gemini-research (deep research), gemini-proxy (auto prompt-engineering). Runs on your Google AI Pro/Ultra subscription, not your agent's tokens. Repo: https://github.com/freestyler-arb/imagine-gemini-for-claude-codex (my own project).