### PR TITLE
Add session-tax plugin (Data Analytics)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1670,6 +1670,24 @@
         "security",
         "compliance"
       ]
+    },
+    {
+      "name": "session-tax",
+      "source": "./plugins/session-tax",
+      "description": "Measure what your Claude Code setup costs on every session before you type anything - opening context, what loads, and how much of it never gets used.",
+      "version": "1.0.0",
+      "author": {
+        "name": "CraniusMaximus LLC",
+        "url": "https://github.com/craniusmaximusllc"
+      },
+      "category": "Data Analytics",
+      "homepage": "https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/session-tax",
+      "keywords": [
+        "context",
+        "cost",
+        "tokens",
+        "audit"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -104,6 +104,7 @@
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
+- [session-tax](./plugins/session-tax)
 - [trend-researcher](./plugins/trend-researcher)
 
 ### 用户体验设计

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [data-scientist](./plugins/data-scientist)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
+- [session-tax](./plugins/session-tax)
 - [trend-researcher](./plugins/trend-researcher)
 
 ### Design UX

--- a/plugins/session-tax/.claude-plugin/plugin.json
+++ b/plugins/session-tax/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "session-tax",
+  "version": "1.0.0",
+  "description": "Measure what your Claude Code setup costs on every session before you type anything - opening context, what loads, and how much of it never gets used.",
+  "author": { "name": "CraniusMaximus LLC", "email": "okachulasyii@gmail.com" },
+  "homepage": "https://operator-shop.pages.dev",
+  "license": "MIT",
+  "keywords": ["context", "cost", "tokens", "audit", "performance"]
+}

--- a/plugins/session-tax/LICENSE
+++ b/plugins/session-tax/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 CraniusMaximus LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/session-tax/README.md
+++ b/plugins/session-tax/README.md
@@ -1,0 +1,102 @@
+# session-tax
+
+**Your Claude Code sessions start tens of thousands of tokens deep before you type
+anything. This tells you what's in there and how much of it never gets used.**
+
+I ran this against my own setup expecting a tidy number. My median session opens at 51,667
+tokens. That's before I say anything — before the first word of the actual work.
+
+Nobody remembers what they installed. You added a skill in March, connected a server in
+April, wired four hooks over a weekend that felt productive. All of it still loads on every
+session whether it earns its place or not, and nothing in a normal session ever says *"this
+one has fired zero times."*
+
+## Install
+
+```
+/plugin marketplace add craniusmaximusllc/session-tax-plugin
+/plugin install session-tax@craniusmaximusllc
+```
+
+Then run `/session-tax` in any session.
+
+Or just run it directly, without installing anything:
+
+```
+node scripts/session-tax-free.mjs --days 90
+```
+
+## What you get
+
+```
+THE BILL
+--------
+  Every session opens at 51,667 tokens before you type anything.
+  The worst tenth open at 71,911.
+  Over a year at your pace that is 1,333,607,076 tokens, about $3236.52.
+
+INSTALLED vs ACTUALLY USED
+--------------------------
+  skills             19 installed     10 fire from the work
+                      9 wired to an event, so zero calls is correct
+  skill calls       112 total
+  servers             4 connected
+  hooks              26 wired
+```
+
+Plus a ranked breakdown of what loads on every session — skill listings, hook output, tool
+schemas, agent listings — each with its own token cost, so you know which one to go after
+first.
+
+## About the money figure
+
+It's a rough guide and it says so on screen. Most of your opening context is cache reads
+and cache writes, which bill at very different rates from fresh input, so the estimate uses
+the split it finds in your own transcripts rather than pricing everything at the list rate.
+Doing it the lazy way overstates the bill by roughly ten times.
+
+If you're on a subscription the dollars are beside the point anyway. You're paying in room
+to think, and that's the more expensive currency — a session that opens half full reasons
+worse the whole way through.
+
+## Skills that never fire
+
+The one finding people don't expect. A skill you have to *remember* is a skill that doesn't
+run. Skills that fire from the work, and skills wired to an event, both earn their place —
+the ones that wait on you are the dead weight, and they cost tokens on every session
+regardless.
+
+The free edition tells you how many you have and what they cost. The paid edition names
+them and tells you what to do with each one.
+
+## What it reads, and what it sends
+
+It reads your session transcripts and config files from your own disk. It sends nothing
+anywhere — there's no network call in it, and you can confirm that in about a minute:
+
+```
+grep -E "fetch|http|net|child_process" scripts/session-tax-free.mjs
+```
+
+You'll get three lines back, all of them imports of `fs`, `path` and `os`.
+
+It tells you what to delete. It never deletes anything for you.
+
+## The paid edition — $19
+
+Same measurements, plus the part that turns a report into a change:
+
+- Names every dead skill, cold server and redundant hook, with the specific action for each
+- Flags connected servers whose tool schemas load on every session but are never called
+- Machine-readable output, and auditing a profile other than your own
+- A quiet monthly check, so it happens without you remembering to run it
+
+[operator-shop.pages.dev](https://operator-shop.pages.dev) — one seat per developer.
+
+## Requirements
+
+Node 18 or newer. No dependencies.
+
+## License
+
+MIT. Use it, fork it, take it apart.

--- a/plugins/session-tax/commands/session-tax.md
+++ b/plugins/session-tax/commands/session-tax.md
@@ -1,0 +1,21 @@
+---
+description: Measure what your Claude Code setup costs before any work starts - opening context, what loads every session, and what never gets used.
+---
+
+Run the session-tax audit and explain the result to the operator.
+
+```
+node "${CLAUDE_PLUGIN_ROOT}/scripts/session-tax-free.mjs" --days 90
+```
+
+Then talk them through it, in this order:
+
+1. **Lead with the tax in plain terms.** "Every session starts N tokens deep before you've
+   said anything" lands harder than any percentage.
+2. **Say whether it's worth acting on.** A big opening context is only a problem if it isn't
+   earning its place. Cheap and stable beats clever and fragile - say so when that's the case.
+3. **Name one change, not a programme.** The single highest-value thing to cut. A list of
+   twelve gets deferred; one gets done.
+4. **Offer to make the change.** Pruning is reversible and low risk. Don't hand back homework.
+
+Do not pad the output or repeat the table back at them - they can already see it.

--- a/plugins/session-tax/scripts/session-tax-free.mjs
+++ b/plugins/session-tax/scripts/session-tax-free.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * session-tax (free edition) — what your Claude Code setup costs you before
+ * you type anything.
+ *
+ * Reads your own session transcripts off your own disk. No network calls, no
+ * account, nothing sent anywhere. Check the source: it imports fs, path and os
+ * and that is the whole list.
+ *
+ * The free edition measures and totals. The paid edition names the specific
+ * skills, servers and hooks that never fire and tells you what to do about
+ * each one: https://operator-shop.pages.dev
+ *
+ * Usage: node session-tax-free.mjs [--days 90] [--rate 3]
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const argv = process.argv.slice(2);
+const flag = (n, d) => { const i = argv.indexOf('--' + n); return i === -1 ? d : argv[i + 1]; };
+
+const HOME = os.homedir();
+const C = path.join(HOME, '.claude');
+const DAYS = Number(flag('days', 90)) || 90;
+const RATE = Number(flag('rate', 3)) || 3;
+const TOK = (s) => Math.round(s.length / 3.7);
+
+// ---------------------------------------------------------------- installed
+function findSkills(root) {
+  const out = [];
+  const rec = (d) => {
+    let e = []; try { e = fs.readdirSync(d, { withFileTypes: true }); } catch { return; }
+    for (const f of e) {
+      if (f.name === 'node_modules' || f.name === '_retired') continue;
+      const p = path.join(d, f.name);
+      if (f.isDirectory()) { rec(p); continue; }
+      if (f.name !== 'SKILL.md') continue;
+      let raw = ''; try { raw = fs.readFileSync(p, 'utf8'); } catch { continue; }
+      const m = raw.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+      if (!m) continue;
+      const name = ((m[1].match(/^name:\s*(.+)$/m) || [])[1] || path.basename(d)).trim();
+      const desc = ((m[1].match(/^description:\s*([\s\S]*?)(?=\n[a-z_-]+:|$)/m) || [])[1] || '')
+        .trim().replace(/\s+/g, ' ');
+      const firedBy = (raw.match(/^\s*fired-by:\s*(.+)$/m) || [])[1] || null;
+      let age = 999;
+      try {
+        const st = fs.statSync(p);
+        age = (Date.now() - Math.min(st.birthtimeMs || Infinity, st.mtimeMs)) / 864e5;
+      } catch { /* treat as old */ }
+      out.push({ name, tok: TOK(name + desc) + 12, firedBy, age });
+    }
+  };
+  rec(root);
+  return out;
+}
+
+const skills = findSkills(path.join(C, 'skills'));
+let settings = {}; try { settings = JSON.parse(fs.readFileSync(path.join(C, 'settings.json'), 'utf8')); } catch { }
+const totalHooks = Object.values(settings.hooks || {})
+  .reduce((s, gs) => s + gs.reduce((n, g) => n + (g.hooks || []).length, 0), 0);
+const agentsDir = path.join(C, 'agents');
+const agents = fs.existsSync(agentsDir) ? fs.readdirSync(agentsDir).filter((f) => f.endsWith('.md')).length : 0;
+let servers = 0;
+try { servers = Object.keys(JSON.parse(fs.readFileSync(path.join(HOME, '.claude.json'), 'utf8')).mcpServers || {}).length; } catch { }
+
+// ---------------------------------------------------------------- used
+const cutoff = Date.now() - DAYS * 864e5;
+const skillUse = {}, injections = {};
+const startCtx = [];
+const mix = { inp: 0, cr: 0, cc: 0 };
+let sessions = 0, injSessions = 0;
+
+let dirs = []; try { dirs = fs.readdirSync(path.join(C, 'projects')); } catch { }
+for (const d of dirs) {
+  const dp = path.join(C, 'projects', d);
+  let files = []; try { files = fs.readdirSync(dp).filter((f) => f.endsWith('.jsonl')); } catch { continue; }
+  for (const f of files) {
+    const fp = path.join(dp, f);
+    let st; try { st = fs.statSync(fp); } catch { continue; }
+    if (st.mtimeMs < cutoff) continue;
+    sessions++;
+    let txt; try { txt = fs.readFileSync(fp, 'utf8'); } catch { continue; }
+    const lines = txt.split('\n');
+    let gotCtx = false, sawInj = false;
+    for (let i = 0; i < lines.length; i++) {
+      const ln = lines[i];
+      if (!ln) continue;
+      if (!(ln.includes('"tool_use"') || (!gotCtx && ln.includes('"usage"')) ||
+            (i < 40 && ln.includes('"attachment"')))) continue;
+      let o; try { o = JSON.parse(ln); } catch { continue; }
+      if (i < 40 && o.type === 'attachment') {
+        const a = o.attachment || o;
+        const key = (a.type || 'unknown') + (a.source ? ':' + a.source : '');
+        (injections[key] = injections[key] || { tok: 0 }).tok += TOK(JSON.stringify(a));
+        sawInj = true;
+      }
+      if (!gotCtx && o.type === 'assistant' && o.message?.usage) {
+        const u = o.message.usage;
+        const inp = u.input_tokens || 0, cr = u.cache_read_input_tokens || 0, cc = u.cache_creation_input_tokens || 0;
+        if (inp + cr + cc > 1000) { startCtx.push(inp + cr + cc); mix.inp += inp; mix.cr += cr; mix.cc += cc; gotCtx = true; }
+      }
+      const content = o.message?.content;
+      if (!Array.isArray(content)) continue;
+      for (const b of content) {
+        if (b.type === 'tool_use' && b.name === 'Skill' && b.input?.skill)
+          skillUse[b.input.skill] = (skillUse[b.input.skill] || 0) + 1;
+      }
+    }
+    if (sawInj) injSessions++;
+  }
+}
+
+if (!sessions) {
+  console.log('\nNo sessions found to read. Looked in ' + path.join(C, 'projects') + '\n');
+  process.exit(0);
+}
+
+startCtx.sort((a, b) => a - b);
+const p = (q) => startCtx[Math.floor(startCtx.length * q)] || 0;
+
+const used = new Set();
+for (const k of Object.keys(skillUse)) { used.add(k); used.add(k.split(':').pop()); }
+const dead = skills.filter((s) => !used.has(s.name) && !s.firedBy && s.age >= 14);
+const eventWired = skills.filter((s) => s.firedBy).length;
+const wastedPerSession = dead.reduce((s, x) => s + x.tok, 0);
+
+const sessionsPerDay = sessions / DAYS;
+const openingPerYear = Math.round(p(0.5) * sessionsPerDay * 365);
+const wastedPerYear = Math.round(wastedPerSession * sessionsPerDay * 365);
+const mixTotal = mix.inp + mix.cr + mix.cc || 1;
+const blended = RATE * ((mix.inp) + (mix.cr * 0.1) + (mix.cc * 1.25)) / mixTotal;
+const money = (t) => '$' + ((t / 1e6) * blended).toFixed(2);
+const cachedShare = Math.round(100 * mix.cr / mixTotal);
+
+// ---------------------------------------------------------------- report
+const H = (s) => '\n' + s + '\n' + '-'.repeat(s.length);
+console.log(`\nsession-tax (free)  ·  ${sessions} sessions over the last ${DAYS} days`);
+
+console.log(H('THE BILL'));
+console.log(`  Every session opens at ${p(0.5).toLocaleString()} tokens before you type anything.`);
+console.log(`  The worst tenth open at ${p(0.9).toLocaleString()}.`);
+console.log(`  Over a year at your pace that is ${openingPerYear.toLocaleString()} tokens, about ${money(openingPerYear)}.`);
+console.log('');
+console.log(`  Rough guide. ${cachedShare}% of that is cache reads, which bill at a tenth of fresh`);
+console.log(`  input, so it is priced at an effective $${blended.toFixed(2)} per million rather than the`);
+console.log(`  $${RATE.toFixed(2)} list rate. On a subscription you pay it in room to think instead of cash.`);
+
+console.log(H('WHAT EVERY SESSION LOADS'));
+const inj = Object.entries(injections)
+  .map(([k, v]) => [k, Math.round(v.tok / Math.max(injSessions, 1))])
+  .filter(([, v]) => v > 20).sort((a, b) => b[1] - a[1]).slice(0, 8);
+for (const [k, v] of inj) console.log(`  ${String(v.toLocaleString()).padStart(7)} tok  ${k}`);
+
+console.log(H('INSTALLED vs ACTUALLY USED'));
+console.log(`  skills           ${String(skills.length).padStart(4)} installed   ${String(skills.length - dead.length - eventWired).padStart(4)} fire from the work`);
+if (eventWired) console.log(`                   ${String(eventWired).padStart(4)} wired to an event, so zero calls is correct`);
+console.log(`  skill calls      ${String(Object.values(skillUse).reduce((a, b) => a + b, 0)).padStart(4)} total`);
+console.log(`  custom agents    ${String(agents).padStart(4)} defined`);
+console.log(`  servers          ${String(servers).padStart(4)} connected`);
+console.log(`  hooks            ${String(totalHooks).padStart(4)} wired`);
+
+console.log(H('WHAT THE FREE EDITION FOUND'));
+if (dead.length) {
+  console.log(`  ${dead.length} of your ${skills.length} skills wait on you to remember them, and have not`);
+  console.log(`  fired once in ${DAYS} days. They cost ${wastedPerSession.toLocaleString()} tokens on every session you run —`);
+  console.log(`  about ${money(wastedPerYear)} a year, for nothing.`);
+} else {
+  console.log('  Nothing obviously dead. What you have installed roughly matches how you work.');
+}
+
+console.log(H('WHAT THE FULL VERSION ADDS'));
+console.log('  - names every dead skill, cold server and redundant hook, and what to do with each');
+console.log('  - flags connected servers whose tool schemas load on every session but are never called');
+console.log('  - machine-readable output, and auditing a profile other than your own');
+console.log('  - a quiet monthly check, so this happens without you remembering to run it');
+console.log('\n  $19, one seat:  https://operator-shop.pages.dev\n');


### PR DESCRIPTION
Adds **session-tax**, a `/session-tax` command that reports what a Claude Code session actually costs before you type anything — the opening context (CLAUDE.md files, MCP tool schemas, skills, hooks), what loaded, and how much of it never got used, with an estimated per-session dollar figure.

Following the pattern of existing entries:

- Vendored the plugin under `plugins/session-tax/` (plugin.json, the `/session-tax` command, the standalone script, LICENSE, README)
- Registered it in `.claude-plugin/marketplace.json` under Data Analytics
- Added it to the Data Analytics list in README.md and README-zh.md (alphabetical order)

Source repo: https://github.com/craniusmaximusllc/session-tax-plugin (MIT). It also works standalone via `/plugin marketplace add craniusmaximusllc/session-tax-plugin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)