### PR TITLE
Add Skill Hub — 4133+ AI Agent Skills Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,11 @@ Example:
 /plugin install analyze-codebase
 ```
 
+## Also See
+
+- [Skill Hub](https://github.com/rdone4425/skill) — 4133+ AI Agent Skills directory with 22 categories and platform filters (Claude Code, Codex, Cursor, Hermes). [Live](https://skill.442595.xyz/)
+
+
 ## Contributing
 
 Contributions are welcome!


### PR DESCRIPTION
Added Skill Hub to the Also See section.

Skill Hub is a categorized directory with 4133+ AI Agent Skills across 22 categories.

🔗 https://skill.442595.xyz/