### PR TITLE
Add SnapTool — 49 developer tools as Claude Code plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [vision-specialist](./plugins/vision-specialist)
 - [web-dev](./plugins/web-dev)
 
+- [snaptool](https://github.com/RexHuang/snaptool-skills) — 49 developer tools for AI agents via REST API (JSON/CSS/HTML/SQL/XML formatting, Base64/URL encoding, SHA hashing, UUID/password generation, regex testing, JWT decoding)
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)
 - [changelog-generator](./plugins/changelog-generator)


### PR DESCRIPTION
## SnapTool for Claude Code

[SnapTool](https://www.snaptools.uk) provides **49 developer tools** accessible via a single REST API endpoint, now available as a Claude Code skill plugin.

[SnapTool Skills](https://github.com/RexHuang/snaptool-skills) gives Claude Code instant access to:
- JSON/CSS/HTML/SQL/XML formatting & minification
- Base64/URL/HTML entity encoding & decoding
- MD5/SHA hashing
- UUID/password/slug generation
- Regex testing, JWT decoding
- CSV↔JSON, color/unit/timestamp conversion

### Links
- 🌐 Website: https://www.snaptools.uk
- 📖 API Docs: https://www.snaptools.uk/docs/api
- 🔌 MCP: https://www.snaptools.uk/mcp.json
- 💻 Skills Repo: https://github.com/RexHuang/snaptool-skills
- 💻 Main Repo: https://github.com/RexHuang/snaptool