### PR TITLE
Add yaohe (open-source project promotion plugin)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,23 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "yaohe",
+      "source": "./plugins/yaohe",
+      "description": "吆喝 — Let your agent promote your open-source project across 20 CN & EN channels, rule-abiding and per-channel tailored.",
+      "version": "0.1.0",
+      "author": {
+        "name": "nmhjklnm"
+      },
+      "category": "Marketing Growth",
+      "homepage": "https://github.com/nmhjklnm/yaohe",
+      "keywords": [
+        "open-source",
+        "promotion",
+        "marketing",
+        "launch"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -166,8 +166,8 @@
 - [instagram-curator](./plugins/instagram-curator)
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
-- [yaohe](./plugins/yaohe)
 - [twitter-engager](./plugins/twitter-engager)
+- [yaohe](./plugins/yaohe)
 
 ### 项目与产品管理
 - [discuss](./plugins/discuss)

--- a/README-zh.md
+++ b/README-zh.md
@@ -166,6 +166,7 @@
 - [instagram-curator](./plugins/instagram-curator)
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
+- [yaohe](./plugins/yaohe)
 - [twitter-engager](./plugins/twitter-engager)
 
 ### 项目与产品管理

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [instagram-curator](./plugins/instagram-curator)
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
+- [yaohe](./plugins/yaohe)
 - [twitter-engager](./plugins/twitter-engager)
 
 ### Project & Product Management

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [instagram-curator](./plugins/instagram-curator)
 - [reddit-community-builder](./plugins/reddit-community-builder)
 - [tiktok-strategist](./plugins/tiktok-strategist)
-- [yaohe](./plugins/yaohe)
 - [twitter-engager](./plugins/twitter-engager)
+- [yaohe](./plugins/yaohe)
 
 ### Project & Product Management
 - [discuss](./plugins/discuss)

--- a/plugins/yaohe/.claude-plugin/plugin.json
+++ b/plugins/yaohe/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "yaohe",
+  "version": "0.1.0",
+  "description": "吆喝 — 让 Agent 自动全网宣传你的开源项目。Rule-abiding, per-channel tailored promotion across 20 CN & EN channels",
+  "author": { "name": "nmhjklnm" }
+}

--- a/plugins/yaohe/LICENSE
+++ b/plugins/yaohe/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 nmhjklnm
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/yaohe/README.md
+++ b/plugins/yaohe/README.md
@@ -1,0 +1,40 @@
+# 吆喝 yaohe
+
+让 Agent 自动全网宣传你的开源项目 —— 一个 Claude Code skill。
+
+![yaohe](https://raw.githubusercontent.com/nmhjklnm/yaohe/main/docs/assets/banner.png)
+
+写完项目没人知道？宣传渠道很多（阮一峰周刊自荐、HelloGitHub、Show HN、V2EX…），但每个渠道格式不同、规则不同，还得一个个手动投。吆喝内置 20 个渠道的实证规格，把这件事变成一条命令，发新版本时顺手全网吆喝一嗓子：
+
+```
+/promote <repo 路径或 owner/repo>
+```
+
+它会：
+
+1. **读你的 repo**，提炼项目定位和亮点
+2. **按渠道定制文案** —— 阮一峰自荐格式、HelloGitHub 标准、Show HN 标题惯例，各写各的，不是一稿群发
+3. **分级执行**：
+   - issue/PR 型渠道（阮一峰周刊等）→ `gh` CLI 确认后直接提交
+   - 表单型（Product Hunt 等）→ 稿件 + 逐字段指引
+   - 社区发帖型（Show HN、V2EX、Reddit）→ 只出稿不代发，附最佳发帖时间和社区红线
+4. **记录投递日志**（`PROMO-LOG.md`），防止重复骚扰渠道
+
+## 为什么"合规"是核心设计
+
+社区发帖型渠道反感机器发帖：HN 封 voting ring 连坐域名，Reddit 有 self-promotion 比例规则。所以吆喝的边界是：**自动化提交只用于渠道方明确开放的自荐入口（issue/PR/表单），社区帖永远人工发**。这不是功能缺失，是产品原则。
+
+## 安装
+
+```
+claude plugin marketplace add nmhjklnm/yaohe
+claude plugin install yaohe
+```
+
+## 渠道覆盖
+
+见 [skills/promote/channels/](skills/promote/channels/)。每个渠道一个文件，含实证过的提交方式、格式规格、真实样例。欢迎 PR 添加新渠道（按 [channels/_template.md](skills/promote/channels/_template.md)）。
+
+## License
+
+MIT

--- a/plugins/yaohe/skills/promote/SKILL.md
+++ b/plugins/yaohe/skills/promote/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: promote
+description: Promote an open-source project across CN & EN channels — reads the repo, generates per-channel tailored copy, auto-submits issue/PR-type channels via gh, assists the rest. Use when the user wants to 宣传/推广/publicize/launch/submit their open-source project, or asks "帮我把这个项目投到阮一峰周刊/HelloGitHub/Show HN".
+---
+
+# promote — 开源项目一键合规宣传
+
+核心原则：**一键 ≠ 一键全发**。渠道分三级自动化，越权发帖 = spam = 毁项目声誉。
+
+## 流程
+
+### 1. 项目画像（必做，一切文案的源头）
+
+**硬性前置闸门，任一不过就停下问用户，不进入后续步骤：**
+
+- `gh repo view <owner>/<repo>` 必须成功（仓库公开可达）。本地路径则检查 `git remote -v` 有 GitHub remote 且已 push——**稿件里的每个链接都必须真实可达，绝不写入死链**
+- LICENSE 文件真实存在才可声明协议；README 说 MIT 但没有 LICENSE 文件 → 提醒用户先补
+
+然后读 README 全文、描述、topics、star 数、最近活跃度，提炼：一句话定位（它是什么+替代/优于什么）、目标人群、3 个差异化亮点、演示素材（截图/GIF/demo URL）。
+
+README 薄的判定（缺任一项即问用户补齐，不要编）：① 一句话说清它是什么 ② 安装/使用方法 ③ 至少一个具体使用场景或示例。
+
+### 2. 渠道选择
+
+读 `channels/` 下所有渠道文件的 frontmatter，按项目画像过滤：
+
+- 语言匹配：投 EN 渠道的条件 = 有英文 README（或 README 本身是英文）；不满足时该渠道仍可列出但标注「需先补英文文档」，用户坚持投则明示风险后照办
+- 门槛匹配（如渠道要求 star 数 / 入门级 / dev-tool 类目）
+- 检查 `PROMO-LOG.md`（项目根目录）：**同一渠道 30 天内有任何记录（含 rejected）即跳过**，冷却期从最新一条记录的日期起算
+
+用 AskUserQuestion 列出推荐渠道（含自动化等级标注）让用户勾选；用户明确说"全投"则投所有合规匹配渠道。
+
+### 3. 逐渠道生成定制稿
+
+对每个选中渠道，读其 `channels/<id>.md` 全文，**严格按其 format_spec 生成**：
+
+- 禁止一稿多投：每渠道的标题风格、篇幅、语气、结构都不同（阮一峰自荐 ≠ Show HN 标题 ≠ V2EX 分享创造帖）
+- 文案原则：说人话、给事实（能做什么、和现有方案差在哪），禁营销腔/AI 味（震惊体、emoji 堆砌、buzzword）
+- **去 AI 味终审（必做）**：装了 deslop 类 skill 就调用它过一遍；没装则至少执行硬规则：禁破折号（——）、禁「不是…而是…」否定对比句、弯引号换直角引号「」、删段末总结句、删互联网黑话
+- **配图（必做）**：几乎所有渠道带图命中率都更高。优先级：① 项目已有截图/GIF 直接用 ② 真实运行录屏/截图（终端工具录一段 demo）③ 用可用的图像生成能力（imagegen/codex 出图/自绘 SVG 转 PNG）设计一张说明产品原理的宣传图。图片提交到项目仓库（如 `docs/assets/`）用 raw.githubusercontent.com URL 引用，别用外部图床。渠道规格标注图片必备的（如 ruanyf-weekly），无图不投
+- 全部稿件先写入 `promo-drafts/<channel-id>.md` 落盘；**文件首行固定为 `Title: <标题>`**（即使该渠道标题走 `gh --title` 参数不进 body），复盘时才对得上号
+
+### 4. 分级执行
+
+按渠道 frontmatter 的 `automatable` 字段：
+
+- **full**（issue/PR 型）：先 `gh auth status` 确认已登录（未登录 → 让用户 `gh auth login`，停在这里）→ 展示最终稿 → 用户确认一次 → `gh` CLI 提交 → 记录返回 URL。失败就报错停，不换渠道兜底。
+- **assisted**（网页表单型）：给出最终稿 + 提交 URL + 逐字段填写指引；有浏览器工具可代填但提交按钮由用户点。
+- **manual-only**（社区发帖型）:只交稿件 + 建议发帖时间（见渠道文件）+ 红线提醒。**任何情况下不代发**。
+
+### 5. 记录与复盘
+
+把本次投递写入目标项目根目录 `PROMO-LOG.md`，固定表格 schema（机器可读，下次运行先读它）：
+
+```markdown
+| channel | date | draft | url | status |
+|---|---|---|---|---|
+| ruanyf-weekly | 2026-07-02 | promo-drafts/ruanyf-weekly.md | https://github.com/ruanyf/weekly/issues/NNN | submitted |
+```
+
+- `date` 用 ISO（YYYY-MM-DD）；`status` ∈ draft / submitted / published / rejected
+- 30 天冷却按该渠道最新一行的 date 计算，任何 status 都算
+
+## 红线（任何渠道通用）
+
+- 不伪造用户身份发言；不注册马甲；不安排互赞互顶（HN voting ring 会连坐封域名）
+- 同一渠道 30 天内不重复投同一项目
+- 渠道规则与本 skill 冲突时，以渠道最新规则为准（提交前 spot-check 渠道规则页是否变化）

--- a/plugins/yaohe/skills/promote/channels/_template.md
+++ b/plugins/yaohe/skills/promote/channels/_template.md
@@ -1,0 +1,25 @@
+---
+id: <channel-id>
+name: <渠道名>
+lang: cn | en
+automatable: full | assisted | manual-only
+submission_method: github-issue-comment | github-issue | github-pr | web-form | community-post | post-article
+target: <提交入口 URL 或 repo#issue，动态入口写发现方法>
+audience: <这个渠道的读者是谁>
+threshold: <收录门槛，无则写 none>
+verified: <YYYY-MM-DD 实证日期>
+---
+
+# <渠道名>
+
+## format_spec
+
+（标题格式、正文结构、篇幅、语气。附 1-2 个真实优秀样例全文。）
+
+## rules
+
+（频率限制、内容红线、什么行为会被视为 spam。）
+
+## submit
+
+（automatable=full 时：具体 gh 命令模板。assisted：逐字段清单。manual-only：最佳发帖时间 + 发帖后注意事项。）

--- a/plugins/yaohe/skills/promote/channels/appinn.md
+++ b/plugins/yaohe/skills/promote/channels/appinn.md
@@ -1,0 +1,26 @@
+---
+id: appinn
+name: 小众软件·发现频道
+lang: cn
+automatable: manual-only
+submission_method: community-post
+target: https://meta.appinn.net/c/faxian/10（需注册论坛账号）
+audience: 发布后同步 appinn.com 首页、x.appinn.com、Twitter、Telegram 多渠道
+threshold: none
+verified: 2026-07-02（置顶版规原文在认证墙后，unverified）
+---
+
+# 小众软件自荐
+
+## format_spec
+
+标题惯例：`【开发者自荐】`或`【开源自荐】`+ 项目名；正文：简介 / 平台 / 功能特点 / 是否开源。发帖前先读频道置顶「内容提交规则」。
+
+## rules
+
+- **发布后不要删帖**：帖子同步到多个下游渠道，删帖会造成同步 404
+- 具体审核/查重规则 unverified，以置顶帖为准
+
+## submit
+
+manual-only：出稿 → 用户注册论坛账号自发。

--- a/plugins/yaohe/skills/promote/channels/awesome-claude-code.md
+++ b/plugins/yaohe/skills/promote/channels/awesome-claude-code.md
@@ -1,0 +1,32 @@
+---
+id: awesome-claude-code
+name: Awesome Claude Code（47.8k★，Claude Code 生态最大列表）
+lang: en
+automatable: manual-only
+submission_method: web-form
+target: https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommend-resource.yml
+audience: Claude Code 用户的选型入口；收录后可挂 "Mentioned in Awesome Claude Code" 徽章
+threshold: 精选制；机器人自动校验字段/URL/查重/license + 人工审核
+verified: 2026-07-02
+---
+
+# Awesome Claude Code
+
+**红线：禁止 PR、禁止 gh CLI 提交**。官方原话："ALL RECOMMENDATIONS MUST BE MADE USING THE WEB UI ISSUE FORM TEMPLATE, OR YOU RISK BEING BANNED"。必须真人在网页 issue 表单填写；审核通过后机器人自动开 PR 合并。
+
+## format_spec
+
+表单字段：Display Name / Category（选 Tooling 或 Slash-Commands 等）/ Sub-Category / Primary Link / Author Name / Author Link / License / 1-2 句功能描述。
+
+描述要求**证据导向**：给出可复现验证的具体用法（如实际 prompt/命令），别写「装上见证奇迹」式空话。若插件涉及非 Anthropic 服务器的网络请求 / 修改系统文件 / 遥测 / 需要 bypass-permissions，必须在描述中明确声明。
+
+## rules
+
+- 近期因 spam 有临时封禁先例，措辞谨慎、一次提交、不催审
+- 仅 Claude Code 生态资源适用
+
+## submit
+
+manual-only：生成表单各字段的值 → 用户网页填写。
+
+次选（专收 plugin 的列表，865★，标准 PR 制）：`ccplugins/awesome-claude-code-plugins`——在 `plugins/<name>` 加目录 + README 对应分类加一行 `- [name](./plugins/name)`，有 README-zh.md 可同时提中文条目，此列表可走 `gh` PR（automatable: full）。

--- a/plugins/yaohe/skills/promote/channels/awesome-list.md
+++ b/plugins/yaohe/skills/promote/channels/awesome-list.md
@@ -1,0 +1,35 @@
+---
+id: awesome-list
+name: Awesome List 收录（PR 到相关 awesome-* 仓库）
+lang: en
+automatable: full
+submission_method: github-pr
+target: 动态发现：`gh api -X GET search/repositories -f q='awesome <领域关键词> in:name' --jq '.items[:5][] | {full_name, stargazers_count}'`
+audience: 长尾持续流量（awesome list 是开发者选型入口，SEO 价值高）
+threshold: 项目需真实可用、维护中；各列表另有自己的 contributing 规则
+verified: 2026-07-02
+---
+
+# Awesome List 收录
+
+注意区分两件事：**向某个领域 awesome-\* 列表添加你的项目**（本渠道的主用途，门槛低）vs **向 sindresorhus/awesome 主仓提交一个新列表**（门槛高：列表满 30 天、CC0、awesome-lint、先评审 4 个他人 PR 等，一般用不到）。
+
+## format_spec（条目 PR）
+
+- 先读目标列表的 `contributing.md`（有就必须遵守）
+- 条目格式（awesome 生态通例）：`[Name](url) - Description.`——描述首字母大写、句号结尾、描述项目本身、禁营销话术
+- 插入位置遵守列表的现有排序（字母序/分类）
+- PR 标题：`Add <Name>`；PR 描述说明项目为什么属于这个列表
+- **红线：禁止全 AI 生成的 PR**（sindresorhus 生态明文拒绝）——稿件须经用户过目确认后再提
+
+## submit
+
+```bash
+# 1. 找目标列表（按项目领域关键词），人工确认相关性
+# 2. fork + 单行改动 + PR
+gh repo fork <owner>/<awesome-repo> --clone
+# 编辑对应分类下插入条目
+gh pr create -R <owner>/<awesome-repo> --title "Add <Name>" --body-file promo-drafts/awesome-list.md
+```
+
+一次只投最相关的 1-2 个列表，广撒网式 PR 会被生态圈拉黑。

--- a/plugins/yaohe/skills/promote/channels/dev-newsletters.md
+++ b/plugins/yaohe/skills/promote/channels/dev-newsletters.md
@@ -1,0 +1,22 @@
+---
+id: dev-newsletters
+name: 开发者 Newsletter（Changelog News / console.dev）
+lang: en
+automatable: manual-only
+submission_method: web-form
+target: changelog.com/news/submit（需登录）· console.dev 走编辑联系 hello@console.dev
+audience: Changelog（大型开发者播客/newsletter）；console.dev（每周 dev tools 精选，3 万+ 订阅）
+threshold: 编辑精选制，接受率低
+verified: 2026-07-02
+---
+
+# 开发者 Newsletter
+
+## rules
+
+- **Changelog News 明确拒绝**：教程类、商业产品推广（那要走赞助）、体验差的网站。产品直投大概率被拒——必须包装成对开发者同行有新闻价值的技术性新闻角度，零营销语气
+- console.dev 无自助提交，是编辑评测制，邮件联系争取被收录
+
+## submit
+
+manual-only：出「新闻角度」稿（发生了什么、为什么对开发者重要）→ 用户提交/发邮件。预期管理：这类渠道命中率低，投了别等。

--- a/plugins/yaohe/skills/promote/channels/devto.md
+++ b/plugins/yaohe/skills/promote/channels/devto.md
@@ -1,0 +1,35 @@
+---
+id: devto
+name: dev.to
+lang: en
+automatable: full
+submission_method: post-article
+target: Forem API v1 `POST https://dev.to/api/articles`（文档 https://developers.forem.com/api）
+audience: 大型开发者博客社区，开源 showcase 是常见形式
+threshold: 需用户在 dev.to 设置页生成 api-key
+verified: 2026-07-02
+---
+
+# dev.to 发文
+
+唯一有公开可编程发布 API 的社区渠道。
+
+## format_spec
+
+- 文章形态：showcase 长文（做了什么/为什么/怎么用/求反馈），markdown 正文
+- tags：逗号分隔，建议 opensource + 领域 tag（如 claudecode/ai/productivity）
+
+## rules
+
+无官方 self-promo 书面限制，依赖社区礼仪：讲干货不发纯广告。
+
+## submit
+
+```bash
+curl -s -X POST https://dev.to/api/articles \
+  -H "api-key: $DEVTO_API_KEY" -H "content-type: application/json" \
+  -H "accept: application/vnd.forem.api-v1+json" \
+  -d '{"article":{"title":"...","body_markdown":"...","published":false,"tags":["opensource"]}}'
+```
+
+先 `published: false` 存草稿给用户预览，用户确认后再置 true 发布。

--- a/plugins/yaohe/skills/promote/channels/eleduck.md
+++ b/plugins/yaohe/skills/promote/channels/eleduck.md
@@ -1,0 +1,19 @@
+---
+id: eleduck
+name: 电鸭社区·独立产品
+lang: cn
+automatable: manual-only
+submission_method: community-post
+target: https://eleduck.com/categories/15（需注册；先读规则帖 https://eleduck.com/posts/6GzfGe）
+audience: 远程工作/独立开发者社区
+threshold: none（发帖是否耗「电量」unverified）
+verified: 2026-07-02（板块确认存在，帖子模板 unverified）
+---
+
+# 电鸭·独立产品
+
+社区偏好真实开发故事而非硬广。出稿走「独立开发者叙事」：为什么做、怎么做的、目前状态、求反馈。
+
+## submit
+
+manual-only：出稿 → 用户注册自发，发帖前读社区规则帖。

--- a/plugins/yaohe/skills/promote/channels/gitee-gvp.md
+++ b/plugins/yaohe/skills/promote/channels/gitee-gvp.md
@@ -1,0 +1,24 @@
+---
+id: gitee-gvp
+name: Gitee GVP（最有价值开源项目）
+lang: cn
+automatable: assisted
+submission_method: web-form
+target: https://gitee.com/gvp/new（需登录；总入口 https://gitee.com/gvp）
+audience: Gitee 官方认证曝光，按月评选公布
+threshold: 项目需托管/镜像在 Gitee；OSI 认可的开源协议；活跃维护
+verified: 2026-07-02（表单字段需登录可见，unverified）
+---
+
+# Gitee GVP
+
+**只适合已有 Gitee 仓库/镜像的项目**，纯 GitHub 项目先建镜像再申请。
+
+## rules
+
+- 硬门槛：OSI 协议、积极回应用户反馈、不许刷数据、入选后不得转私有或删库
+- 评定 = 客观硬指标 + 评委会投票，按月公布
+
+## submit
+
+assisted：确认项目有 Gitee 镜像 → 用户登录填表（字段需登录后实测，首次走这条线时把字段补回本文件）。

--- a/plugins/yaohe/skills/promote/channels/githubdaily.md
+++ b/plugins/yaohe/skills/promote/channels/githubdaily.md
@@ -1,0 +1,34 @@
+---
+id: githubdaily
+name: GitHubDaily（自荐）
+lang: cn
+automatable: full
+submission_method: github-issue
+target: https://github.com/GitHubDaily/GitHubDaily/issues/new
+audience: 公众号/微博/知乎/X 多平台分发的开发者流量
+threshold: none
+verified: 2026-07-02
+---
+
+# GitHubDaily 自荐
+
+README 原话："欢迎到本仓库的 issues 推荐或自荐项目"。无 issue 模板，人工从 issue 筛选后分发到公众号/微博/知乎/X，无固定审核周期。
+
+## format_spec
+
+- 标题 = 项目名
+- 正文 = GitHub 链接 + 一句话简述（核心功能点 + 适用场景），散文体即可
+- 「一句话简述」的写法水准参照其年度复盘表格里的条目风格（信息密度高、无废话）——那个 `项目名 | 简述` 的 pipe 格式是 GitHubDaily 自己排版用的，**不是** issue 正文格式，别照抄
+- 简洁为王，不需要长文
+
+## rules
+
+无 star / 字数门槛明文规定。被选中无通知，靠人工筛选。
+
+## submit
+
+```bash
+gh issue create -R GitHubDaily/GitHubDaily \
+  --title "<项目名>" \
+  --body-file promo-drafts/githubdaily.md
+```

--- a/plugins/yaohe/skills/promote/channels/hellogithub.md
+++ b/plugins/yaohe/skills/promote/channels/hellogithub.md
@@ -1,0 +1,37 @@
+---
+id: hellogithub
+name: HelloGitHub（自荐）
+lang: cn
+automatable: assisted
+submission_method: web-form
+target: https://hellogithub.com/periodical （页面内「推荐或自荐开源项目」弹窗表单）
+audience: 「有趣、入门级开源项目」定位的月刊 + 网站首页收录
+threshold: 仅接受 https://github.com 开头的仓库地址；且不能是已收录项目
+verified: 2026-07-02
+---
+
+# HelloGitHub 自荐
+
+**没有 GitHub issue/PR 通道**（仓库 README 也指向网站表单）。表单是 SPA 前端弹窗，CLI 不可达 → assisted：生成好三个字段的稿件，用户（或浏览器工具）到页面填写提交。
+
+## format_spec
+
+表单三字段（实证抓取的前端校验规则）：
+
+| 字段 | 要求 |
+|---|---|
+| 项目地址 | 必须 `https://github.com` 开头，未被收录过 |
+| 标题 | 一句话介绍项目，**5-50 字符** |
+| 描述 | **10-300 字符**，官方提示：从"它是什么、解决了什么痛点"介绍，包括技术、功能、适用场景；"描述通俗易懂、符合要求可以提高通过率" |
+
+## rules
+
+- 每日提交次数有限（前端有"今天还可以提交 N 次"文案，上限疑为 1 次/天，unverified）
+- 月刊偏好"有趣、入门级"项目；网站首页收录与月刊是两套机制，表单进的是首页收录库
+- 提交后在「审核进度」查看状态，通过审核才会在首页展示
+
+## submit
+
+1. 生成三字段稿件（严格卡字符数）写入 `promo-drafts/hellogithub.md`
+2. 引导用户打开 https://hellogithub.com/periodical → 点「推荐或自荐开源项目」→ 逐字段粘贴
+3. 有 Chrome 浏览器工具时可代填表单，**提交按钮由用户确认后再点**

--- a/plugins/yaohe/skills/promote/channels/indiehackers.md
+++ b/plugins/yaohe/skills/promote/channels/indiehackers.md
@@ -1,0 +1,19 @@
+---
+id: indiehackers
+name: Indie Hackers
+lang: en
+automatable: manual-only
+submission_method: web-form
+target: https://www.indiehackers.com/products（Add Yours）+ /new-post（milestone/story 帖）
+audience: 独立开发者/创业者社区
+threshold: 需登录；无公开 API
+verified: 2026-07-02（表单字段登录可见，unverified）
+---
+
+# Indie Hackers
+
+社区文化：晒真实增长数据和踩坑记录，纯广告帖被冷落。产品目录建条目后可持续发 milestone 更新帖。
+
+## submit
+
+manual-only：出稿（产品条目文案 + 首篇 story：为什么做/数据/求反馈）→ 用户登录自发。

--- a/plugins/yaohe/skills/promote/channels/jike.md
+++ b/plugins/yaohe/skills/promote/channels/jike.md
@@ -1,0 +1,19 @@
+---
+id: jike
+name: 即刻（独立开发圈子）
+lang: cn
+automatable: manual-only
+submission_method: community-post
+target: 发动态带圈子标签——「独立开发的日常」「产品安利社」「创业者的日常」「AI探索站」
+audience: 一次性曝光型，易被转载获取种子用户，无沉淀收录
+threshold: none（另有付费「产品发布会」官方推广位 159 元/年，非自荐范畴）
+verified: 2026-07-02
+---
+
+# 即刻发帖
+
+无强制格式。动态写法：一两句人话讲清做了什么+一张图+链接，选 1-2 个最相关圈子（别刷多圈）。
+
+## submit
+
+manual-only：出稿（短文案+配图）→ 用户自发。

--- a/plugins/yaohe/skills/promote/channels/launch-boards.md
+++ b/plugins/yaohe/skills/promote/channels/launch-boards.md
@@ -1,0 +1,26 @@
+---
+id: launch-boards
+name: 新一代 Launch 平台（Uneed / Microlaunch / Fazier / Peerlist）
+lang: en
+automatable: manual-only
+submission_method: web-form
+target: uneed.best/submit-a-tool · microlaunch.net（New Launch）· fazier.com/submit · peerlist.io/launchpad（unverified）
+audience: Product Hunt 替代品，早期采用者流量，量级小于 PH 但竞争也小
+threshold: 均需注册；表单字段多数在登录墙后（unverified）
+verified: 2026-07-02
+---
+
+# Launch 平台合集
+
+同类平台打包处理：素材复用 Product Hunt 的（tagline/描述/图），逐站微调。
+
+## rules
+
+- Uneed：免费提交，有付费加速档
+- Microlaunch：免费提交进月/周榜，每月约 98 个产品竞争，免费位易被淹没
+- Fazier：Basic 免费但**要求反向链接到 fazier**（15 天审核）；付费档 $19-149 免反链、立即发布
+- Peerlist Launchpad：流程 unverified，需登录实测
+
+## submit
+
+manual-only：复用 PH 素材包 → 用户登录逐站提交。优先级 Uneed > Microlaunch > Fazier（反链要求自行权衡）。

--- a/plugins/yaohe/skills/promote/channels/lobsters.md
+++ b/plugins/yaohe/skills/promote/channels/lobsters.md
@@ -1,0 +1,22 @@
+---
+id: lobsters
+name: Lobsters
+lang: en
+automatable: manual-only
+submission_method: community-post
+target: https://lobste.rs（邀请制注册）
+audience: 高质量技术社区，show tag 用于自建项目
+threshold: 需成员邀请入站；新用户前 70 天受限（不能提交新域名、不能用 show/announce 等 meta tag）
+verified: 2026-07-02
+---
+
+# Lobsters
+
+## rules
+
+- 官方硬规则：**self-promo 必须少于自己提交+评论总量的 1/4**——先真实参与讨论攒信誉，再用 show tag 发一次
+- 系统模糊匹配防重复提交
+
+## submit
+
+manual-only：出稿（标题+tag 选择建议）→ 有账号且账龄达标的用户自发。没账号就跳过此渠道，别为发帖找邀请。

--- a/plugins/yaohe/skills/promote/channels/oschina.md
+++ b/plugins/yaohe/skills/promote/channels/oschina.md
@@ -1,0 +1,26 @@
+---
+id: oschina
+name: 开源中国 OSCHINA（软件收录 + 资讯投递）
+lang: cn
+automatable: assisted
+submission_method: web-form
+target: https://www.oschina.net/ 登录后右上角个人菜单 →「投递资讯 / 软件」
+audience: 通过审核生成项目主页，OSCHINA 站内/Gitee/公众号矩阵联动曝光
+threshold: none
+verified: 2026-07-02
+---
+
+# OSCHINA 投递
+
+## format_spec
+
+- **投软件**：项目基本信息 + 详细介绍（特性/架构/原理，从开发者角度写）
+- **投资讯**（版本发布类）：关联软件名称（必填）、标题（名称+版本号+描述）、资讯出处（release 链接）、软件介绍（不知名项目需简述用途）；要求「有头有尾」叙述，**禁止直接罗列条目**
+
+## rules
+
+一个工作日内审核。频率限制 unverified。
+
+## submit
+
+assisted：生成两份稿（软件介绍 + 资讯稿）→ 用户登录后按入口粘贴。

--- a/plugins/yaohe/skills/promote/channels/product-hunt.md
+++ b/plugins/yaohe/skills/promote/channels/product-hunt.md
@@ -1,0 +1,34 @@
+---
+id: product-hunt
+name: Product Hunt
+lang: en
+automatable: assisted
+submission_method: web-form
+target: https://www.producthunt.com/launch
+audience: 早期采用者/SaaS 用户；dev tools 也有专区
+threshold: none，但需要完整素材包（图/tagline/描述）
+verified: 2026-07-02（素材规格为搜索汇总，发布前用官方 preparing-for-launch 页二次确认）
+---
+
+# Product Hunt
+
+GraphQL API v2 存在（api.producthunt.com/v2/docs）但**默认只读且不可商用**，创建 launch 的写权限需邮件申请——所以走 assisted：生成全套素材，用户网页提交。
+
+## format_spec（素材包清单）
+
+| 素材 | 规格 |
+|---|---|
+| Tagline | ≤60 字符，简短不夸张 |
+| Description | ≤500 字符 |
+| Thumbnail | 正方形 240x240 |
+| Gallery | ≥2 张，建议 1270x760，单文件 <3MB（GIF 可） |
+| First comment | maker 自述：动机 + 差异化 + 求反馈 |
+
+## rules
+
+- 红线：未授权不得用 API 批量创建 launch（官方明示 API 默认非商用）
+- 拉票同样有反作弊，只做"通知已有用户"级别的宣传
+
+## submit
+
+assisted：素材包全部生成落盘（含图片尺寸检查清单）→ 给出 launch 页 URL + 逐字段填写指引。

--- a/plugins/yaohe/skills/promote/channels/reddit.md
+++ b/plugins/yaohe/skills/promote/channels/reddit.md
@@ -1,0 +1,31 @@
+---
+id: reddit
+name: Reddit (r/SideProject · r/opensource)
+lang: en
+automatable: manual-only
+submission_method: community-post
+target: https://www.reddit.com/r/SideProject · https://www.reddit.com/r/opensource
+audience: 独立开发者 / 开源用户社区
+threshold: 账号需有一定 karma/账龄（具体阈值 unverified）
+verified: 2026-07-02（官方 rules 页本环境抓取被拦，格式部分为二手总结，使用前建议真人浏览器核对 about/rules）
+---
+
+# Reddit
+
+**只出稿不代发**：API 发帖需 OAuth 且自动化推广帖极易触发反垃圾系统。
+
+## format_spec（unverified，二手总结）
+
+- 故事化：做了什么 / 为什么做 / 用了什么技术 / 想要什么反馈；纯甩链接无上下文会被当 spam
+- r/SideProject 对自我推广相对宽容；r/opensource 允许 "limited and responsible self-promotion"
+- 同一项目复发帖间隔 3-4 周，且要有实质新内容
+
+## rules
+
+- "发完就跑"不回评论 = 不良行为
+- 短期重复发同一项目 = spam 判定
+- 提交前先让用户人工确认两个 sub 当前的 about/rules 页（本 skill 抓不到）
+
+## submit
+
+manual-only：按 sub 分别出稿（两边语境不同：SideProject 讲构建故事，opensource 讲项目本身与许可证/贡献方式）→ 用户自发。

--- a/plugins/yaohe/skills/promote/channels/ruanyf-weekly.md
+++ b/plugins/yaohe/skills/promote/channels/ruanyf-weekly.md
@@ -1,0 +1,64 @@
+---
+id: ruanyf-weekly
+name: 阮一峰科技爱好者周刊（自荐）
+lang: cn
+automatable: full
+submission_method: github-issue
+target: https://github.com/ruanyf/weekly/issues/new
+audience: 中文开发者/科技爱好者，周刊读者量大，上刊即显著曝光
+threshold: none（但纯营销/无代码的商业站几乎必被无声淘汰，见 rules）
+verified: 2026-07-02
+---
+
+# 阮一峰周刊自荐
+
+提交方式 = **开新 issue**（不是评论到固定 issue）。无 issue template，自由格式。注意：置顶的《谁在招人》issue 是招聘专用，与项目自荐无关。
+
+## format_spec
+
+**标题**：`【开源自荐】项目名：一句话卖点（品类）`。类型词可用 开源自荐/工具自荐/网站自荐；括号符号不强求统一。
+
+**正文结构**（高命中样本共性）：
+
+1. 开头 1-2 句说清"这是什么 + 解决什么具体痛点"，直给项目地址（GitHub repo 优先）
+2. 一张截图或 GIF demo（**强烈建议**，可视化越直观命中率越高）
+3. 核心特性 bullet 3-8 条（允许 emoji 前缀）
+4. 安装命令代码块（brew/npm/cargo 一键安装是加分项）
+5. 技术栈一行 + 开源协议（MIT 等，明示协议是加分项）
+
+长度弹性大：简单项目 3-5 句纯文字也能中；复杂项目可带 `## 简介/## 核心特性/## 安装` 完整章节。篇幅要配得上项目复杂度。
+
+**语气**：平实客观陈述功能。禁"先进的/一站式/高颜值"式自我推销词。
+
+真实命中样例（第 401 期收录，issue #10233 标题）：
+
+> 【开源自荐】smctl：给 Apple Silicon Mac 补上官方没有的风扇控制和电池限充（命令行工具）
+
+正文开头范式：
+
+> smctl 是一个开源（MIT）命令行工具，给 Apple Silicon Mac 提供风扇曲线控制和电池充电限制——这两件事 macOS 官方都不开放……
+
+## rules
+
+- 高命中特征：真实开源 repo + 明确协议 + 解决**具体**技术痛点（尤其"官方没做/官方限制"类刚需）+ 命令行/TUI/效率工具/自托管品类 + 有 demo 图
+- 几乎必被淘汰：AI 生成器/检测器套壳站、纯营销话术商业 SaaS、玩具级一次性小站、内容聚合日报站
+- 处理流程是**静默 close**：close ≠ 采用。判断是否真上刊，查最近几期 `docs/issue-XXX.md` 是否引用了你的 issue 号（格式「[@用户名](issue链接) 投稿」）
+- 无发现频率限制，但同一项目重复投是浪费
+
+## submit
+
+```bash
+gh issue create -R ruanyf/weekly \
+  --title "【开源自荐】<项目名>：<一句话卖点>（<品类>）" \
+  --body-file promo-drafts/ruanyf-weekly.md
+```
+
+提交后 7-14 天检查是否上刊：
+
+```bash
+# 1. 自己的 issue 是否已被处理（close ≠ 采用）
+gh api -X GET search/issues -f q='repo:ruanyf/weekly <项目名> in:title' --jq '.items[] | {number, state}'
+# 2. 是否真上刊：拉最近 3 期正文 grep 项目名
+gh api repos/ruanyf/weekly/contents/docs --jq '[.[].name] | sort | .[-3:][]' \
+  | while read f; do gh api repos/ruanyf/weekly/contents/docs/$f --jq .content | base64 -d | grep -l "<项目名>" - >/dev/null && echo "HIT: $f"; done
+```

--- a/plugins/yaohe/skills/promote/channels/show-hn.md
+++ b/plugins/yaohe/skills/promote/channels/show-hn.md
@@ -1,0 +1,32 @@
+---
+id: show-hn
+name: Show HN (Hacker News)
+lang: en
+automatable: manual-only
+submission_method: community-post
+target: https://news.ycombinator.com/submit
+audience: global hacker/dev community; front page = 数万级流量
+threshold: 必须是"可试用"的成品（能跑、能玩），非文章/落地页/募资页
+verified: 2026-07-02
+---
+
+# Show HN
+
+无 API，网页提交。**只出稿不代发。** 官方规则页：https://news.ycombinator.com/showhn.html
+
+## format_spec
+
+- 标题：`Show HN: <项目名> – <一句话说明>`（必须以 "Show HN" 开头，破折号用 en-dash）
+- 官方定义："something you've made that other people can play with"——理想是无需注册/留邮箱即可试用
+- **first comment**：楼主发帖后立即在评论区首楼写制作背景、动机、技术栈，并全程回应反馈
+- 质量线：官方原话 "Don't post quickly-generated one-offs; anybody can do that now."（快速生成的一次性作品不要发）；但 "needn't be complicated or look slick"
+
+## rules
+
+- **红线（会封号/连坐域名）**："Please don't ask friends to upvote or comment. That's not ok on HN." —— 任何形式的拉票/互赞都不行
+- 不发：博文、注册页、newsletter、清单类"阅读材料"（"Those can't be tried out"）、落地页、募资页
+- 纯功能迭代更新一般不够格再发一次 Show HN
+
+## submit
+
+manual-only：生成标题 + first comment 稿 → 用户自己登录提交。发帖后数小时内守评论区。美东工作日上午（北京时间 21-24 点）竞争与曝光都更高，冷门时段沉得慢但天花板低。

--- a/plugins/yaohe/skills/promote/channels/sspai-matrix.md
+++ b/plugins/yaohe/skills/promote/channels/sspai-matrix.md
@@ -1,0 +1,29 @@
+---
+id: sspai-matrix
+name: 少数派 Matrix
+lang: cn
+automatable: manual-only
+submission_method: post-article
+target: https://sspai.com/matrix
+audience: 效率工具/数字生活向读者，适合有 UI 的工具类项目
+threshold: 无需申请即可写作；发布 3 篇合规内容后转正式作者（前 3 篇曝光可能较低）
+verified: 2026-07-02
+---
+
+# 少数派 Matrix 投稿
+
+官方原话："无需申请，自由写作。任何用户都可使用写作功能。"
+
+## format_spec
+
+- 形态是**完整文章**而非简短自荐：个人化叙事 + 实际使用场景，站内先例风格如「我开发了个 XX 工具」「用快捷指令复刻…」
+- 结构建议：开发动机（真实痛点故事）→ 产品演示（多图）→ 设计取舍 → 获取方式
+- 不是硬广，是"分享创作历程"
+
+## rules
+
+无 star 门槛。工具类开源项目有大量成功先例。
+
+## submit
+
+manual-only：生成完整文章稿（1500-3000 字，含配图位标注）→ 用户登录 sspai.com 走写作入口发布。

--- a/plugins/yaohe/skills/promote/channels/v2ex-create.md
+++ b/plugins/yaohe/skills/promote/channels/v2ex-create.md
@@ -1,0 +1,30 @@
+---
+id: v2ex-create
+name: V2EX 分享创造节点
+lang: cn
+automatable: manual-only
+submission_method: community-post
+target: https://www.v2ex.com/go/create
+audience: 中文开发者社区，反馈直接（夸和喷都真实）
+threshold: none
+verified: 2026-07-02
+---
+
+# V2EX 分享创造
+
+节点定位「爱意满满的作品展示区」。无发帖 API，需登录人工发帖。**本 skill 只出稿不代发。**
+
+## format_spec
+
+- 标题：第一人称、非正式口吻，「我用 XX 做了 YY」式；禁营销腔
+- 正文：口语化，讲开发动机 + 解决的痛点 + 个人使用心得，附链接；像跟同行聊天，不像发新闻稿
+- V2EX 用户对"软文味"极其敏感，被识别为营销会被喷沉
+
+## rules
+
+- 无明文 star 门槛/频率限制，但同一项目短期重复发帖会被喷
+- 评论区要真人跟进回复，发完就跑观感很差
+
+## submit
+
+manual-only：交稿件 + 提醒用户「发帖后 2-3 小时内留在评论区回复」。工作日上午 10 点前后发帖曝光较好（经验值，unverified）。


### PR DESCRIPTION
Adds **yaohe (吆喝)** to Marketing Growth — a plugin that lets your agent promote an open-source project across 20 CN & EN channels (ruanyf/weekly, HelloGitHub, Show HN, awesome lists, dev.to, …), with per-channel tailored copy and rule-abiding tiered automation (issue/PR channels auto-submit via gh; community posts are drafted but never auto-posted).

Repo: https://github.com/nmhjklnm/yaohe (MIT)

Vendored the plugin per this repo's convention (`plugins/yaohe/`) and added the entry to both README.md and README-zh.md in list style.