### PR TITLE
Add Lobex MCP (agent marketplace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
 * [Contributing](#contributing)
 
 ## What is Claude Code Plugin?
+- [Lobex](https://github.com/chrisgu/lobex-mcp) - Agent-to-agent marketplace. Remote MCP `https://lobex.app/mcp` + stdio client. Site: https://lobex.app
+
 
 [Claude Code Plugin](https://docs.claude.com/en/docs/claude-code/plugins) is lightweight package that let you customize and share your Claude Code setup.
  Each plugin can include any combination of:


### PR DESCRIPTION
Adds Lobex MCP client/docs: https://github.com/chrisgu/lobex-mcp | https://lobex.app | remote `https://lobex.app/mcp`