### PR TITLE
Add a Marketplaces section, starting with protonium

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,6 +21,7 @@
     - [市场营销与增长](#市场营销与增长)
     - [项目与产品管理](#项目与产品管理)
     - [安全、合规与法律](#安全、合规与法律)
+* [插件市场](#插件市场)
 * [使用教程](#使用教程)
 * [如何贡献](#如何贡献)
 
@@ -189,6 +190,14 @@
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
 
+## 插件市场
+
+可通过 `/plugin marketplace add` 直接添加的社区插件市场：
+
+- [protonium](https://github.com/protonium-labs/protonium-marketplace) —— AI 智能体与效率工具。包含 **AxiomCore**：项目与日常事务管理智能体，提供强制化结构（编号目录、任务 ID、wiki 记忆）、计划 → 确认 → 执行工作流，支持敏捷或 WBS 方式创建项目.
+```bash
+ /plugin marketplace add protonium-labs/protonium-marketplace
+```
 
 ## 使用教程
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Community-hosted plugin marketplaces you can add directly with `/plugin marketpl
 
 - [protonium](https://github.com/protonium-labs/protonium-marketplace) — AI agents and productivity tools. Includes **AxiomCore**, a project & routine management agent: enforced structure (numbered folders, task IDs, wiki memory), plan → approve → execute workflow, agile or WBS project creation.
 
+```bash
+/plugin marketplace add protonium-labs/protonium-marketplace
+```
+
 ## Tutorials
 
 You can host and share your own curated plugin marketplace using a simple Git repository with a `.claude-plugin/marketplace.json` file.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
     - [Marketing Growth](#marketing-growth)
     - [Project & Product Management](#project--product-management)
     - [Security, Compliance, & Legal](#security-compliance--legal)
+* [Marketplaces](#marketplaces)
+* [Tutorials](#tutorials)
 * [Tutorials](#tutorials)
 * [Contributing](#contributing)
 
@@ -189,6 +191,11 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
 
+## Marketplaces
+
+Community-hosted plugin marketplaces you can add directly with `/plugin marketplace add`:
+
+- [protonium](https://github.com/protonium-labs/protonium-marketplace) — AI agents and productivity tools. Includes **AxiomCore**, a project & routine management agent: enforced structure (numbered folders, task IDs, wiki memory), plan → approve → execute workflow, agile or WBS project creation.
 
 ## Tutorials
 


### PR DESCRIPTION
The Contributing section invites submitting your own marketplace, and the Tutorials section documents the format — but there is currently no place in the README where marketplaces are listed. This PR adds a `## Marketplaces` section and the first entry.

- Marketplace: https://github.com/protonium-labs/protonium-marketplace
- Install: `/plugin marketplace add protonium-labs/protonium-marketplace`
- Currently hosts AxiomCore (MIT, v1.1.0) — 8 skills, 3 subagents, guided onboarding via `/axiom start`

Only `README.md` and `README-zh.md` are touched; no plugin files, no changes to `.claude-plugin/marketplace.json`.

Happy to move the section, rename it, or reformat the entry — and equally happy to close this if you would rather keep the list plugin-only.