### PR TITLE
Add claude-session-tint plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1674,8 +1674,8 @@
     {
       "name": "claude-session-tint",
       "source": "./plugins/claude-session-tint",
-      "description": "Tint a Terminal.app window by project and brighten it when a Claude Code response finishes unseen; includes a UserPromptSubmit hook that runs an input-box command without invoking the model.",
-      "version": "1.1.0",
+      "description": "Tint a Terminal.app window by project and brighten it when a Claude Code response finishes unseen; tabs sharing a window get a tab-title marker instead. Includes a UserPromptSubmit hook that runs an input-box command without invoking the model.",
+      "version": "1.2.0",
       "author": {
         "name": "DotcomJack"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1675,7 +1675,7 @@
       "name": "claude-session-tint",
       "source": "./plugins/claude-session-tint",
       "description": "Tint a Terminal.app window by project and brighten it when a Claude Code response finishes unseen; tabs sharing a window get a tab-title marker instead. Includes a UserPromptSubmit hook that runs an input-box command without invoking the model.",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "author": {
         "name": "DotcomJack"
       },

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,23 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "claude-session-tint",
+      "source": "./plugins/claude-session-tint",
+      "description": "Tint a Terminal.app window by project and brighten it when a Claude Code response finishes unseen; includes a UserPromptSubmit hook that runs an input-box command without invoking the model.",
+      "version": "1.1.0",
+      "author": {
+        "name": "DotcomJack"
+      },
+      "category": "Workflow Orchestration",
+      "homepage": "https://github.com/dotcomjack/claude-session-tint",
+      "keywords": [
+        "terminal",
+        "macos",
+        "hooks",
+        "multi-session"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [claude-session-tint](./plugins/claude-session-tint)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/plugins/claude-session-tint/.claude-plugin/plugin.json
+++ b/plugins/claude-session-tint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-session-tint",
   "displayName": "Claude Session Tint",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Know which Claude Code session needs you. Tints a Terminal.app window by project and brightens it when a response lands unseen.",
   "author": {
     "name": "DotcomJack",

--- a/plugins/claude-session-tint/.claude-plugin/plugin.json
+++ b/plugins/claude-session-tint/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-session-tint",
   "displayName": "Claude Session Tint",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Know which Claude Code session needs you. Tints a Terminal.app window by project and brightens it when a response lands unseen.",
   "author": {
     "name": "DotcomJack",

--- a/plugins/claude-session-tint/.claude-plugin/plugin.json
+++ b/plugins/claude-session-tint/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "claude-session-tint",
+  "displayName": "Claude Session Tint",
+  "version": "1.1.0",
+  "description": "Know which Claude Code session needs you. Tints a Terminal.app window by project and brightens it when a response lands unseen.",
+  "author": {
+    "name": "DotcomJack",
+    "url": "https://dotcomjack.com"
+  },
+  "homepage": "https://github.com/dotcomjack/claude-session-tint",
+  "repository": "https://github.com/dotcomjack/claude-session-tint",
+  "license": "MIT",
+  "keywords": ["terminal", "macos", "hooks", "multi-session", "productivity"]
+}

--- a/plugins/claude-session-tint/LICENSE
+++ b/plugins/claude-session-tint/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 DotcomJack
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/claude-session-tint/README.md
+++ b/plugins/claude-session-tint/README.md
@@ -1,0 +1,27 @@
+# claude-session-tint
+
+Know which Claude Code session needs you.
+
+Tag a terminal window with a project. It wears that project's color quietly
+while it works, brightens when a response lands while you are looking elsewhere,
+and drops back the moment you focus it.
+
+```
+,api        tag this window "API"   (no turn, no tokens, no reply)
+,           show the palette
+,off        untag
+```
+
+Typing `,api` runs a command from inside a live session **without invoking the
+model**: a `UserPromptSubmit` hook returns `decision:"block"` with
+`suppressOriginalPrompt`, so Claude Code never queries the model. That pattern
+works on any terminal and any OS. The window coloring itself is macOS
+Terminal.app only, because Terminal.app is the one terminal with no native tab
+colors.
+
+Edit your palette at `~/.claude/tabtint-palette.conf` (falls back to the bundled
+`palette.conf`). Tune with `TABTINT_IDLE_PCT` and `TABTINT_ATTN_PCT`.
+
+Upstream, issues and full docs: https://github.com/dotcomjack/claude-session-tint
+
+MIT.

--- a/plugins/claude-session-tint/bin/tabtint
+++ b/plugins/claude-session-tint/bin/tabtint
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Tag this terminal window with a project color.
+#   tabtint                  show this window's tag and the palette
+#   tabtint api              tag it (case insensitive, prefixes work)
+#   tabtint off              untag, back to the original background
+#   tabtint list             just the palette
+#   tabtint sync             repaint every window (after editing colors)
+#   tabtint idle on|off      resting tint on or off
+#   tabtint status           what the hook currently sees
+#
+# Prefers tabtint.sh one level up (plugin layout: bin/ inside the plugin root),
+# then falls back to a manual install under ~/.claude/hooks.
+here=$(cd "$(dirname "$0")" 2>/dev/null && pwd)
+for c in "$here/../tabtint.sh" "$HOME/.claude/hooks/tabtint.sh"; do
+  [ -x "$c" ] && exec "$c" tab "$@"
+done
+echo "tabtint: cannot find tabtint.sh (looked in $here/.. and ~/.claude/hooks)" >&2
+exit 1

--- a/plugins/claude-session-tint/commands/tabtint.md
+++ b/plugins/claude-session-tint/commands/tabtint.md
@@ -1,0 +1,17 @@
+---
+description: Tint this terminal window with a project color. No argument shows the palette.
+argument-hint: "<project> | off | list | idle on|off | status   (or just type ,project)"
+allowed-tools: Bash(${CLAUDE_PLUGIN_ROOT}/tabtint.sh:*)
+disable-model-invocation: true
+model: haiku
+effort: low
+---
+
+The window color command has already run during expansion. Its output:
+
+!`${CLAUDE_PLUGIN_ROOT}/tabtint.sh tab $ARGUMENTS`
+
+Print that output back verbatim, then on a final line print exactly:
+`tip: ,<project> in the input box does the same thing with no turn.`
+
+No other commentary, no summary, no preamble, no tool calls. There is nothing left to do.

--- a/plugins/claude-session-tint/hooks/hooks.json
+++ b/plugins/claude-session-tint/hooks/hooks.json
@@ -1,0 +1,34 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}\"/tabtint.sh rest", "timeout": 25, "async": true }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}\"/prompt-hook.sh", "timeout": 10 }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}\"/tabtint.sh clear", "timeout": 25, "async": true }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          { "type": "command", "command": "\"${CLAUDE_PLUGIN_ROOT}\"/tabtint.sh set", "timeout": 25, "async": true }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-session-tint/palette.conf
+++ b/plugins/claude-session-tint/palette.conf
@@ -1,0 +1,35 @@
+# tabtint palette
+#
+# Format, TAB separated:
+#   HEX <TAB> KEY <TAB> LABEL <TAB> EMOJI
+#
+# KEY is what you type: `tabtint api`. Matching is case insensitive and accepts
+# a prefix, so `tabtint ap` works too.
+#
+# HEX is the identity color at full strength. It is never painted at full
+# strength: it scales to a readable dark wash (22% at rest, 48% unread).
+#
+# EMOJI is optional. When set, tagging a window copies a ready-to-paste
+# `/rename <emoji> <label>` line to your clipboard, because most terminals
+# cannot color the tab itself but every terminal renders an emoji in the title.
+#
+# Replace these with your own projects. Edit freely, no restart needed, then
+# run `tabtint sync`.
+
+#HEX	KEY	LABEL	EMOJI
+#A3D8E1	api	API	🔵
+#6FB07A	web	Web	🌿
+#C4744A	mobile	Mobile	🧱
+#B07AC4	infra	Infra	🟣
+#D9B44A	docs	Docs	📜
+#E8833A	data	Data	🟠
+#7E7BD4	ml	ML	🎧
+#46C8B8	tooling	Tooling	🩵
+
+# Unbranded tags, for scratch or throwaway windows
+#D94F4F	red	Red	🔴
+#4FD97A	green	Green	🟢
+#2F72E6	blue	Blue	🔵
+#D9D94F	yellow	Yellow	🟡
+#B84FD9	purple	Purple	🟣
+#CCCCCC	white	White	⚪

--- a/plugins/claude-session-tint/prompt-hook.sh
+++ b/plugins/claude-session-tint/prompt-hook.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# tab-tag-prompt.sh  -  UserPromptSubmit hook  (companion to tabtint.sh)
+#
+# Tag the current Terminal window from inside a running Claude session without
+# spending a turn. Type a lone comma line into the Claude input box:
+#
+#   ,aianyone    tag this window        (prefixes work, so ,ai is enough)
+#   ,off         untag it
+#   ,            show this window's tag plus the palette
+#   ,list        just the palette
+#   ,idle on     resting tint on / off
+#
+# HOW THE ZERO-TURN PART ACTUALLY WORKS (verified against the 2.1.223 binary,
+# not inferred from docs). On a UserPromptSubmit hook result that carries a
+# blockingError, Claude Code returns { shouldQuery: false, ... }, so the model
+# is never invoked: no turn, no tokens, no assistant message.
+#
+# The important detail, and the reason this script prints JSON instead of just
+# exiting 2 with a message on stderr:
+#
+#     V = H.suppressOriginalPrompt ? q : `${q}\n\nOriginal prompt: ${O}`
+#
+# A bare `exit 2` cannot set suppressOriginalPrompt, so the blocked prompt gets
+# echoed back into the transcript as "Original prompt: ,ai". Emitting
+# hookSpecificOutput.suppressOriginalPrompt = true drops that echo. Setting
+# decision:"block" also supplies the reason text directly, instead of Claude
+# Code synthesising "[<command>]: <stderr>" around it.
+#
+# We still exit 2 as well as printing the JSON. That is deliberate: with exit 0
+# there is an earlier success branch (gated on `de.status===0`) that can yield
+# before the blocking decision is applied. Exit 2 skips it, and because
+# decision:"block" already populated blockingError, the exit-2 stderr fallback
+# (`if (status===2 && !fe.blockingError)`) never fires either.
+#
+# Everything that is not a comma line exits 0 and is passed through untouched.
+# Every failure path also exits 0. This must never eat a real prompt.
+#
+# Must be wired NON-async in settings.json. An async hook runs in the
+# background, so its result arrives too late to gate the prompt.
+
+set -uo pipefail
+
+# Resolve tabtint.sh next to this script rather than at a fixed path. That makes
+# the same file work as a plugin (both scripts sit in the plugin root, which
+# moves on every update) and as a manual install (both in ~/.claude/hooks/).
+TAB="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/tabtint.sh"
+
+payload=$(cat 2>/dev/null) || exit 0
+[ -n "$payload" ] || exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Field name is `prompt`, confirmed in the binary:
+#   hook_event_name:"UserPromptSubmit",prompt:e,...
+prompt=$(printf '%s' "$payload" | jq -r '.prompt // empty' 2>/dev/null) || exit 0
+[ -n "$prompt" ] || exit 0
+
+# ---- the gate -------------------------------------------------------------
+# Pure bash 3.2 pattern matching. No grep: `grep -E '^,...$'` matches ANY LINE
+# of a multi-line prompt, so a long real message containing a short
+# comma-leading line would be silently eaten. Reject newlines outright first.
+
+case $prompt in
+  *'
+'*) exit 0 ;;                                   # multi-line, always a real prompt
+esac
+
+# Trim leading whitespace before matching. Typing a space before the comma is
+# easy to do and used to fall straight through as a real prompt.
+prompt=${prompt#"${prompt%%[![:space:]]*}"}
+
+case $prompt in
+  ,*) ;;                                        # candidate
+  *) exit 0 ;;
+esac
+
+[ ${#prompt} -le 25 ] || exit 0                 # long comma line, real prompt
+
+# Only characters a brand key / subcommand can contain. This also excludes the
+# glob metacharacters, which is what makes the unquoted expansion below safe.
+case $prompt in
+  *[!A-Za-z0-9\ _,.-]*) exit 0 ;;
+esac
+
+[ -x "$TAB" ] || exit 0
+
+# ---- do the work ----------------------------------------------------------
+
+arg=${prompt#,}
+arg=${arg#"${arg%%[![:space:]]*}"}              # ltrim
+arg=${arg%"${arg##*[![:space:]]}"}              # rtrim
+
+set -f                                          # belt and braces, no globbing
+# shellcheck disable=SC2086
+out=$("$TAB" tab $arg 2>&1)
+set +f
+
+[ -n "$out" ] || out="tabcolor: no output"
+
+jq -n --arg r "$out" '{
+  decision: "block",
+  reason: $r,
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit",
+    suppressOriginalPrompt: true
+  }
+}' 2>/dev/null || exit 0
+
+exit 2

--- a/plugins/claude-session-tint/tabtint.sh
+++ b/plugins/claude-session-tint/tabtint.sh
@@ -1,0 +1,404 @@
+#!/bin/bash
+# tabtint.sh  (drive it with the `tabcolor` command)
+#
+# Purely cosmetic Terminal.app window coloring:
+#   1. You tag a window with a brand once      ->  tabcolor aianyone
+#   2. It wears that brand quietly at rest     ->  10% wash
+#   3. It lights up when a response lands      ->  34% wash
+#   4. It drops back the moment you focus it
+#
+# Terminal.app cannot color a TAB. Verified by enumerating every property on the
+# tab class: the only color properties (background, normal text, bold text,
+# cursor, selected text) all paint the content area, never the tab chrome. Real
+# per-tab color is an iTerm2 / kitty / Ghostty capability.
+#
+# So this paints the window BODY, which is what shows in Mission Control and
+# cmd-tab. The tab bar stays grey. The only thing that reaches the tab bar is
+# the title text, which Claude Code owns; put an emoji in /rename if you want
+# color there.
+#
+# Colors live in ~/.claude/tabtint-palette.conf. Nothing here inspects your work,
+# your files, or your transcripts. A window is whatever you said it was.
+#
+# Hook modes (wired in ~/.claude/settings.json):
+#   set    light up this window        (Stop)
+#   clear  drop back to rest           (UserPromptSubmit)
+#   rest   apply resting state         (SessionStart)
+#   watch  internal shared watcher
+#
+# Tuning:
+#   TABTINT_ATTN_PCT  brightness when unread  (default 34)
+#   TABTINT_IDLE_PCT  brightness at rest      (default 10)
+
+set -uo pipefail
+
+STATE_DIR="$HOME/.claude/state/tabtint"
+
+# Your palette lives in ~/.claude so it survives plugin updates, which replace
+# the plugin directory wholesale. Fall back to the palette bundled next to this
+# script so a fresh plugin install works with no setup step.
+BRANDS_FILE="$HOME/.claude/tabtint-palette.conf"
+if [ ! -r "$BRANDS_FILE" ]; then
+  BRANDS_FILE="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/palette.conf"
+fi
+LOCK_DIR="$STATE_DIR/.watcher.lock"
+IDLE_FLAG="$STATE_DIR/.idle-enabled"
+
+ATTN_PCT="${TABTINT_ATTN_PCT:-48}"
+IDLE_PCT="${TABTINT_IDLE_PCT:-22}"
+
+# These two reach $(( )), and bash recursively evaluates a variable's CONTENT as
+# an arithmetic expression, which will run a command substitution hidden in an
+# array subscript. They come from the environment, so validate them as plain
+# integers and fall back to the defaults rather than trusting them.
+case $ATTN_PCT in ''|*[!0-9]*) ATTN_PCT=48 ;; esac
+case $IDLE_PCT in ''|*[!0-9]*) IDLE_PCT=22 ;; esac
+DEFAULT_HEX="#6E6E6E" # untagged windows still light up, just colorless and dimmer
+                      # than any tagged brand (must not equal a palette entry)
+
+POLL_SECONDS=1
+MAX_WATCH_SECONDS=21600 # 6h, so a watcher can never outlive the day
+
+mkdir -p "$STATE_DIR"
+
+# ---------------------------------------------------------------- helpers ---
+
+# Hard wall clock cap, so a hung Apple Event (a TCC dialog waiting on a click,
+# say) can never wedge a hook.
+osa() { perl -e 'alarm 15; exec @ARGV' osascript "$@" 2>/dev/null; }
+
+# "#A3D8E1" plus a percentage to the 16-bit triple AppleScript wants. Pure bash
+# arithmetic, no subprocess, because this runs on every Stop.
+scale16() {
+  local h="${1#\#}" pct="$2" r g b
+  r=$((16#${h:0:2})); g=$((16#${h:2:2})); b=$((16#${h:4:2}))
+  printf '%s %s %s' "$((r * 257 * pct / 100))" "$((g * 257 * pct / 100))" "$((b * 257 * pct / 100))"
+}
+
+# Claude Code pipes stdin to hooks, so `tty` reports "not a tty". Walk up the
+# process tree to the login shell to find the real terminal device.
+session_tty() {
+  local pid=$$ t ppid
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    t=$(ps -o tty= -p "$pid" 2>/dev/null | tr -d ' ')
+    case "$t" in ttys*) printf '%s' "$t"; return 0 ;; esac
+    ppid=$(ps -o ppid= -p "$pid" 2>/dev/null | tr -d ' ')
+    [ -z "$ppid" ] && break
+    [ "$ppid" -le 1 ] 2>/dev/null && break
+    pid=$ppid
+  done
+  return 1
+}
+
+# The window's login process. Terminal reuses tty numbers when you close and
+# open windows, so this pins a tag to one physical window, not to "ttys004".
+tty_owner() { ps -t "$1" -o pid=,comm= 2>/dev/null | awk '$NF=="login"{print $1; exit}'; }
+tty_alive() { [ -n "$(ps -t "$1" -o pid= 2>/dev/null)" ]; }
+
+# Look up a brand by key or label. Accepts a case insensitive prefix.
+lookup_brand() {
+  awk -F'\t' -v q="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')" '
+    $1 !~ /^#[0-9A-Fa-f]{6}$/ { next }
+    {
+      k = tolower($2); l = tolower($3)
+      if (k == q || l == q) { print $1 "\t" $2 "\t" $3 "\t" $4; exit }
+      if (!hit && (index(k, q) == 1 || index(l, q) == 1)) hit = $1 "\t" $2 "\t" $3 "\t" $4
+    }
+    END { if (hit) print hit }
+  ' "$BRANDS_FILE"
+}
+
+# This window's tag, or empty. Ignores a tag left behind by a closed window
+# that happened to hold the same tty number.
+assignment() {
+  local t="$1" owner
+  [ -f "$STATE_DIR/$t.brand" ] || return 1
+  owner=$(tty_owner "$t")
+  if [ -n "$owner" ] && [ -f "$STATE_DIR/$t.owner" ] && [ "$owner" != "$(cat "$STATE_DIR/$t.owner")" ]; then
+    # Only the tag is stale. Deleting .orig here would make the NEXT
+    # remember_original capture an already-painted wash as the "original",
+    # which is unrecoverable without hand-editing state.
+    rm -f "$STATE_DIR/$t.brand" "$STATE_DIR/$t.owner"
+    return 1
+  fi
+  cat "$STATE_DIR/$t.brand"
+}
+
+# tty of the tab you are actually looking at, empty if Terminal is not front.
+focused_tty() {
+  osa <<'EOS'
+tell application "Terminal"
+	if not frontmost then return ""
+	if (count of windows) is 0 then return ""
+	try
+		return tty of (selected tab of window 1)
+	on error
+		return ""
+	end try
+end tell
+EOS
+}
+
+read_bg() {
+  osa - "$1" <<'EOS'
+on run argv
+	tell application "Terminal"
+		repeat with w in windows
+			repeat with t in tabs of w
+				if tty of t is (item 1 of argv) then
+					set c to background color of t
+					return ((item 1 of c) as string) & " " & ((item 2 of c) as string) & " " & ((item 3 of c) as string)
+				end if
+			end repeat
+		end repeat
+	end tell
+	return ""
+end run
+EOS
+}
+
+write_bg() {
+  osa - "$1" "$2" "$3" "$4" <<'EOS'
+on run argv
+	tell application "Terminal"
+		repeat with w in windows
+			repeat with t in tabs of w
+				if tty of t is (item 1 of argv) then
+					set background color of t to {(item 2 of argv) as integer, (item 3 of argv) as integer, (item 4 of argv) as integer}
+					return "ok"
+				end if
+			end repeat
+		end repeat
+	end tell
+	return ""
+end run
+EOS
+}
+
+# Record the window's true background once, so we can always get back to it.
+remember_original() {
+  local t="$1" orig
+  [ -f "$STATE_DIR/$t.orig" ] && return 0
+  orig=$(read_bg "/dev/$t")
+  [ -z "$orig" ] && return 1
+  printf '%s\n' "$orig" >"$STATE_DIR/$t.orig"
+}
+
+idle_enabled() { [ -f "$IDLE_FLAG" ]; }
+
+# Drop a window back to rest: its idle brand wash if it is tagged and idle tint
+# is on, otherwise the background it had before we ever touched it.
+rest_window() {
+  local t="$1" row hex color
+  row=$(assignment "$t") || row=""
+  if [ -n "$row" ] && idle_enabled; then
+    hex=$(printf '%s' "$row" | cut -f1)
+    color=$(scale16 "$hex" "$IDLE_PCT")
+  else
+    color=$(cat "$STATE_DIR/$t.orig" 2>/dev/null)
+  fi
+  [ -n "$color" ] && write_bg "/dev/$t" $color >/dev/null
+  rm -f "$STATE_DIR/$t.unread"
+}
+
+purge_dead() {
+  shopt -s nullglob
+  local f b
+  for f in "$STATE_DIR"/ttys*.orig; do
+    b=$(basename "$f" .orig)
+    tty_alive "$b" || rm -f "$STATE_DIR/$b".*
+  done
+}
+
+start_watcher() {
+  if [ ! -d "$LOCK_DIR" ] || ! kill -0 "$(cat "$LOCK_DIR/pid" 2>/dev/null)" 2>/dev/null; then
+    nohup "$0" watch >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+  fi
+}
+
+all_ttys() {
+  osa <<'EOS'
+tell application "Terminal"
+	set out to ""
+	repeat with w in windows
+		repeat with t in tabs of w
+			set out to out & (tty of t) & linefeed
+		end repeat
+	end repeat
+	return out
+end tell
+EOS
+}
+
+# ------------------------------------------------------------------ modes ---
+
+case "${1:-set}" in
+
+  set) # Stop hook
+    t=$(session_tty) || exit 0
+    remember_original "$t" || exit 0 # not a Terminal.app tab
+
+    # Already looking at it, so nothing was missed. Do not light it up.
+    if [ "$(focused_tty)" = "/dev/$t" ]; then rest_window "$t"; exit 0; fi
+
+    row=$(assignment "$t") || row=""
+    hex=$(printf '%s' "$row" | cut -f1)
+    [ -z "$hex" ] && hex="$DEFAULT_HEX"
+
+    touch "$STATE_DIR/$t.unread"
+    write_bg "/dev/$t" $(scale16 "$hex" "$ATTN_PCT") >/dev/null
+    start_watcher
+    ;;
+
+  clear | rest) # UserPromptSubmit / SessionStart hooks
+    t=$(session_tty) || exit 0
+    remember_original "$t" || exit 0
+    rest_window "$t"
+    ;;
+
+  watch)
+    # Single instance. mkdir is atomic, so two Stop hooks racing cannot both win.
+    # The loser re-reads the pid once before treating an empty pid file as a dead
+    # lock, because there is a real gap between the winner's mkdir and its write.
+    if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+      p=$(cat "$LOCK_DIR/pid" 2>/dev/null)
+      [ -z "$p" ] && { sleep 1; p=$(cat "$LOCK_DIR/pid" 2>/dev/null); }
+      [ -n "$p" ] && kill -0 "$p" 2>/dev/null && exit 0
+      rm -rf "$LOCK_DIR"; mkdir "$LOCK_DIR" 2>/dev/null || exit 0
+    fi
+    printf '%s\n' "$$" >"$LOCK_DIR/pid"
+    # Release only a lock we still own, so a watcher that lost the race and is
+    # exiting cannot delete the lock its replacement already took.
+    trap '[ "$(cat "$LOCK_DIR/pid" 2>/dev/null)" = "$$" ] && rm -rf "$LOCK_DIR"' EXIT INT TERM
+
+    deadline=$(($(date +%s) + MAX_WATCH_SECONDS))
+    iter=0; nlast=0
+    shopt -s nullglob
+    while :; do
+      unread=("$STATE_DIR"/ttys*.unread)
+      [ ${#unread[@]} -eq 0 ] && break
+
+      # Poll at 1Hz for the first ~12s after anything lights up, which is the
+      # window that matters for "drops back the moment you focus it", then back
+      # off to 3s. Reaping dead ttys is not urgent, so it rides the slow path.
+      [ ${#unread[@]} -gt "$nlast" ] && iter=0
+      nlast=${#unread[@]}
+      if [ $((iter % 10)) -eq 0 ]; then
+        for f in "${unread[@]}"; do
+          b=${f##*/}; b=${b%.unread}
+          tty_alive "$b" || rm -f "$STATE_DIR/$b".*
+        done
+      fi
+
+      ft=$(focused_tty)
+      [ -n "$ft" ] && [ -f "$STATE_DIR/${ft#/dev/}.unread" ] && rest_window "${ft#/dev/}"
+
+      if [ "$(date +%s)" -ge "$deadline" ]; then
+        for f in "$STATE_DIR"/ttys*.unread; do b=${f##*/}; rest_window "${b%.unread}"; done
+        break
+      fi
+      iter=$((iter + 1))
+      if [ "$iter" -lt 12 ]; then sleep "$POLL_SECONDS"; else sleep 3; fi
+    done
+    ;;
+
+  # --------------------------------------------------------- tabcolor CLI ---
+  tab)
+    sub="${2:-}"
+    t=$(session_tty) || { echo "not running inside a Terminal.app window"; exit 1; }
+
+    case "$sub" in
+      "" | show)
+        row=$(assignment "$t") || row=""
+        if [ -n "$row" ]; then
+          echo "$t is tagged: $(printf '%s' "$row" | cut -f3)  ($(printf '%s' "$row" | cut -f1))"
+        else
+          echo "$t is untagged"
+        fi
+        idle_enabled && echo "resting tint: ON (${IDLE_PCT}%)" || echo "resting tint: OFF"
+        echo
+        echo "tag it with:  tabcolor <name>"
+        "$0" tab list
+        ;;
+
+      list)
+        echo "available:"
+        awk -F'\t' '$1 ~ /^#[0-9A-Fa-f]{6}$/ { printf "  %-2s %-14s %-22s %s\n", $4, $2, $3, $1 }' "$BRANDS_FILE"
+        ;;
+
+      off | none | clear)
+        remember_original "$t" || true
+        rm -f "$STATE_DIR/$t.brand" "$STATE_DIR/$t.owner"
+        rest_window "$t"
+        echo "$t untagged, back to its original background"
+        ;;
+
+      sync)
+        purge_dead
+        printf '%s\n' "$(all_ttys)" | while read -r dev; do
+          [ -z "$dev" ] && continue
+          b="${dev#/dev/}"
+          remember_original "$b" || continue
+          rest_window "$b"
+          r=$(assignment "$b") || r=""
+          printf '  %-9s %s\n' "$b" "${r:+$(printf '%s' "$r" | cut -f3)}"
+        done
+        ;;
+
+      idle)
+        case "${3:-}" in
+          on)  touch "$IDLE_FLAG"; echo "resting brand tint ON";  "$0" tab sync ;;
+          off) rm -f "$IDLE_FLAG"; echo "resting brand tint OFF"; "$0" tab sync ;;
+          *)   idle_enabled && echo "resting brand tint is ON" || echo "resting brand tint is OFF" ;;
+        esac
+        ;;
+
+      status)
+        echo "brands file : $BRANDS_FILE"
+        echo "this tty    : $t"
+        echo "focused     : $(focused_tty)"
+        idle_enabled && echo "resting tint: ON" || echo "resting tint: OFF"
+        if [ -d "$LOCK_DIR" ]; then echo "watcher     : pid $(cat "$LOCK_DIR/pid" 2>/dev/null)"; else echo "watcher     : not running"; fi
+        echo "tagged windows:"
+        shopt -s nullglob
+        for f in "$STATE_DIR"/ttys*.brand; do
+          b=$(basename "$f" .brand)
+          u=""; [ -f "$STATE_DIR/$b.unread" ] && u="  <- UNREAD"
+          printf '  %-9s %-22s orig=%s%s\n' "$b" "$(cut -f3 <"$f")" "$(cat "$STATE_DIR/$b.orig" 2>/dev/null)" "$u"
+        done
+        ;;
+
+      *)
+        row=$(lookup_brand "$sub")
+        if [ -z "$row" ]; then
+          echo "no color named '$sub'"; echo; "$0" tab list; exit 1
+        fi
+        remember_original "$t" || { echo "not a Terminal.app tab"; exit 1; }
+        printf '%s\n' "$row" >"$STATE_DIR/$t.brand"
+        tty_owner "$t" >"$STATE_DIR/$t.owner"
+        rest_window "$t"
+        idle_enabled || echo "note: resting tint is OFF, so this window stays black until a response lands"
+        echo "$t tagged $(printf '%s' "$row" | cut -f3)  ($(printf '%s' "$row" | cut -f1))"
+        # Terminal.app cannot color the tab chrome, so the only way to get a
+        # colored marker into the tab bar is an emoji in the title. Claude Code
+        # owns the title, so hand back a ready /rename line instead of fighting
+        # it, and put it on the clipboard so it is one paste, not an emoji hunt.
+        emo=$(printf '%s' "$row" | cut -f4)
+        if [ -n "$emo" ]; then
+          rn="/rename $emo $(printf '%s' "$row" | cut -f3)"
+          if printf '%s' "$rn" | pbcopy 2>/dev/null; then
+            echo "clipboard (paste into the input box):  $rn"
+          else
+            echo "for the tab bar, paste:  $rn"
+          fi
+        fi
+        ;;
+    esac
+    ;;
+
+  *)
+    echo "usage: $0 {set|clear|rest|watch|tab [...]}" >&2
+    exit 2
+    ;;
+esac

--- a/plugins/claude-session-tint/tabtint.sh
+++ b/plugins/claude-session-tint/tabtint.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
-# tabtint.sh  (drive it with the `tabcolor` command)
+# tabtint.sh  (drive it with the `tabtint` command)
 #
 # Purely cosmetic Terminal.app window coloring:
-#   1. You tag a window with a brand once      ->  tabcolor aianyone
-#   2. It wears that brand quietly at rest     ->  10% wash
-#   3. It lights up when a response lands      ->  34% wash
+#   1. You tag a window with a project once    ->  tabtint api
+#   2. It wears that color quietly at rest     ->  22% wash
+#   3. It lights up when a response lands      ->  48% wash
 #   4. It drops back the moment you focus it
 #
 # Terminal.app cannot color a TAB. Verified by enumerating every property on the
@@ -13,9 +13,13 @@
 # per-tab color is an iTerm2 / kitty / Ghostty capability.
 #
 # So this paints the window BODY, which is what shows in Mission Control and
-# cmd-tab. The tab bar stays grey. The only thing that reaches the tab bar is
-# the title text, which Claude Code owns; put an emoji in /rename if you want
-# color there.
+# cmd-tab. That works when a window holds ONE tab.
+#
+# In a MULTI-TAB window Terminal draws only the selected tab's body, so painting
+# a background tab is invisible exactly when you need it, and selecting the tab
+# clears it before you see it. There the signal moves to the one thing that does
+# reach the tab bar: a dot in front of the tab TITLE, stripped again the moment
+# you look. See the marker section below.
 #
 # Colors live in ~/.claude/tabtint-palette.conf. Nothing here inspects your work,
 # your files, or your transcripts. A window is whatever you said it was.
@@ -27,8 +31,9 @@
 #   watch  internal shared watcher
 #
 # Tuning:
-#   TABTINT_ATTN_PCT  brightness when unread  (default 34)
-#   TABTINT_IDLE_PCT  brightness at rest      (default 10)
+#   TABTINT_ATTN_PCT  brightness when unread  (default 48)
+#   TABTINT_IDLE_PCT  brightness at rest      (default 22)
+#   TABTINT_MARK      tab-bar marker glyph    (default ●)
 
 set -uo pipefail
 
@@ -175,6 +180,109 @@ end run
 EOS
 }
 
+# ------------------------------------------ tab-bar marker (shared windows) ---
+# Terminal draws only the SELECTED tab's body, so painting a background tab is
+# invisible exactly when it matters, and the watcher clears it the instant you
+# select it. For tabs that share a window the signal moves to the one thing that
+# reaches the tab bar: a dot in front of the title.
+#
+# U+2060 WORD JOINER is a zero-width sentinel. It renders as nothing and nothing
+# else in a terminal title emits it, so we can find our own marker without ever
+# storing the title. We STRIP, never restore: Claude Code owns the title and
+# rewrites it, so a saved copy would be stale on arrival and would clobber a
+# user's own /rename.
+WJ=$(printf '\xe2\x81\xa0')
+MARK="${TABTINT_MARK:-●}"
+
+# One Apple Event answering everything the Stop hook needs:
+#   ntabs <TAB> selected <TAB> focused <TAB> title
+#
+# `tab` inside a "tell application \"Terminal\"" block resolves to Terminal's tab
+# CLASS, not the tab character, and stringifies to the literal text "tab". Bind
+# the real character outside the tell block. Verified with od -c.
+tab_ctx() {
+  osa - "$1" <<'EOS'
+on run argv
+	set TB to tab
+	tell application "Terminal"
+		set fm to frontmost
+		repeat with i from 1 to (count of windows)
+			set w to item i of windows
+			set n to (count of tabs of w)
+			repeat with t in tabs of w
+				if tty of t is (item 1 of argv) then
+					set ttl to ""
+					try
+						set ttl to custom title of t
+					end try
+					return (n as string) & TB & ((selected of t) as string) & TB & ((fm and i is 1 and (selected of t)) as string) & TB & ttl
+				end if
+			end repeat
+		end repeat
+	end tell
+	return ""
+end run
+EOS
+}
+
+write_title() {
+  osa - "$1" "$2" <<'EOS'
+on run argv
+	tell application "Terminal"
+		repeat with w in windows
+			repeat with t in tabs of w
+				if tty of t is (item 1 of argv) then
+					set custom title of t to (item 2 of argv)
+					return "ok"
+				end if
+			end repeat
+		end repeat
+	end tell
+	return ""
+end run
+EOS
+}
+
+# Everything through the last sentinel goes. A no-op when the sentinel is absent,
+# so this can never eat a title we did not write, and it collapses a doubled
+# marker instead of nesting it.
+strip_mark() { printf '%s' "${1##*"$WJ" }"; }
+
+# Mark a background tab in a shared window. Takes the already-parsed context so
+# the single-tab path costs no extra Apple Event. Returns 0 only when it marked,
+# which is how the caller knows to skip the (invisible) paint.
+mark_set() {
+  local t="$1" n="$2" sel="$3" ttl="$4" stripped
+  case $n in ''|*[!0-9]*) return 1 ;; esac
+  [ "$n" -le 1 ] && return 1
+  [ "$sel" = "true" ] && return 1
+  # Flag BEFORE the title. A flag with no marker costs one wasted read; a marker
+  # with no flag is invisible to every cleanup path and strands the dot.
+  : >"$STATE_DIR/$t.mark" || return 1
+  stripped=$(strip_mark "$ttl")
+  write_title "/dev/$t" "$MARK$WJ $stripped" >/dev/null
+}
+
+# Strip only, never restore. Returns non-zero without dropping the flag when
+# Terminal did not answer, so the next hook retries instead of leaving the dot
+# stranded with nothing left that knows to remove it.
+mark_clear() {
+  local t="$1" ctx n sel foc ttl stripped
+  [ -f "$STATE_DIR/$t.mark" ] || [ "${2:-}" = "force" ] || return 0
+  ctx=$(tab_ctx "/dev/$t")
+  [ -z "$ctx" ] && return 1
+  IFS=$'\t' read -r n sel foc ttl <<<"$ctx"
+  case $ttl in
+    *"$WJ"*)
+      stripped=$(strip_mark "$ttl")
+      # Never blank a tab's name. If the title was nothing but our marker, leave
+      # it rather than writing an empty custom title.
+      [ -n "$stripped" ] && write_title "/dev/$t" "$stripped" >/dev/null
+      ;;
+  esac
+  rm -f "$STATE_DIR/$t.mark"
+}
+
 # Record the window's true background once, so we can always get back to it.
 remember_original() {
   local t="$1" orig
@@ -198,6 +306,7 @@ rest_window() {
     color=$(cat "$STATE_DIR/$t.orig" 2>/dev/null)
   fi
   [ -n "$color" ] && write_bg "/dev/$t" $color >/dev/null
+  mark_clear "$t"
   rm -f "$STATE_DIR/$t.unread"
 }
 
@@ -239,15 +348,24 @@ case "${1:-set}" in
     t=$(session_tty) || exit 0
     remember_original "$t" || exit 0 # not a Terminal.app tab
 
+    # One Apple Event answers both questions the Stop hook has: is the user
+    # looking at this tab, and does it share a window. Replaces the separate
+    # focused_tty call so the single-tab path costs no more than it did before.
+    ctx=$(tab_ctx "/dev/$t")
+    IFS=$'\t' read -r ntabs seltab foctab ttl <<<"$ctx"
+
     # Already looking at it, so nothing was missed. Do not light it up.
-    if [ "$(focused_tty)" = "/dev/$t" ]; then rest_window "$t"; exit 0; fi
+    if [ "$foctab" = "true" ]; then rest_window "$t"; exit 0; fi
 
     row=$(assignment "$t") || row=""
     hex=$(printf '%s' "$row" | cut -f1)
     [ -z "$hex" ] && hex="$DEFAULT_HEX"
 
     touch "$STATE_DIR/$t.unread"
-    write_bg "/dev/$t" $(scale16 "$hex" "$ATTN_PCT") >/dev/null
+    # In a shared window the wash is invisible while it matters and would flash
+    # at you a beat after you click the tab, so mark the tab bar instead of it.
+    mark_set "$t" "$ntabs" "$seltab" "$ttl" \
+      || write_bg "/dev/$t" $(scale16 "$hex" "$ATTN_PCT") >/dev/null
     start_watcher
     ;;
 
@@ -290,6 +408,20 @@ case "${1:-set}" in
           tty_alive "$b" || rm -f "$STATE_DIR/$b".*
         done
       fi
+
+      # Claude Code may rewrite the title just after Stop and wipe the marker.
+      # Re-assert; strip-then-prepend makes it idempotent. Flag-gated, so an
+      # unmarked (single-tab) unread costs nothing here.
+      for f in "${unread[@]}"; do
+        b=${f##*/}; b=${b%.unread}
+        if [ -f "$STATE_DIR/$b.mark" ]; then
+          mctx=$(tab_ctx "/dev/$b")
+          if [ -n "$mctx" ]; then
+            IFS=$'\t' read -r mn ms mf mt <<<"$mctx"
+            mark_set "$b" "$mn" "$ms" "$mt"
+          fi
+        fi
+      done
 
       ft=$(focused_tty)
       [ -n "$ft" ] && [ -f "$STATE_DIR/${ft#/dev/}.unread" ] && rest_window "${ft#/dev/}"
@@ -340,6 +472,7 @@ case "${1:-set}" in
           [ -z "$dev" ] && continue
           b="${dev#/dev/}"
           remember_original "$b" || continue
+          mark_clear "$b" force
           rest_window "$b"
           r=$(assignment "$b") || r=""
           printf '  %-9s %s\n' "$b" "${r:+$(printf '%s' "$r" | cut -f3)}"
@@ -365,6 +498,7 @@ case "${1:-set}" in
         for f in "$STATE_DIR"/ttys*.brand; do
           b=$(basename "$f" .brand)
           u=""; [ -f "$STATE_DIR/$b.unread" ] && u="  <- UNREAD"
+          [ -f "$STATE_DIR/$b.mark" ] && u="$u (tab-bar $MARK)"
           printf '  %-9s %-22s orig=%s%s\n' "$b" "$(cut -f3 <"$f")" "$(cat "$STATE_DIR/$b.orig" 2>/dev/null)" "$u"
         done
         ;;

--- a/plugins/claude-session-tint/tabtint.sh
+++ b/plugins/claude-session-tint/tabtint.sh
@@ -206,16 +206,16 @@ on run argv
 	set TB to tab
 	tell application "Terminal"
 		set fm to frontmost
-		repeat with i from 1 to (count of windows)
-			set w to item i of windows
-			set n to (count of tabs of w)
+		set i to 0
+		repeat with w in windows
+			set i to i + 1
 			repeat with t in tabs of w
 				if tty of t is (item 1 of argv) then
 					set ttl to ""
 					try
 						set ttl to custom title of t
 					end try
-					return (n as string) & TB & ((selected of t) as string) & TB & ((fm and i is 1 and (selected of t)) as string) & TB & ttl
+					return ((count of tabs of w) as string) & TB & ((selected of t) as string) & TB & ((fm and i is 1 and (selected of t)) as string) & TB & ttl
 				end if
 			end repeat
 		end repeat
@@ -256,10 +256,14 @@ mark_set() {
   case $n in ''|*[!0-9]*) return 1 ;; esac
   [ "$n" -le 1 ] && return 1
   [ "$sel" = "true" ] && return 1
+  # Nothing to prepend to. A lone marker would BE the whole title, and
+  # mark_clear refuses to blank a tab's name, so that dot would strand with no
+  # way back. Decline and let the caller paint instead.
+  stripped=$(strip_mark "$ttl")
+  [ -z "$stripped" ] && return 1
   # Flag BEFORE the title. A flag with no marker costs one wasted read; a marker
   # with no flag is invisible to every cleanup path and strands the dot.
   : >"$STATE_DIR/$t.mark" || return 1
-  stripped=$(strip_mark "$ttl")
   write_title "/dev/$t" "$MARK$WJ $stripped" >/dev/null
 }
 
@@ -306,8 +310,9 @@ rest_window() {
     color=$(cat "$STATE_DIR/$t.orig" 2>/dev/null)
   fi
   [ -n "$color" ] && write_bg "/dev/$t" $color >/dev/null
-  mark_clear "$t"
-  rm -f "$STATE_DIR/$t.unread"
+  # Keep .unread when the marker could not be removed, so the watcher stays
+  # alive and retries instead of exiting with the dot still on the tab.
+  if mark_clear "$t"; then rm -f "$STATE_DIR/$t.unread"; fi
 }
 
 purge_dead() {
@@ -349,8 +354,10 @@ case "${1:-set}" in
     remember_original "$t" || exit 0 # not a Terminal.app tab
 
     # One Apple Event answers both questions the Stop hook has: is the user
-    # looking at this tab, and does it share a window. Replaces the separate
-    # focused_tty call so the single-tab path costs no more than it did before.
+    # looking at this tab, and does it share a window. It replaces focused_tty,
+    # which could bail on "not frontmost" without touching a window, so this
+    # walk costs roughly 400ms against that call's 80ms even on a one-tab
+    # window. One event instead of two, but not free.
     ctx=$(tab_ctx "/dev/$t")
     IFS=$'\t' read -r ntabs seltab foctab ttl <<<"$ctx"
 


### PR DESCRIPTION
Adds `claude-session-tint` under Workflow Orchestration.

**What it does.** Tag a terminal window with a project. It wears that project's color quietly while it works, brightens when a Claude Code response finishes while you are looking at a different window, and drops back the moment you focus it. Built for running many sessions in parallel and not knowing which one is waiting on you.

**The part that may be most useful to this list:** typing `,api` into the Claude Code input box runs a command with no model turn. No tokens, no assistant message in the transcript. It is a `UserPromptSubmit` hook returning `decision:"block"` with `hookSpecificOutput.suppressOriginalPrompt`, so Claude Code never queries the model. That pattern is terminal- and OS-independent and is reusable for any in-session command.

Two non-obvious details, documented in the source:
- the hook must be wired non-async, since an async hook returns after the prompt already reached the model and cannot gate it
- it exits 2 as well as printing the JSON, because an earlier success branch can return before the blocking decision is applied

**Honest scope.** The window coloring is macOS Terminal.app only, because Terminal.app is the one terminal with no native tab colors, which is the reason it exists. On iTerm2, Ghostty or kitty you already have tab colors; the hook is still useful on its own. It no-ops rather than erroring elsewhere.

**Notes for review**
- This looks like the first hooks-based entry in the list. Everything I checked ships commands or agents, so please tell me if hooks belong somewhere other than `hooks/hooks.json` here.
- Category is a guess. Workflow Orchestration was the closest fit for parallel-session management, but the existing entries there are mostly agent personas. Happy to move it.
- Vendored to match the repo's model (all 118 existing entries use `./plugins/<name>`, none use an external source). Upstream is https://github.com/dotcomjack/claude-session-tint if you would rather link out.
- `marketplace.json` diff is 17 insertions and 0 deletions; I preserved the file's original lack of a trailing newline so the diff stays minimal.

MIT licensed.