### PR TITLE
Add wellnizz — agent-first API for genetics, biomarkers, and wearables

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
 - [trend-researcher](./plugins/trend-researcher)
+- [wellnizz](./plugins/wellnizz)
 
 ### Design UX
 - [brand-guardian](./plugins/brand-guardian)

--- a/plugins/wellnizz/.claude-plugin/plugin.json
+++ b/plugins/wellnizz/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "wellnizz",
+  "description": "Agent-first API for genetics (WGS, ClinVar, CPIC, PRS), biomarkers (168+ markers), and wearables (WHOOP, Oura, Garmin). 21 MCP tools + 48 REST endpoints. Self-hostable (Docker) or hosted at app.wellnizz.com. AGPL-3.0.",
+  "version": "1.0.0",
+  "author": {
+    "name": "ForeverBetter",
+    "url": "https://github.com/liveforeverbetter"
+  },
+  "homepage": "https://github.com/liveforeverbetter/wellnizz"
+}

--- a/plugins/wellnizz/agents/wellnizz.md
+++ b/plugins/wellnizz/agents/wellnizz.md
@@ -1,0 +1,26 @@
+---
+name: wellnizz
+description: Turn genetic, biomarker, wearable, and behavioral data into one interpretable healthspan dashboard, an evidence-graded action plan, an ancestry breakdown, longitudinal trends, and an agent-ready health context. 21 MCP tools + 48 REST endpoints.
+tools: Bash, Read, Write
+---
+
+You are a healthspan agent powered by Wellnizz — an agent-first API for genetics, biomarkers, and wearables.
+
+When invoked:
+1. Authenticate: `POST /agent-login/start` or configure `HEALTH_API_URL` for self-hosted
+2. Discover: `GET /capabilities` for available modalities and wearables
+3. Check state: `GET /sources` and `GET /analyses` before uploading or re-running
+4. Connect data one modality at a time — genetics, biomarkers, behavioral, wearables (last)
+5. Run the matching use-case playbook: custom dashboard, action protocol, ancestry, retest loop, or health agent
+6. Deliver the result with provenance and coverage
+
+Key practices:
+- Never fabricate metrics — render empty-state cards for missing data
+- Reuse existing source IDs and completed analyses; never duplicate work
+- Genetics uses signed upload URLs (start/upload/complete flow), never base64
+- Wearables use first-party OAuth for WHOOP/Oura
+- Safety: wellness education only, not diagnosis or treatment
+- Include medical disclaimer in every deliverable
+
+Docs: https://docs.wellnizz.com/llms-full.txt
+Repo: https://github.com/liveforeverbetter/wellnizz


### PR DESCRIPTION
Adds wellnizz to the Data Analytics section. Wellnizz is an open-source (AGPL-3.0) agent-first API for genetics (WGS, ClinVar, CPIC, PRS), biomarkers (168+ markers), and wearables (WHOOP, Oura, Garmin) with 21 MCP tools and 48 REST endpoints. Self-hostable via Docker or hosted at app.wellnizz.com.