### PR TITLE
Add gemini-claude-bridge to Development Engineering

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -131,6 +131,7 @@
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
+- [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge) — 让 Claude Code 使用 Gemini 模型的即插即用代理，支持思维签名持久化、多模态工具结果和流式工具参数。
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [project-curator](./plugins/project-curator)
 - [python-expert](./plugins/python-expert)

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
+- [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge) — Drop-in proxy that lets Claude Code use Gemini models, with thought signature persistence, multimodal tool results, and streaming tool arguments.
 - [ios-app-dev-skills](https://github.com/JasonColapietro/ios-app-dev-skills)
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [html-report](https://github.com/panhongwei/html-report)


### PR DESCRIPTION
## Summary

- add gemini-claude-bridge to the Development Engineering section
- add the matching entry to the Chinese README
- link to the separately maintained public repository

## Verification

- confirmed the repository is public, active, and MIT licensed
- verified the project implementation and 45 unit tests locally
- verified the new public GitHub link
- no executable hooks or scripts are added to this repository

Closes #88