### PR TITLE
Add nuhuh plugin under Code Quality Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [debug-session](./plugins/debug-session)
 - [debugger](./plugins/debugger)
 - [double-check](./plugins/double-check)
+- [nuhuh](./plugins/nuhuh)
 - [optimize](./plugins/optimize)
 - [performance-benchmarker](./plugins/performance-benchmarker)
 - [refractor](./plugins/refractor)

--- a/plugins/nuhuh/.claude-plugin/plugin.json
+++ b/plugins/nuhuh/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuhuh",
   "description": "Your agent said Done. nuhuh runs the experiment and bounces the agent until the receipt is green.",
-  "version": "0.1.4",
+  "version": "0.1.9",
   "author": {
     "name": "sjh9714"
   },

--- a/plugins/nuhuh/.claude-plugin/plugin.json
+++ b/plugins/nuhuh/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuhuh",
   "description": "Your agent said Done. nuhuh runs the experiment and bounces the agent until the receipt is green.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": {
     "name": "sjh9714"
   },

--- a/plugins/nuhuh/.claude-plugin/plugin.json
+++ b/plugins/nuhuh/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "nuhuh",
+  "description": "Your agent said Done. nuhuh runs the experiment and bounces the agent until the receipt is green.",
+  "version": "0.1.4",
+  "author": {
+    "name": "sjh9714"
+  },
+  "homepage": "https://github.com/sjh9714/nuhuh"
+}

--- a/plugins/nuhuh/README.md
+++ b/plugins/nuhuh/README.md
@@ -1,0 +1,15 @@
+# nuhuh
+
+Your agent said "Done." nuhuh runs the experiment.
+
+This plugin installs a Stop hook. Every time the agent tries to finish, nuhuh extracts the completion claims from its final message ("all tests pass", "created src/x.ts", "endpoint works") and re-runs reality, fresh. The whole test suite in a clean process, the build, the file on disk, the local endpoint. If a claim is false, the Done is rejected and the failing evidence goes straight back to the agent, which returns to work. After 3 bounces it hands the receipt to you.
+
+Deterministic and local. No LLM calls in the verification path, no API key, nothing leaves your machine. Claims it cannot safely check are marked unverifiable, never failed.
+
+Full documentation, a False Done Rate benchmark, and the source live at [github.com/sjh9714/nuhuh](https://github.com/sjh9714/nuhuh).
+
+Try it without installing anything
+
+```bash
+npx nuhuh demo
+```

--- a/plugins/nuhuh/hooks/hooks.json
+++ b/plugins/nuhuh/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes nuhuh@latest gate",
+            "timeout": 600
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/nuhuh/hooks/hooks.json
+++ b/plugins/nuhuh/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx --yes nuhuh@0.1.9 gate",
+            "command": "npx --yes nuhuh@0.1.10 gate",
             "timeout": 600
           }
         ]

--- a/plugins/nuhuh/hooks/hooks.json
+++ b/plugins/nuhuh/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "npx --yes nuhuh@latest gate",
+            "command": "npx --yes nuhuh@0.1.9 gate",
             "timeout": 600
           }
         ]

--- a/plugins/nuhuh/plugin.json
+++ b/plugins/nuhuh/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuhuh",
   "description": "A Stop hook that verifies the agent's completion claims by re-running reality. It extracts every claim from the final message (tests pass, file created, endpoint works) and verifies each one fresh with real exit codes, then bounces a false Done back to the agent with the failing evidence.",
-  "version": "0.1.4",
+  "version": "0.1.9",
   "author": {
     "name": "sjh9714"
   },

--- a/plugins/nuhuh/plugin.json
+++ b/plugins/nuhuh/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nuhuh",
   "description": "A Stop hook that verifies the agent's completion claims by re-running reality. It extracts every claim from the final message (tests pass, file created, endpoint works) and verifies each one fresh with real exit codes, then bounces a false Done back to the agent with the failing evidence.",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "author": {
     "name": "sjh9714"
   },

--- a/plugins/nuhuh/plugin.json
+++ b/plugins/nuhuh/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "nuhuh",
+  "description": "A Stop hook that verifies the agent's completion claims by re-running reality. It extracts every claim from the final message (tests pass, file created, endpoint works) and verifies each one fresh with real exit codes, then bounces a false Done back to the agent with the failing evidence.",
+  "version": "0.1.4",
+  "author": {
+    "name": "sjh9714"
+  },
+  "homepage": "https://github.com/sjh9714/nuhuh"
+}


### PR DESCRIPTION
Adds nuhuh, a Stop hook plugin that verifies the agent's completion claims by re-running reality. When the agent declares Done, nuhuh extracts every claim from the final message (tests pass, file created, endpoint works) and verifies each one fresh, whole suite in a clean process, real exit codes, files on disk, localhost probes. A false Done is bounced back to the agent with the failing evidence, and after 3 bounces the receipt goes to the human.

It is the deterministic sibling of double-check already on this list. No LLM calls in the verification path, local only, MIT licensed. Source and a False Done Rate benchmark at https://github.com/sjh9714/nuhuh and the plugin folder mirrors the upstream .claude-plugin packaging.