### PR TITLE
Add x-skills to Marketing Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
 - [twitter-engager](./plugins/twitter-engager)
+- [x-skills](https://github.com/sergebulaev/x-skills)
 
 ### Project & Product Management
 - [discuss](./plugins/discuss)


### PR DESCRIPTION
Adds x-skills to the Marketing Growth section.

x-skills is a bundle of 6 Claude Code and Codex skills for X (Twitter): tweets and auto-threads, hook extractor, humanizer, reply drafter, and weekly planner. MIT licensed.

- Repo: https://github.com/sergebulaev/x-skills
- Install: `/plugin marketplace add sergebulaev/x-skills`

Inserted alphabetically after twitter-engager. Single line added, no other changes.