### PR TITLE
Add cicada-husk — token-lean operating discipline (read-only, ~0 tokens/turn)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [claw-army/claude-node](https://github.com/claw-army/claude-node) - Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.
 - [api-integration-specialist](./plugins/api-integration-specialist)
 - [backend-architect](./plugins/backend-architect)
+- [blazephoenixxyz-crypto/cicada-husk](https://github.com/blazephoenixxyz-crypto/cicada-husk) - Token-lean operating discipline: read code by symbol instead of by whole file, cite prior findings by name, dose effort per task, budget every sub-agent by risk. Fully read-only — two commands, one ~25-token session banner, ~0 tokens per turn.
 - [blueprint](https://github.com/JuliusBrussee/blueprint)
 - [code-architect](./plugins/code-architect)
 - [context-memory](./plugins/context-memory)


### PR DESCRIPTION
Adds [cicada-husk](https://github.com/blazephoenixxyz-crypto/cicada-husk) under **Development Engineering**, in alphabetical position.

**What it does.** Teaches the agent to spend far fewer tokens without cutting quality or safety: read code by **symbol** instead of by whole file, cite prior findings **by name** rather than re-deriving them, **dose effort** to the task, never poll in a loop, **budget every sub-agent by risk**, and route each task to the lightest tool that is still fully safe.

**Why it may interest this list.** The plugin applies its own doctrine to itself. A plugin is billed only where bytes enter the model's context, so the knowledge ships as documentation (free at runtime) and the runtime surface is deliberately tiny: **two commands, one portable shell script, one ~25-token session banner, ~0 tokens per turn** — no per-turn spikes by construction.

**Safety.** Fully **read-only**. No daemon, no background process, nothing that can touch your files, memory or state.

- Repo: https://github.com/blazephoenixxyz-crypto/cicada-husk
- Release: v0.5.0 · MIT · doctrine and cost model documented in `docs/doctrine.md`

Happy to move it to a different category if you would rather see it under Thinking & Knowledge Management.