### PR TITLE
fix: marketplace integrity (broken links, orphans, missing plugin.json)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -458,18 +458,6 @@
       "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/husky"
     },
     {
-      "name": "2-commit-fast",
-      "source": "./plugins/2-commit-fast",
-      "description": "Automates git commit process by selecting the first suggested message, generating structured commits with consistent formatting while skipping manual confirmation and removing Claude co-Contributorship footer",
-      "version": "1.0.0",
-      "author": {
-        "name": "steadycursor",
-        "url": "https://github.com/steadycursor"
-      },
-      "category": "general",
-      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/2-commit-fast"
-    },
-    {
       "name": "pr-issue-resolve",
       "source": "./plugins/pr-issue-resolve",
       "description": "this is to analyze the PRs and solve the requested changes in them\n",
@@ -503,20 +491,6 @@
         "refactoring",
         "testing",
         "security"
-      ]
-    },
-    {
-      "name": "accessibility-expert",
-      "source": "./plugins/accessibility-expert",
-      "description": "Examples:",
-      "version": "1.0.0",
-      "author": {
-        "name": "Alysson Franklin"
-      },
-      "category": "agents",
-      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/accessibility-expert",
-      "keywords": [
-        "subagent"
       ]
     },
     {

--- a/README-zh.md
+++ b/README-zh.md
@@ -49,7 +49,7 @@
 
 ### Claude Code 官方插件
 - [agent-sdk-dev](./plugins/agent-sdk-dev)
-- [pr-review-toolkit](./plugins/pr-review-toolkit")
+- [pr-review-toolkit](./plugins/pr-review-toolkit)
 - [commit-commands](./plugins/commit-commands)
 - [feature-dev](./plugins/feature-dev)
 - [security-guidance](./plugins/security-guidance)

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Official Claude Code Plugins
 - [agent-sdk-dev](./plugins/agent-sdk-dev)
-- [pr-review-toolkit](./plugins/pr-review-toolkit")
+- [pr-review-toolkit](./plugins/pr-review-toolkit)
 - [commit-commands](./plugins/commit-commands)
 - [feature-dev](./plugins/feature-dev)
 - [security-guidance](./plugins/security-guidance)

--- a/plugins/commit-commands/.claude-plugin/plugin.json
+++ b/plugins/commit-commands/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "commit-commands",
+  "description": "Commands for git commit workflows including commit, push, and PR creation",
+  "version": "1.0.0",
+  "author": {
+    "name": "Anthropic",
+    "email": "support@anthropic.com"
+  },
+  "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/commit-commands"
+}


### PR DESCRIPTION
## Summary
- Fix broken README marketplace links (EN + zh).
- Remove orphan entries from `.claude-plugin/marketplace.json`.
- Add missing `plugins/commit-commands/.claude-plugin/plugin.json`.

## Why
Marketplace catalog integrity: broken links and orphan/missing plugin metadata make the list harder to trust and install from.

## Test plan
- [ ] Diff `marketplace.json` — orphan entries removed, no accidental drops of valid plugins
- [ ] Click fixed README links (EN + zh)
- [ ] Confirm `plugins/commit-commands/.claude-plugin/plugin.json` is valid JSON and matches the plugin folder

## Notes
Fork is 2 commits ahead / 0 behind `ccplugins/awesome-claude-code-plugins:main`. No rebase needed.