### PR TITLE
Add agent-safety-preflight plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -188,6 +188,7 @@
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+- [agent-safety-preflight](./plugins/agent-safety-preflight)
 
 
 ## 使用教程

--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
+- [agent-safety-preflight](./plugins/agent-safety-preflight)
 
 
 ## Tutorials

--- a/plugins/agent-safety-preflight/.claude-plugin/plugin.json
+++ b/plugins/agent-safety-preflight/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "agent-safety-preflight",
+  "version": "1.0.0",
+  "description": "Claude Code slash command that runs a local AI-agent repo preflight before tool-enabled coding sessions get shell, package-script, MCP, or secret-adjacent scope.",
+  "author": {
+    "name": "Signal Loom Works",
+    "url": "https://github.com/el-zachariah/ai-agent-safety-starter-pack"
+  },
+  "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/agent-safety-preflight"
+}

--- a/plugins/agent-safety-preflight/commands/agent-preflight.md
+++ b/plugins/agent-safety-preflight/commands/agent-preflight.md
@@ -1,0 +1,36 @@
+---
+description: Run a local repo preflight before Claude Code gets tool access
+allowed-tools: Bash(git status:*), Bash(git branch:*), Bash(python3 agent_preflight_lite.py:*)
+---
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- Current status: !`git status --short`
+
+## Your task
+
+Run an AI-agent safety preflight before this Claude Code session gets broad tool access.
+
+1. If `agent_preflight_lite.py` is present in this repo, run:
+
+   ```bash
+   python3 agent_preflight_lite.py .
+   python3 agent_preflight_lite.py . --json
+   ```
+
+2. Summarize the result as **Green**, **Yellow**, or **Red**:
+   - Green: zero or one low-risk bucket; continue with normal review discipline.
+   - Yellow: two or three buckets, package scripts, MCP/Claude/Cursor config, or secret-adjacent files; write may-run / must-ask / must-not-touch rules before executing commands.
+   - Red: destructive shell, credential-adjacent files, or four-plus risk buckets; stop and get explicit approval before shell/package/deploy commands.
+
+3. If the scanner is missing, do not curl-pipe or auto-install anything. Tell the user to inspect or copy the free scanner from:
+   `https://github.com/el-zachariah/ai-agent-safety-starter-pack`
+
+4. End with a concise handoff:
+   - Findings
+   - Commands allowed now
+   - Commands that need approval
+   - Files or directories the agent must not touch
+
+This command is a lightweight pre-tool-access checklist for Claude Code plugin users; it is not a sandbox, malware scanner, or full security audit.


### PR DESCRIPTION
Adds a free `agent-safety-preflight` Claude Code plugin command under Security, Compliance, & Legal.

Why it fits this list:
- Claude Code slash command packaged with `.claude-plugin/plugin.json`.
- Helps users run a local repo preflight before tool-enabled Claude Code sessions get shell/package/MCP/secret-adjacent scope.
- Links only to the free public scanner/source repo for inspection; no checkout or paid-product link in this listing.

Validation performed:
- `plugin.json` parsed successfully.
- README entry and command markers verified locally.
- Duplicate code search for `agent-preflight`, `agent-safety-preflight`, and `ai-agent-safety-starter-pack` returned no upstream hits before submission.
