### PR TITLE
docs: add OraClaw decision-intelligence MCP server

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -229,6 +229,7 @@
 
 ### MCP 服务器
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — 面向 Claude Code 的 AI 模型定价与推荐 MCP 服务器，帮助为每项任务选择最合适、性价比最高的模型。数据经交叉验证，每 4 小时更新一次。MCP 端点：`https://whichmodel.dev/mcp`
+- [OraClaw](https://github.com/Whatsonyourmind/oraclaw) — 确定性决策智能 MCP 服务器：17 个工具，涵盖优化（bandits/LinUCB、CMA-ES、HiGHS LP/MIP）、模拟（蒙特卡洛）、预测与校准（conformal）。响应低于 25ms，无需调用 LLM；其中 11 个工具免费且无需 API key。`npx @oraclaw/mcp-server`
 
 ## 插件市场
 - [protonium](https://github.com/protonium-labs/protonium-marketplace) —— AI 智能体与效率工具。包含 **AxiomCore**：项目与日常事务管理智能体，提供强制化结构（编号目录、任务 ID、wiki 记忆）、计划 → 确认 → 执行工作流，支持敏捷或 WBS 方式创建项目.

--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [OraClaw](https://github.com/Whatsonyourmind/oraclaw) — Deterministic decision-intelligence MCP server: 17 tools spanning optimization (bandits/LinUCB, CMA-ES, HiGHS LP/MIP), simulation (Monte Carlo), prediction, and calibration (conformal). Sub-25ms, no LLM calls; 11 tools are free with no API key. `npx @oraclaw/mcp-server`
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)


### PR DESCRIPTION
Closes #121.

Adds OraClaw to the `MCP Servers` section of both `README.md` and `README-zh.md`. One line per file, no other changes.

Against the triage checklist:

- **Section** — `MCP Servers` in `README.md`, `MCP 服务器` in `README-zh.md`, matching the existing entry format in each.
- **Links verified** — `https://github.com/Whatsonyourmind/oraclaw` returns 200, and `@oraclaw/mcp-server` resolves on the npm registry at 1.5.1. (npmjs.com's web page 403s automated requests, so I checked `registry.npmjs.org` rather than report a link as broken that isn't.)
- **Plugin manifest** — not applicable: OraClaw is an external npm package, not an in-repo package under `plugins/`.
- **Executable hooks/scripts** — none; this PR is documentation only.

One correction to my original submission: it said *12 tools / 19 algorithms*, which is stale. The current published package is **17 tools**, so the entry states that instead. I checked the live registry rather than reuse the March numbers.

Install: `npx @oraclaw/mcp-server` — 11 of the 17 tools run without an API key.
