### PR TITLE
Add claude-bionify plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1675,7 +1675,7 @@
       "name": "claude-bionify",
       "source": "./plugins/claude-bionify",
       "description": "Bionic reading for Claude Code responses that bolds the leading part of each word to improve readability and focus.",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Samuel Ruairí Bullard",
         "url": "https://github.com/abullard1"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,19 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "claude-bionify",
+      "source": "./plugins/claude-bionify",
+      "description": "Bionic reading for Claude Code responses that bolds the leading part of each word to improve readability and focus.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Samuel Ruairí Bullard",
+        "url": "https://github.com/abullard1"
+      },
+      "category": "Design UX",
+      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/claude-bionify",
+      "keywords": ["accessibility", "readability", "bionic-reading", "focus", "claude-code"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Design UX
 - [brand-guardian](./plugins/brand-guardian)
+- [claude-bionify](./plugins/claude-bionify)
 - [joker](./plugins/joker)
 - [mobile-ux-optimizer](./plugins/mobile-ux-optimizer)
 - [onomastophes](./plugins/onomastophes)

--- a/plugins/claude-bionify/.claude-plugin/plugin.json
+++ b/plugins/claude-bionify/.claude-plugin/plugin.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "claude-bionify",
+  "displayName": "claude-bionify",
+  "version": "1.0.0",
+  "description": "Bionic reading for Claude's responses that bolds the leading part of each word to guide your eyes and enable you to read faster.",
+  "author": {
+    "name": "Samuel Ruairí Bullard",
+    "email": "samuel.ruairi.bullard@gmail.com",
+    "url": "https://github.com/abullard1"
+  },
+  "homepage": "https://github.com/abullard1/claude-bionify",
+  "repository": "https://github.com/abullard1/claude-bionify",
+  "license": "MIT",
+  "keywords": [
+    "bionic-reading",
+    "speed-reading",
+    "accessibility",
+    "readability",
+    "adhd",
+    "dyslexia",
+    "focus",
+    "productivity"
+  ],
+  "userConfig": {
+    "fixation": {
+      "type": "number",
+      "title": "Fixation strength",
+      "description": "Fraction of each word to bold (0.1–0.9). Higher means more bold.",
+      "default": 0.5,
+      "min": 0.1,
+      "max": 0.9
+    },
+    "min_word_length": {
+      "type": "number",
+      "title": "Minimum word length",
+      "description": "Words shorter than this are left unbolded.",
+      "default": 4,
+      "min": 1
+    },
+    "boundary": {
+      "type": "string",
+      "title": "Bold boundary",
+      "description": "How much of each word to bold: \"fraction\" uses Fixation strength; \"syllable\" ends at the first syllable (e.g. stri-ng); \"log\" grows logarithmically so long words are bolded less.",
+      "default": "fraction"
+    },
+    "skip_acronyms": {
+      "type": "boolean",
+      "title": "Skip acronyms",
+      "description": "Leave ALL-CAPS acronyms like API or JSON unbolded.",
+      "default": true
+    },
+    "protect_urls": {
+      "type": "boolean",
+      "title": "Protect URLs, paths, and files",
+      "description": "Don't bold inside URLs, emails, file paths, or filenames.",
+      "default": true
+    },
+    "skip_headings": {
+      "type": "boolean",
+      "title": "Skip headings",
+      "description": "Leave markdown headings (lines starting with #) unbolded. Headings are already visually prominent, so bolding inside them adds clutter.",
+      "default": true
+    }
+  },
+  "experimental": {
+    "themes": "./themes/"
+  }
+}

--- a/plugins/claude-bionify/.claude-plugin/plugin.json
+++ b/plugins/claude-bionify/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "claude-bionify",
   "displayName": "claude-bionify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Bionic reading for Claude's responses that bolds the leading part of each word to guide your eyes and enable you to read faster.",
   "author": {
     "name": "Samuel Ruairí Bullard",

--- a/plugins/claude-bionify/CHANGELOG.md
+++ b/plugins/claude-bionify/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to claude-bionify are documented here. This project follows
+[semantic versioning](https://semver.org) and [Keep a Changelog](https://keepachangelog.com).
+
+## [1.0.0] - 2026-06-28
+
+Initial release.
+
+### Added
+- `MessageDisplay` hook that bolds the leading part of each word in Claude's
+  streamed replies as they render. The change is display-only: the saved
+  transcript and what Claude reads are never altered.
+- Unicode-aware bolding that works in any language, while leaving numbers and
+  identifiers like `value3` or `api_key` alone.
+- Three bolding strategies via the `boundary` option: `fraction` (default),
+  `syllable` (ends at the first syllable), and `log` (long words bolded less).
+- Configurable `fixation` strength and `min_word_length`.
+- `skip_acronyms` (default on) leaves ALL-CAPS acronyms like `API` whole.
+- `protect_urls` (default on) keeps URLs, emails, and file paths unbolded, while
+  still bolding prose like `and/or` or `e.g.`.
+- `skip_headings` (default on) leaves markdown headings unbolded.
+- Inline `` `code` ``, fenced code blocks, markdown links, and existing
+  `**bold**` always render verbatim.
+- Live control commands (`/claude-bionify:on`, `:off`, `:toggle`,
+  `:set <option> <value>`, `:status`, `:reset`) that change settings mid-session
+  with no reload.
+- Seven color themes (Nord, Dracula, Gruvbox, Solarized Dark, Solarized Light,
+  Sepia, Focus Dark) in Claude Code's `/theme` picker as `custom:claude-bionify:<name>`.
+- Crash-safe by design: on any error the original text is shown unchanged.

--- a/plugins/claude-bionify/CHANGELOG.md
+++ b/plugins/claude-bionify/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to claude-bionify are documented here. This project follows
 [semantic versioning](https://semver.org) and [Keep a Changelog](https://keepachangelog.com).
 
+## [1.0.1] - 2026-07-04
+
+### Fixed
+- Preserve fenced code blocks that use spaced info strings such as
+  ```` ``` python ````.
+- Stop URL protection before surrounding quotes and brackets.
+- Reject invalid boolean and minimum-word-length live override values instead
+  of silently applying surprising settings.
+- Save live overrides correctly when `CLAUDE_BIONIFY_STATE_FILE` is set to a
+  filename in the current working directory.
+- Use fully-qualified `/claude-bionify:set ...` examples in the plugin README.
+
 ## [1.0.0] - 2026-06-28
 
 Initial release.

--- a/plugins/claude-bionify/LICENSE
+++ b/plugins/claude-bionify/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Samuel Ruairí Bullard
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/claude-bionify/README.md
+++ b/plugins/claude-bionify/README.md
@@ -1,0 +1,102 @@
+<div align="center">
+
+<h1>claude-bionify</h1>
+
+<p>
+  <strong>Bionic reading for Claude Code. Bold the front of every word so your eyes move faster.</strong><br>
+  <sub>So <b>Bio</b>nify <b>mak</b>es <b>Cla</b>ude's <b>repl</b>ies <b>eas</b>ier to <b>re</b>ad.</sub>
+</p>
+
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-d97757)
+![Python](https://img.shields.io/badge/python-3.10%2B-blue)
+![Version](https://img.shields.io/badge/version-1.0.0-success)
+
+</div>
+
+---
+
+claude-bionify restyles Claude's responses as they stream into your terminal, bolding the
+leading part of each word so your eye gets a fixation point per word. That is the
+bionic-reading technique, inspired by eye-movement research showing we read by fixating a single
+convenient position toward the start of each word, where the opening letters carry the most
+information ([Rayner, 1979](https://doi.org/10.1068/p080021);
+[O'Regan et al., 1984](https://doi.org/10.1037/0096-1523.10.2.250)).
+
+## Install
+
+```shell
+/plugin marketplace add abullard1/claude-bionify
+/plugin install claude-bionify@claude-bionify
+```
+
+claude-bionify is active right away. Turn it off or on with `/claude-bionify:off` / `/claude-bionify:on`.
+
+## Configure
+
+When you enable the plugin, Claude Code prompts for these (all optional):
+
+| Setting | Default | Meaning |
+| :------ | :------ | :------ |
+| **Bold boundary** | `fraction` | `fraction` bolds by Fixation strength; `syllable` ends each word at its first syllable (e.g. **stri**ng); `log` grows logarithmically so long words are bolded less. |
+| **Fixation strength** | `0.5` | Fraction of each word to bold (`0.1`–`0.9`). Higher is bolder. Applies to `fraction` mode only. |
+| **Minimum word length** | `4` | Words shorter than this are left unbolded. |
+| **Skip acronyms** | `on` | Leave ALL-CAPS acronyms like `API` or `JSON` whole. |
+| **Protect URLs, paths, files** | `on` | Don't bold inside URLs, emails, file paths, or filenames. |
+| **Skip headings** | `on` | Leave markdown headings (`#` lines) unbolded. |
+
+## Control it live
+
+Change claude-bionify mid-session without a reload. The next reply reflects it instantly:
+
+- `/claude-bionify:toggle` · `/claude-bionify:on` · `/claude-bionify:off`
+- `/claude-bionify:set strength 0.7` · `/claude-bionify:set boundary syllable` · `set minlen 5` · `set acronyms off` · `set urls off` · `set headings off`
+- `/claude-bionify:status` · `/claude-bionify:reset`
+
+## Themes
+
+claude-bionify also ships seven color themes for Claude Code's `/theme` picker: Nord, Dracula,
+Gruvbox, Solarized Dark, Solarized Light, Sepia, and Focus Dark. Optional and independent of
+the bolding. See the [project README](https://github.com/abullard1/claude-bionify#themes) for
+the palette gallery.
+
+## What it touches
+
+- **Bolded:** ordinary prose words, in any language (Unicode-aware).
+- **Left alone:** inline `` `code` ``, fenced code blocks (even across streamed chunks),
+  markdown link/image targets, URLs, emails, file paths and filenames, ALL-CAPS acronyms,
+  and existing `**bold**`.
+- **Never touched:** your input and tool output.
+
+## How it works
+
+```
+Claude streams a reply ▸ claude-bionify ▸ bolded text in your terminal
+```
+
+claude-bionify bolds each batch of Claude's reply just before it reaches your screen, so only
+what you see changes — what's saved to the transcript and what Claude reads stay the original
+text. It runs entirely on your machine with no dependencies, and if anything ever goes wrong it
+falls back to the original.
+
+## Requirements
+
+- Claude Code with plugin support · `python3` on your `PATH` · a terminal that renders markdown bold
+
+## Terminal compatibility
+
+claude-bionify emits standard markdown bold, which virtually every terminal renders correctly:
+Alacritty, kitty, WezTerm, iTerm2, GNOME Terminal, foot, and the rest.
+
+The one known exception is the COSMIC desktop terminal (`cosmic-term`), which currently ignores
+the code that *ends* a bold span, so bold leaks across the whole word instead of stopping after
+the front.
+That is a terminal bug, not a claude-bionify or Claude Code issue. A future release may add an
+optional Unicode-glyph bold mode that avoids ANSI entirely and sidesteps it.
+
+For the full write-up, demo, and development guide, see the
+[project README](https://github.com/abullard1/claude-bionify#readme).
+
+## License
+
+[MIT](./LICENSE) © 2026 [Samuel Ruairí Bullard](https://github.com/abullard1).

--- a/plugins/claude-bionify/README.md
+++ b/plugins/claude-bionify/README.md
@@ -10,7 +10,7 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![Claude Code](https://img.shields.io/badge/Claude%20Code-plugin-d97757)
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue)
-![Version](https://img.shields.io/badge/version-1.0.0-success)
+![Version](https://img.shields.io/badge/version-1.0.1-success)
 
 </div>
 

--- a/plugins/claude-bionify/README.md
+++ b/plugins/claude-bionify/README.md
@@ -50,7 +50,7 @@ When you enable the plugin, Claude Code prompts for these (all optional):
 Change claude-bionify mid-session without a reload. The next reply reflects it instantly:
 
 - `/claude-bionify:toggle` · `/claude-bionify:on` · `/claude-bionify:off`
-- `/claude-bionify:set strength 0.7` · `/claude-bionify:set boundary syllable` · `set minlen 5` · `set acronyms off` · `set urls off` · `set headings off`
+- `/claude-bionify:set strength 0.7` · `/claude-bionify:set boundary syllable` · `/claude-bionify:set minlen 5` · `/claude-bionify:set acronyms off` · `/claude-bionify:set urls off` · `/claude-bionify:set headings off`
 - `/claude-bionify:status` · `/claude-bionify:reset`
 
 ## Themes

--- a/plugins/claude-bionify/commands/off.md
+++ b/plugins/claude-bionify/commands/off.md
@@ -1,0 +1,8 @@
+---
+description: Turn claude-bionify off so Claude's replies render normally.
+allowed-tools: Bash(python3 *)
+---
+
+!`python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control.py" off`
+
+The command above applied the change and printed claude-bionify's new state. Relay that single line to the user and take no further action.

--- a/plugins/claude-bionify/commands/on.md
+++ b/plugins/claude-bionify/commands/on.md
@@ -1,0 +1,8 @@
+---
+description: Turn claude-bionify on so Claude's replies are bolded.
+allowed-tools: Bash(python3 *)
+---
+
+!`python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control.py" on`
+
+The command above applied the change and printed claude-bionify's new state. Relay that single line to the user and take no further action.

--- a/plugins/claude-bionify/commands/reset.md
+++ b/plugins/claude-bionify/commands/reset.md
@@ -1,0 +1,8 @@
+---
+description: Clear all live claude-bionify overrides, back to your configured defaults.
+allowed-tools: Bash(python3 *)
+---
+
+!`python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control.py" reset`
+
+The command above cleared the overrides and printed claude-bionify's new state. Relay that single line to the user and take no further action.

--- a/plugins/claude-bionify/commands/set.md
+++ b/plugins/claude-bionify/commands/set.md
@@ -1,0 +1,9 @@
+---
+description: Change a claude-bionify setting, e.g. "fixation 0.7" or "boundary syllable".
+allowed-tools: Bash(python3 *)
+argument-hint: <fixation|boundary|minlen|acronyms|urls|headings> <value>
+---
+
+!`python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control.py" set $ARGUMENTS`
+
+The command above applied the change and printed claude-bionify's new state. Relay that single line to the user and take no further action.

--- a/plugins/claude-bionify/commands/status.md
+++ b/plugins/claude-bionify/commands/status.md
@@ -1,0 +1,8 @@
+---
+description: Show claude-bionify's current settings.
+allowed-tools: Bash(python3 *)
+---
+
+!`python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control.py" status`
+
+The command above printed claude-bionify's current state. Relay that single line to the user and take no further action.

--- a/plugins/claude-bionify/commands/toggle.md
+++ b/plugins/claude-bionify/commands/toggle.md
@@ -1,0 +1,8 @@
+---
+description: Flip claude-bionify on or off.
+allowed-tools: Bash(python3 *)
+---
+
+!`python3 "${CLAUDE_PLUGIN_ROOT}/scripts/control.py" toggle`
+
+The command above applied the change and printed claude-bionify's new state. Relay that single line to the user and take no further action.

--- a/plugins/claude-bionify/hooks/hooks.json
+++ b/plugins/claude-bionify/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "description": "Bionic reading: bolds leading portions of each word for faster reading.",
+  "hooks": {
+    "MessageDisplay": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/scripts/bionify.py"],
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-bionify/scripts/bionify.py
+++ b/plugins/claude-bionify/scripts/bionify.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""claude-bionify MessageDisplay hook: bold the leading part of prose words.
+
+Reads a MessageDisplay event as JSON on stdin and prints a `displayContent`
+replacement built by the functional `core`. Code, existing bold, markdown links,
+bare URLs, and emails render verbatim, and ALL-CAPS acronyms are left whole.
+
+The change is display-only. Claude Code keeps the original text in the
+transcript and in the model's context. This shell holds the side effects: it
+reads userConfig and live overrides, persists per-message fence state, and
+writes to stdout. It is crash-safe: on any error it prints nothing, so Claude
+Code falls back to the original text. Set CLAUDE_BIONIFY_DEBUG=1 to re-raise instead.
+"""
+
+import json
+import os
+import re
+import sys
+from typing import NamedTuple
+
+import core
+import overrides
+import settings
+
+
+def _option(name: str) -> str | None:
+    """Read a userConfig value from its CLAUDE_PLUGIN_OPTION_* env var."""
+    return (os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name.upper()}")
+            or os.environ.get(f"CLAUDE_PLUGIN_OPTION_{name}"))
+
+
+def load_config() -> settings.Style | None:
+    """Resolve the active Style from userConfig plus any live overrides.
+
+    Returns None when claude-bionify is turned off via `/claude-bionify:off`, so the hook
+    passes the original text through unchanged.
+    """
+    raw = settings.from_env(_option)
+    override = overrides.load()
+    if override.get("enabled") is False:
+        return None
+    for key in settings.RAW_KEYS:
+        if key in override:
+            raw[key] = override[key]
+    return settings.build_style(raw)
+
+
+def _fence_dir() -> str | None:
+    return os.environ.get("CLAUDE_PLUGIN_DATA")
+
+
+def _fence_path(data_dir: str, message_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_-]", "-", message_id)
+    return os.path.join(data_dir, f"fence-{safe}.state")
+
+
+def _remove_quietly(path: str) -> None:
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def read_fence_state(message_id: str, index: int | None) -> bool:
+    """Whether the previous delta ended inside a code fence.
+
+    A message always begins outside a fence, so the first delta (index 0) starts
+    fresh and never trusts a leftover file.
+    """
+    data_dir = _fence_dir()
+    if not data_dir or not message_id or index == 0:
+        return False
+    try:
+        with open(_fence_path(data_dir, message_id), encoding="utf-8") as f:
+            return f.read().strip() == "1"
+    except OSError:
+        return False
+
+
+def write_fence_state(message_id: str, inside_fence: bool, final: bool) -> None:
+    """Persist fence state for the next delta, or clear it when the message ends."""
+    data_dir = _fence_dir()
+    if not data_dir or not message_id:
+        return
+    path = _fence_path(data_dir, message_id)
+    try:
+        if final:
+            _remove_quietly(path)
+        else:
+            os.makedirs(data_dir, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("1" if inside_fence else "0")
+    except OSError:
+        pass
+
+
+def sweep_stale_state(current_message_id: str) -> None:
+    """Drop fence files left by earlier messages that never sent a final delta.
+
+    A session streams one message at a time, so when a new message starts every
+    other fence file is safe to remove.
+    """
+    data_dir = _fence_dir()
+    if not data_dir:
+        return
+    keep = (os.path.basename(_fence_path(data_dir, current_message_id))
+            if current_message_id else None)
+    try:
+        for entry in os.listdir(data_dir):
+            if (entry.startswith("fence-") and entry.endswith(".state")
+                    and entry != keep):
+                _remove_quietly(os.path.join(data_dir, entry))
+    except OSError:
+        pass
+
+
+class DisplayEvent(NamedTuple):
+    """The MessageDisplay payload, parsed from Claude Code's raw hook event.
+
+    Claude Code streams an assistant message as a sequence of these and names its
+    fields in camelCase (`messageId`); `parse_event` is the one place that maps
+    them onto the names the rest of the module uses.
+    """
+    delta: str
+    message_id: str    # keys the per-message fence state
+    index: int | None
+    final: bool
+
+
+def parse_event(raw: dict) -> DisplayEvent:
+    """Read the fields the hook needs from a raw MessageDisplay event.
+
+    `messageId` is Claude Code's field; `session_id` is a guaranteed fallback so
+    the fence-state key is never empty, since an empty key would let code blocks
+    that span streamed deltas get bolded.
+    """
+    return DisplayEvent(
+        delta=raw.get("delta") or "",
+        message_id=str(raw.get("messageId") or raw.get("session_id") or ""),
+        index=raw.get("index"),
+        final=bool(raw.get("final")),
+    )
+
+
+def main() -> None:
+    try:
+        event = parse_event(json.loads(sys.stdin.read() or "{}"))
+        if not event.delta:
+            return
+
+        style = load_config()
+        if style is None:        # turned off via /claude-bionify:off
+            return
+
+        if event.index == 0:
+            sweep_stale_state(event.message_id)
+        inside_fence = read_fence_state(event.message_id, event.index)
+        display, inside_fence = core.transform(event.delta, inside_fence, style)
+        write_fence_state(event.message_id, inside_fence, event.final)
+
+        json.dump({
+            "hookSpecificOutput": {
+                "hookEventName": "MessageDisplay",
+                "displayContent": display,
+            }
+        }, sys.stdout)
+    except Exception:
+        # Crash-safe: emit nothing so Claude Code renders the original text.
+        if os.environ.get("CLAUDE_BIONIFY_DEBUG"):
+            raise
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/claude-bionify/scripts/control.py
+++ b/plugins/claude-bionify/scripts/control.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""claude-bionify live control: update the runtime-override file the hook reads.
+
+Usage: control.py <verb> [args]
+  on | off | toggle            enable / disable claude-bionify
+  set <option> <value>         fixation <0.1-0.9> | boundary <fraction|syllable|log>
+                               | minlen <n> | acronyms <on|off> | urls <on|off>
+                               | headings <on|off>
+  status                       show the active overrides
+  reset                        clear all overrides (back to your configured defaults)
+
+Option metadata lives in `settings`; persistence in `overrides`. This shell only
+parses the verb and prints a single status line, and always exits 0 so the slash
+command never errors.
+"""
+
+import sys
+
+import overrides
+import settings
+
+
+def _apply_set(state: dict, rest: list) -> tuple[dict, str]:
+    if len(rest) < 2:
+        return state, "claude-bionify: set <fixation|boundary|minlen|acronyms|urls|headings> <value>"
+    key, value = rest[0].lower(), rest[1]
+    setting = settings.by_cli_key(key)
+    if setting is None:
+        return state, f"claude-bionify: unknown option '{key}'"
+    try:
+        state[setting.name] = setting.parse(value)
+    except (TypeError, ValueError):
+        return state, f"claude-bionify: {setting.invalid(value)}"
+    return state, settings.render_state(state)
+
+
+def apply(state: dict, argv: list) -> tuple[dict | None, str]:
+    """Apply a command to `state`. Returns (new_state | None to reset, message)."""
+    if not argv:
+        return state, settings.render_state(state)
+    verb, rest = argv[0].lower(), argv[1:]
+    if verb in ("on", "enable"):
+        state["enabled"] = True
+    elif verb in ("off", "disable"):
+        state["enabled"] = False
+    elif verb == "toggle":
+        state["enabled"] = state.get("enabled") is False  # flip; default ON
+    elif verb == "status":
+        return state, settings.render_state(state)
+    elif verb == "reset":
+        return None, "claude-bionify: overrides cleared, using your configured defaults"
+    elif verb == "set":
+        return _apply_set(state, rest)
+    else:
+        return _apply_set(state, argv)  # forgiving: treat bare `<option> <value>`
+    return state, settings.render_state(state)
+
+
+def main(argv: list) -> None:
+    new_state, message = apply(overrides.load(), argv)
+    if new_state is None:
+        overrides.clear()
+    else:
+        overrides.save(new_state)
+    print(message)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/plugins/claude-bionify/scripts/core.py
+++ b/plugins/claude-bionify/scripts/core.py
@@ -1,0 +1,153 @@
+"""Formatting core for claude-bionify: pure bionic-reading text transformation.
+
+No I/O lives here. Every function operates only on its arguments and returns a
+value. The hook (`bionify.py`) and the control CLI (`control.py`) build on this
+module and on `settings`; this module never imports them.
+"""
+
+import math
+import re
+import unicodedata
+
+from settings import Style
+
+# In "syllable" mode the bold span lands on the first-syllable boundary, then is
+# clamped into this band so vowel-initial words are not under-bolded and long
+# words are not over-bolded.
+SYLLABLE_MIN_FRACTION = 0.35
+SYLLABLE_MAX_FRACTION = 0.70
+
+
+# A word is a run of letters in any language. Digits and underscores are
+# excluded so numbers and identifiers like `value3` or `api_key` are never
+# treated as prose.
+_WORD = re.compile(r"[^\W\d_]+")
+
+# Spans within a line that must render verbatim, matched in one pass so prose
+# bolding flows around them. The second group (URLs, emails, paths, files) is
+# optional, gated by `protect_urls`.
+_PROTECTED_PARTS = (
+    r"`[^`]*`",         # `inline code`
+    r"\*\*.+?\*\*",     # **existing bold**
+    r"\]\([^)]*\)",     # ](destination) of a [label](url) link or image
+)
+# Each rule below triggers only on a signal that prose lacks (a scheme, an `@`,
+# a token-anchored or multi-segment path, or a lowercase file extension), so
+# words like "and/or", "e.g.", or "3.14" are never caught. Path character
+# classes exclude quotes and brackets, so a path stops cleanly at `)` or `"`.
+_URL_PARTS = (
+    r"https?://\S+",                          # URL with a scheme
+    r"www\.\S+",                              # scheme-less www URL
+    r"\b[\w.+-]+@[\w-]+\.\w+",                # email address
+    r"(?<!\S)(?:\.\.?|~)?/[\w@.~/-]*[\w/]",   # path: /a, ./a, ../a, ~/a
+    r"[\w.-]+/[\w.-]+/[\w@./-]+",             # relative path with 3+ segments
+    r"[\w-]+/[\w@.-]*\.[A-Za-z0-9]{1,5}\b",   # segment/file.ext, e.g. src/index.ts
+    r"\b[\w-]+(?:\.[\w-]+)*\.[a-z]{2,5}\b",   # filename or bare domain, e.g. main.py
+)
+_PROTECTED = re.compile("|".join(_PROTECTED_PARTS))
+_PROTECTED_WITH_URLS = re.compile("|".join(_PROTECTED_PARTS + _URL_PARTS))
+
+_FENCE_PREFIXES = ("```", "~~~")
+
+# A markdown ATX heading: 0 to 3 leading spaces, then 1 to 6 # characters, then
+# whitespace or end-of-line. #hashtag and Issue #42 do not match.
+_HEADING = re.compile(r"^ {0,3}#{1,6}(?:\s|$)")
+
+
+def _is_fence(line: str) -> bool:
+    """Whether a line is a code-fence marker rather than prose.
+
+    A real marker is ``` or ~~~ alone, or followed immediately by an info string
+    with no space. Prose like "``` is the marker" has a space right after the
+    backticks, so it does not flip the fence state.
+    """
+    stripped = line.strip()
+    if not stripped.startswith(_FENCE_PREFIXES):
+        return False
+    return len(stripped) == 3 or not stripped[3:4].isspace()
+
+
+def _is_vowel(char: str) -> bool:
+    """True if `char` is a vowel in any language (diacritics stripped)."""
+    return unicodedata.normalize("NFD", char)[:1].lower() in "aeiou"
+
+
+def _syllable_cut(word: str) -> int:
+    """Bold length ending at the word's first syllable, clamped to a sane band.
+
+    Walks onset (leading consonants) to nucleus (first vowel run) to an optional
+    single coda consonant, then clamps into [MIN, MAX] of the word length.
+    """
+    length = len(word)
+    cut = 0
+    while cut < length and not _is_vowel(word[cut]):  # onset (y reads consonant)
+        cut += 1
+    while cut < length and (_is_vowel(word[cut]) or word[cut].lower() == "y"):
+        cut += 1  # nucleus (y now reads vowel)
+    if cut < length - 1 and not _is_vowel(word[cut]) and not _is_vowel(word[cut + 1]):
+        cut += 1  # coda: keep a consonant that another consonant follows
+
+    low = max(1, math.ceil(length * SYLLABLE_MIN_FRACTION))
+    high = max(low, math.floor(length * SYLLABLE_MAX_FRACTION))
+    return min(max(cut, low), high)
+
+
+def _log_cut(word: str) -> int:
+    """Bold length that grows logarithmically, so long words are bolded less."""
+    return max(1, min(len(word), math.ceil(math.log2(len(word)))))
+
+
+def _bold_cut(word: str, style: Style) -> int:
+    """How many leading characters of `word` to bold, per the active strategy."""
+    if style.boundary == "syllable":
+        return _syllable_cut(word)
+    if style.boundary == "log":
+        return _log_cut(word)
+    return max(1, min(len(word), math.ceil(len(word) * style.fixation)))
+
+
+def bionify_word(word: str, style: Style) -> str:
+    """Bold the leading part of a single word."""
+    if len(word) < style.min_length:
+        return word
+    if style.skip_acronyms and word.isupper():
+        return word
+    cut = _bold_cut(word, style)
+    return f"**{word[:cut]}**{word[cut:]}"
+
+
+def bionify_text(text: str, style: Style) -> str:
+    """Bold every prose word in a line, leaving protected spans untouched."""
+    def bold(segment: str) -> str:
+        return _WORD.sub(lambda m: bionify_word(m.group(), style), segment)
+
+    protected = _PROTECTED_WITH_URLS if style.protect_urls else _PROTECTED
+    out = []
+    cursor = 0
+    for span in protected.finditer(text):
+        out.append(bold(text[cursor:span.start()]))
+        out.append(span.group())
+        cursor = span.end()
+    out.append(bold(text[cursor:]))
+    return "".join(out)
+
+
+def transform(delta: str, inside_fence: bool, style: Style) -> tuple[str, bool]:
+    """claude-bionify a streamed delta, tracking fenced code blocks across deltas.
+
+    Returns (rendered text, updated inside_fence). Deltas are line-aligned, so
+    each line is a ``` / ~~~ fence marker, code inside an open fence, or a prose
+    line that gets bionified.
+    """
+    out = []
+    for line in delta.split("\n"):
+        if _is_fence(line):
+            inside_fence = not inside_fence
+            out.append(line)
+        elif inside_fence:
+            out.append(line)
+        elif style.skip_headings and _HEADING.match(line):
+            out.append(line)
+        else:
+            out.append(bionify_text(line, style))
+    return "\n".join(out), inside_fence

--- a/plugins/claude-bionify/scripts/core.py
+++ b/plugins/claude-bionify/scripts/core.py
@@ -33,11 +33,12 @@ _PROTECTED_PARTS = (
 )
 # Each rule below triggers only on a signal that prose lacks (a scheme, an `@`,
 # a token-anchored or multi-segment path, or a lowercase file extension), so
-# words like "and/or", "e.g.", or "3.14" are never caught. Path character
-# classes exclude quotes and brackets, so a path stops cleanly at `)` or `"`.
+# words like "and/or", "e.g.", or "3.14" are never caught. URL and path
+# character classes exclude quotes and brackets, so protected spans stop before
+# surrounding punctuation such as `)` or `"`.
 _URL_PARTS = (
-    r"https?://\S+",                          # URL with a scheme
-    r"www\.\S+",                              # scheme-less www URL
+    r"https?://[^\s<>()\[\]\"']+",            # URL with a scheme
+    r"www\.[^\s<>()\[\]\"']+",                # scheme-less www URL
     r"\b[\w.+-]+@[\w-]+\.\w+",                # email address
     r"(?<!\S)(?:\.\.?|~)?/[\w@.~/-]*[\w/]",   # path: /a, ./a, ../a, ~/a
     r"[\w.-]+/[\w.-]+/[\w@./-]+",             # relative path with 3+ segments
@@ -57,14 +58,12 @@ _HEADING = re.compile(r"^ {0,3}#{1,6}(?:\s|$)")
 def _is_fence(line: str) -> bool:
     """Whether a line is a code-fence marker rather than prose.
 
-    A real marker is ``` or ~~~ alone, or followed immediately by an info string
-    with no space. Prose like "``` is the marker" has a space right after the
-    backticks, so it does not flip the fence state.
+    Markdown allows an optional info string after the opening marker, with or
+    without a separating space, so lines like ``` python and ```python both
+    begin fenced code blocks.
     """
     stripped = line.strip()
-    if not stripped.startswith(_FENCE_PREFIXES):
-        return False
-    return len(stripped) == 3 or not stripped[3:4].isspace()
+    return stripped.startswith(_FENCE_PREFIXES)
 
 
 def _is_vowel(char: str) -> bool:

--- a/plugins/claude-bionify/scripts/overrides.py
+++ b/plugins/claude-bionify/scripts/overrides.py
@@ -1,0 +1,52 @@
+"""Runtime-override persistence: the live settings the /claude-bionify commands write
+and the hook reads.
+
+This is the shared contract between the control CLI (writer) and the hook
+(reader): one place that owns where the override file lives and how it is read,
+written, and cleared. The schema is just a JSON object of Style fields plus an
+optional `enabled` flag; this module stays agnostic about its contents.
+"""
+
+import json
+import os
+
+
+def path() -> str:
+    """Location of the override file (overridable via CLAUDE_BIONIFY_STATE_FILE)."""
+    return (os.environ.get("CLAUDE_BIONIFY_STATE_FILE")
+            or os.path.expanduser("~/.claude/claude-bionify/runtime.json"))
+
+
+def load() -> dict:
+    """Current overrides, or {} when none exist or the file is unreadable."""
+    try:
+        with open(path(), encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def save(state: dict) -> None:
+    """Persist the override dict atomically, creating the parent directory if needed.
+
+    Writes to a temp file and renames it into place so the hook never reads a
+    half-written file if a control command lands while a message is streaming.
+    """
+    target = path()
+    tmp = f"{target}.tmp"
+    try:
+        os.makedirs(os.path.dirname(target), exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(state, f)
+        os.replace(tmp, target)
+    except OSError:
+        pass
+
+
+def clear() -> None:
+    """Remove the override file, reverting to the configured defaults."""
+    try:
+        os.remove(path())
+    except OSError:
+        pass

--- a/plugins/claude-bionify/scripts/overrides.py
+++ b/plugins/claude-bionify/scripts/overrides.py
@@ -36,7 +36,9 @@ def save(state: dict) -> None:
     target = path()
     tmp = f"{target}.tmp"
     try:
-        os.makedirs(os.path.dirname(target), exist_ok=True)
+        parent = os.path.dirname(target)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
         with open(tmp, "w", encoding="utf-8") as f:
             json.dump(state, f)
         os.replace(tmp, target)

--- a/plugins/claude-bionify/scripts/settings.py
+++ b/plugins/claude-bionify/scripts/settings.py
@@ -1,0 +1,154 @@
+"""Settings model and the single source of truth for claude-bionify's options.
+
+Every option is declared once in SETTINGS: its canonical name, its plugin.json
+manifest key, the keys the `set` command accepts, default, parser, and how it
+renders in the status line. The formatting core, the hook, and the control CLI
+all read from here, so adding or changing an option happens in one place rather
+than across several modules.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import NamedTuple
+
+DEFAULT_FIXATION = 0.5
+DEFAULT_MIN_WORD_LENGTH = 4
+DEFAULT_BOUNDARY = "fraction"
+DEFAULT_SKIP_ACRONYMS = True
+DEFAULT_PROTECT_URLS = True
+DEFAULT_SKIP_HEADINGS = True
+BOUNDARIES = ("fraction", "syllable", "log")
+_TRUTHY = ("1", "true", "yes", "on", "enable", "enabled")
+
+
+class Style(NamedTuple):
+    """Resolved formatting settings, threaded through the formatting functions."""
+    fixation: float = DEFAULT_FIXATION
+    min_length: int = DEFAULT_MIN_WORD_LENGTH
+    boundary: str = DEFAULT_BOUNDARY
+    skip_acronyms: bool = DEFAULT_SKIP_ACRONYMS
+    protect_urls: bool = DEFAULT_PROTECT_URLS
+    skip_headings: bool = DEFAULT_SKIP_HEADINGS
+
+
+def clamp_fixation(value: float) -> float:
+    """Constrain a fixation strength to the usable 0.1 to 0.9 range."""
+    return max(0.1, min(0.9, value))
+
+
+def clamp_min_length(value: int) -> int:
+    """Constrain a minimum word length to at least 1."""
+    return max(1, value)
+
+
+def valid_boundary(value: str) -> bool:
+    """Whether `value` names a known boundary strategy."""
+    return str(value).strip().lower() in BOUNDARIES
+
+
+def as_bool(value: object) -> bool:
+    """Read an env string or JSON boolean as a bool."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in _TRUTHY
+
+
+def _parse_boundary(value: str) -> str:
+    if not valid_boundary(value):
+        raise ValueError(value)
+    return str(value).strip().lower()
+
+
+@dataclass(frozen=True)
+class Setting:
+    """One option, declared once: its names, default, parser, and renderer."""
+    name: str                          # canonical Style field
+    manifest_key: str                  # plugin.json userConfig key
+    cli_keys: tuple[str, ...]          # accepted by /claude-bionify:set
+    default: object
+    parse: Callable[[object], object]  # raises ValueError on an invalid value
+    render: Callable[[object], str]    # value -> status-line fragment
+    invalid: Callable[[str], str]      # message when set is given a bad value
+
+
+SETTINGS = (
+    Setting(
+        "fixation", "fixation", ("fixation", "strength"), DEFAULT_FIXATION,
+        parse=lambda v: clamp_fixation(float(v)),
+        render=lambda v: f"strength={v}",
+        invalid=lambda v: f"'{v}' is not a number between 0.1 and 0.9",
+    ),
+    Setting(
+        "min_length", "min_word_length", ("minlen", "min_length"),
+        DEFAULT_MIN_WORD_LENGTH,
+        parse=lambda v: clamp_min_length(int(float(v))),
+        render=lambda v: f"minlen={v}",
+        invalid=lambda v: f"'{v}' is not a whole number",
+    ),
+    Setting(
+        "boundary", "boundary", ("boundary",), DEFAULT_BOUNDARY,
+        parse=_parse_boundary,
+        render=lambda v: f"boundary={v}",
+        invalid=lambda v: f"boundary must be one of {', '.join(BOUNDARIES)}",
+    ),
+    Setting(
+        "skip_acronyms", "skip_acronyms", ("acronyms",), DEFAULT_SKIP_ACRONYMS,
+        parse=as_bool,
+        render=lambda v: f"acronyms={'on' if v else 'off'}",
+        invalid=lambda v: f"'{v}' is not on or off",
+    ),
+    Setting(
+        "protect_urls", "protect_urls", ("urls",), DEFAULT_PROTECT_URLS,
+        parse=as_bool,
+        render=lambda v: f"urls={'on' if v else 'off'}",
+        invalid=lambda v: f"'{v}' is not on or off",
+    ),
+    Setting(
+        "skip_headings", "skip_headings", ("headings",), DEFAULT_SKIP_HEADINGS,
+        parse=as_bool,
+        render=lambda v: f"headings={'on' if v else 'off'}",
+        invalid=lambda v: f"'{v}' is not on or off",
+    ),
+)
+
+RAW_KEYS = tuple(s.name for s in SETTINGS)
+_BY_CLI = {key: s for s in SETTINGS for key in s.cli_keys}
+
+
+def by_cli_key(key: str) -> Setting | None:
+    """The Setting a `set` command key refers to, or None if unknown."""
+    return _BY_CLI.get(key)
+
+
+def build_style(raw: dict) -> Style:
+    """Resolve a raw settings dict (from env or an override) into a Style.
+
+    A missing value falls back to the default; a present but invalid value is
+    parsed, and if parsing fails it also falls back rather than raising.
+    """
+    values = {}
+    for setting in SETTINGS:
+        given = raw.get(setting.name)
+        if given is None:
+            values[setting.name] = setting.default
+            continue
+        try:
+            values[setting.name] = setting.parse(given)
+        except (TypeError, ValueError):
+            values[setting.name] = setting.default
+    return Style(**values)
+
+
+def from_env(read: Callable[[str], object]) -> dict:
+    """Collect the userConfig values via `read(manifest_key)` into a raw dict."""
+    return {s.name: read(s.manifest_key) for s in SETTINGS}
+
+
+def render_state(state: dict) -> str:
+    """Render the active overrides as a single status line."""
+    if not state:
+        return "claude-bionify: ON · using your configured defaults"
+    parts = [s.render(state[s.name]) for s in SETTINGS if s.name in state]
+    tail = (" · " + " · ".join(parts)) if parts else ""
+    state_word = "OFF" if state.get("enabled") is False else "ON"
+    return f"claude-bionify: {state_word}{tail}"

--- a/plugins/claude-bionify/scripts/settings.py
+++ b/plugins/claude-bionify/scripts/settings.py
@@ -9,6 +9,7 @@ than across several modules.
 
 from collections.abc import Callable
 from dataclasses import dataclass
+import re
 from typing import NamedTuple
 
 DEFAULT_FIXATION = 0.5
@@ -19,6 +20,7 @@ DEFAULT_PROTECT_URLS = True
 DEFAULT_SKIP_HEADINGS = True
 BOUNDARIES = ("fraction", "syllable", "log")
 _TRUTHY = ("1", "true", "yes", "on", "enable", "enabled")
+_FALSY = ("0", "false", "no", "off", "disable", "disabled")
 
 
 class Style(NamedTuple):
@@ -47,10 +49,31 @@ def valid_boundary(value: str) -> bool:
 
 
 def as_bool(value: object) -> bool:
-    """Read an env string or JSON boolean as a bool."""
+    """Read an env string or JSON boolean as a bool, rejecting typos."""
     if isinstance(value, bool):
         return value
-    return str(value).strip().lower() in _TRUTHY
+    normalized = str(value).strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    raise ValueError(value)
+
+
+def parse_min_length(value: object) -> int:
+    """Read a whole-number minimum word length."""
+    if isinstance(value, bool):
+        raise ValueError(value)
+    if isinstance(value, int):
+        return clamp_min_length(value)
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise ValueError(value)
+        return clamp_min_length(int(value))
+    text = str(value).strip()
+    if not re.fullmatch(r"[+-]?\d+", text):
+        raise ValueError(value)
+    return clamp_min_length(int(text))
 
 
 def _parse_boundary(value: str) -> str:
@@ -79,9 +102,9 @@ SETTINGS = (
         invalid=lambda v: f"'{v}' is not a number between 0.1 and 0.9",
     ),
     Setting(
-        "min_length", "min_word_length", ("minlen", "min_length"),
+        "min_length", "min_word_length", ("minlen",),
         DEFAULT_MIN_WORD_LENGTH,
-        parse=lambda v: clamp_min_length(int(float(v))),
+        parse=parse_min_length,
         render=lambda v: f"minlen={v}",
         invalid=lambda v: f"'{v}' is not a whole number",
     ),

--- a/plugins/claude-bionify/skills/claude-bionify/SKILL.md
+++ b/plugins/claude-bionify/skills/claude-bionify/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: claude-bionify
+description: Configure and control the claude-bionify bionic reading plugin. Use when the user asks about bionic reading settings (fixation/strength, boundary, minimum word length, acronyms, URLs, headings), wants to turn the bionic display on, off, or toggle it, asks for the current status, or asks how to use the /claude-bionify commands.
+when_to_use: User says things like "make bionify bolder", "turn off bionic reading", "set fixation to 0.7", "how do I change the minimum word length", "what bionify commands are there", or "reset bionify to defaults".
+user-invocable: false
+---
+
+# claude-bionify control
+
+Background knowledge for answering questions about the claude-bionify plugin, which
+bolds the leading part of each word in Claude's responses (cosmetic bionic reading).
+Use it to recommend the right command and the exact key a user needs.
+
+## When to use
+
+Load this skill when the user wants to:
+
+- Change a setting (boldness, boundary, word length, acronyms, URLs, headings).
+- Turn the formatting on, off, or toggle it.
+- Check the current state or reset overrides.
+- Learn what `/claude-bionify` commands exist.
+
+## Settings
+
+Each setting has a default in `plugin.json` and a short key used by the live
+`/claude-bionify:set` command. The set key is what you pass to the command, and it is
+shorter than the `plugin.json` field name.
+
+| Setting | `set` key | Default | Values | Meaning |
+| :-- | :-- | :-- | :-- | :-- |
+| Fixation strength | `fixation` (alias `strength`) | `0.5` | `0.1` to `0.9` | Fraction of each word bolded; higher is bolder. Applies to the `fraction` boundary only. |
+| Bold boundary | `boundary` | `fraction` | `fraction`, `syllable`, `log` | `fraction` uses the fixation strength; `syllable` bolds up to the first syllable; `log` grows logarithmically so long words are bolded less. |
+| Minimum word length | `minlen` | `4` | `1` or greater | Words shorter than this stay unbolded. |
+| Skip acronyms | `acronyms` | `true` | `on`, `off` | Leave ALL-CAPS acronyms such as API or JSON unbolded. |
+| Protect URLs, paths, files | `urls` | `true` | `on`, `off` | Do not bold inside URLs, emails, file paths, or filenames. |
+| Skip headings | `headings` | `true` | `on`, `off` | Leave markdown headings (lines starting with `#`) unbolded. |
+
+## Commands
+
+All commands live under the `/claude-bionify` namespace.
+
+| Command | Argument | Action |
+| :-- | :-- | :-- |
+| `/claude-bionify:status` | none | Show the current settings and whether bionify is on. |
+| `/claude-bionify:on` | none | Enable bionic formatting. |
+| `/claude-bionify:off` | none | Disable bionic formatting. |
+| `/claude-bionify:toggle` | none | Flip bionify on or off. |
+| `/claude-bionify:set` | `<key> <value>` | Override one setting live. Keys: `fixation` (or `strength`), `boundary`, `minlen`, `acronyms`, `urls`, `headings`. |
+| `/claude-bionify:reset` | none | Clear live overrides and restore the `plugin.json` defaults. |
+
+Examples:
+
+- `/claude-bionify:set fixation 0.7`
+- `/claude-bionify:set boundary syllable`
+- `/claude-bionify:set minlen 5`
+- `/claude-bionify:set acronyms off`
+
+Important: `set` only accepts the short keys above, not the longer `plugin.json` field
+names. `set minlen 5` works; `set min_word_length 5` does not. Likewise use `acronyms`,
+`urls`, and `headings`, not `skip_acronyms`, `protect_urls`, or `skip_headings`.
+
+## Notes
+
+- `set` changes apply to the next response and persist until `/claude-bionify:reset`.
+- Changing the `plugin.json` defaults instead takes effect on the next session.
+- The formatting is cosmetic: it never alters the underlying text Claude reads or saves.

--- a/plugins/claude-bionify/themes/dracula.json
+++ b/plugins/claude-bionify/themes/dracula.json
@@ -1,0 +1,13 @@
+{
+  "name": "Dracula",
+  "base": "dark",
+  "overrides": {
+    "text": "#F8F8F2",
+    "claude": "#BD93F9",
+    "subtle": "#6272A4",
+    "promptBorder": "#44475A",
+    "error": "#FF5555",
+    "success": "#50FA7B",
+    "warning": "#F1FA8C"
+  }
+}

--- a/plugins/claude-bionify/themes/focus-dark.json
+++ b/plugins/claude-bionify/themes/focus-dark.json
@@ -1,0 +1,13 @@
+{
+  "name": "Focus Dark",
+  "base": "dark",
+  "overrides": {
+    "text": "#ABB2BF",
+    "claude": "#C678DD",
+    "subtle": "#4B5263",
+    "promptBorder": "#3E4452",
+    "error": "#E06C75",
+    "success": "#98C379",
+    "warning": "#D19A66"
+  }
+}

--- a/plugins/claude-bionify/themes/gruvbox.json
+++ b/plugins/claude-bionify/themes/gruvbox.json
@@ -1,0 +1,13 @@
+{
+  "name": "Gruvbox",
+  "base": "dark",
+  "overrides": {
+    "text": "#EBDBB2",
+    "claude": "#FABD2F",
+    "subtle": "#928374",
+    "promptBorder": "#3C3836",
+    "error": "#FB4934",
+    "success": "#B8BB26",
+    "warning": "#FE8019"
+  }
+}

--- a/plugins/claude-bionify/themes/nord.json
+++ b/plugins/claude-bionify/themes/nord.json
@@ -1,0 +1,13 @@
+{
+  "name": "Nord",
+  "base": "dark",
+  "overrides": {
+    "text": "#D8DEE9",
+    "claude": "#88C0D0",
+    "subtle": "#4C566A",
+    "promptBorder": "#3B4252",
+    "error": "#BF616A",
+    "success": "#A3BE8C",
+    "warning": "#EBCB8B"
+  }
+}

--- a/plugins/claude-bionify/themes/sepia.json
+++ b/plugins/claude-bionify/themes/sepia.json
@@ -1,0 +1,13 @@
+{
+  "name": "Sepia",
+  "base": "light",
+  "overrides": {
+    "text": "#5C3C24",
+    "claude": "#B58900",
+    "subtle": "#8A7E72",
+    "promptBorder": "#E5D9C4",
+    "error": "#DC322F",
+    "success": "#859900",
+    "warning": "#CB4B16"
+  }
+}

--- a/plugins/claude-bionify/themes/solarized-dark.json
+++ b/plugins/claude-bionify/themes/solarized-dark.json
@@ -1,0 +1,13 @@
+{
+  "name": "Solarized Dark",
+  "base": "dark",
+  "overrides": {
+    "text": "#839496",
+    "claude": "#268BD2",
+    "subtle": "#586E75",
+    "promptBorder": "#073642",
+    "error": "#DC322F",
+    "success": "#859900",
+    "warning": "#CB4B16"
+  }
+}

--- a/plugins/claude-bionify/themes/solarized-light.json
+++ b/plugins/claude-bionify/themes/solarized-light.json
@@ -1,0 +1,13 @@
+{
+  "name": "Solarized Light",
+  "base": "light",
+  "overrides": {
+    "text": "#657B83",
+    "claude": "#268BD2",
+    "subtle": "#93A1A1",
+    "promptBorder": "#EEE8D5",
+    "error": "#DC322F",
+    "success": "#859900",
+    "warning": "#CB4B16"
+  }
+}


### PR DESCRIPTION
## Summary
- Add the `claude-bionify` Claude Code plugin under `plugins/claude-bionify`
- List `claude-bionify` under the README `Design UX` category
- Register `claude-bionify` in `.claude-plugin/marketplace.json`
- Update the vendored plugin and marketplace entry to `1.0.1`, including the live-override persistence fix

## Validation
- `jq empty .claude-plugin/marketplace.json plugins/claude-bionify/.claude-plugin/plugin.json plugins/claude-bionify/hooks/hooks.json`
- `claude plugin validate ./plugins/claude-bionify --strict`
- Source plugin: `.venv/bin/python -m pytest tests/test_bionify.py` (80 passed)
- Runtime check: `CLAUDE_BIONIFY_STATE_FILE=runtime.json` now writes the override file successfully