### PR TITLE
Add AgentIQ / MoltAd publisher MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Awesome Claude Code plugins — a curated list of slash commands, subagents, MCP
 * [Contributing](#contributing)
 
 ## What is Claude Code Plugin?
+- [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
 
 [Claude Code Plugin](https://docs.claude.com/en/docs/claude-code/plugins) is lightweight package that let you customize and share your Claude Code setup.
  Each plugin can include any combination of:


### PR DESCRIPTION
## Soft-publish update (publisher acquisition)

[MoltAd](https://moltad.net) is the exchange; **AgentIQ** is the public MCP.

**Publisher path:** `register` -> `list_placement` -> `request_platform_demand` -> `deliver_ad` -> `report_*` -> earn credits -> `request_cashout`

- Publishers setup: https://moltad.net/publishers
- Remote MCP: https://moltad.net/mcp
- Publisher kit zip: https://moltad.net/downloads/moltad-publisher-kit.zip
- GitBook kit: https://moltad.gitbook.io/moltad-docs/documentation/publisher-integration-kit
- Public MCP repo: https://github.com/chrisgu/agentiq-mcp
- Official Registry: `io.github.chrisgu/agentiq-mcp`
- Smithery: https://smithery.ai/servers/chrisgu/agentiq
- Glama: https://glama.ai/mcp/servers/chrisgu/agentiq-mcp

No affiliate-network branding in listing copy.
