### PR TITLE
Add trigger-tree documentation telemetry plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,6 +11,36 @@
   },
   "plugins": [
     {
+      "name": "trigger-tree",
+      "displayName": "trigger-tree",
+      "source": {
+        "source": "github",
+        "repo": "Hedde/trigger_tree"
+      },
+      "description": "Local documentation-discovery telemetry for Claude Code with live dashboards, heat maps, health diagnostics, and evidence-backed router fixes.",
+      "version": "0.8.0",
+      "author": {
+        "name": "Hedde van der Heide",
+        "url": "https://github.com/Hedde"
+      },
+      "category": "Documentation",
+      "homepage": "https://hedde.github.io/trigger_tree/",
+      "repository": "https://github.com/Hedde/trigger_tree",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "docs-as-code",
+        "documentation",
+        "observability",
+        "telemetry"
+      ],
+      "tags": [
+        "documentation",
+        "local-first",
+        "observability"
+      ]
+    },
+    {
       "name": "documentation-generator",
       "source": "./plugins/documentation-generator",
       "description": "Create comprehensive documentation for code, APIs, and projects.",

--- a/README-zh.md
+++ b/README-zh.md
@@ -141,6 +141,7 @@
 - [documentation-generator](./plugins/documentation-generator)
 - [generate-api-docs](./plugins/generate-api-docs)
 - [openapi-expert](./plugins/openapi-expert)
+- [trigger-tree](https://github.com/Hedde/trigger_tree)
 - [update-claudemd](./plugins/update-claudemd)
 
 ### Git工作流

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [documentation-generator](./plugins/documentation-generator)
 - [generate-api-docs](./plugins/generate-api-docs)
 - [openapi-expert](./plugins/openapi-expert)
+- [trigger-tree](https://github.com/Hedde/trigger_tree)
 - [update-claudemd](./plugins/update-claudemd)
 
 ### Git Workflow


### PR DESCRIPTION
<img width="254" height="254" alt="logo-tt" src="https://github.com/user-attachments/assets/65754f0a-4281-4171-abaa-908c993a4367" />

Adds [trigger-tree](https://github.com/Hedde/trigger_tree) to the **Documentation** category as an external GitHub source.

trigger-tree records which documentation Claude Code discovers during normal repository work and presents the local event data as a live dashboard, heat/cold maps, health diagnostics, and evidence-backed router suggestions. Runtime telemetry stays local and uses no model tokens or network calls.

### Changes
- Register `Hedde/trigger_tree` as an external GitHub plugin source
- Add the plugin to the English and Chinese Documentation lists
- Include release, author, license, homepage, repository, keyword, and tag metadata

### Validation
- `jq empty .claude-plugin/marketplace.json`
- Unique `trigger-tree` plugin-name check
- External source repository field check
- `git diff --check`
- Upstream repository CI: Python 3.10–3.13 compatibility, Linux/macOS/Windows tests, Ruff, Black, ShellCheck, plugin validation, CodeQL, dependency review, and 100% Python coverage