### PR TITLE
Add agent-memory (Knowledge Management + External Marketplaces)

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)
+- [agent-memory](https://github.com/vib795/agent-memory) — Cross-repository memory for Claude Code and GitHub Copilot. `/handoff`, `/remember` and `/recall` over one local markdown store, indexed into SQLite via `node:sqlite`. Notes live outside any repository, so a note written in one project is readable from another. Zero runtime dependencies and no install script.
 
 ## External Marketplaces
 
@@ -394,6 +395,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
+| [vib795/agent-memory](https://github.com/vib795/agent-memory) | agent-memory plugin: cross-repository memory — `/handoff`, `/remember`, `/recall` over one local markdown store. The plugin carries the skills; the store needs the CLI: `npm i -g @vib795/agent-memory` (Node >= 22.5) | `claude plugin marketplace add vib795/agent-memory` then `claude plugin install agent-memory@vib795` |
 
 
 ### Skills & Frameworks


### PR DESCRIPTION
Adds [agent-memory](https://github.com/vib795/agent-memory) — cross-repository memory for Claude Code and GitHub Copilot.

`/handoff`, `/remember` and `/recall` over one local markdown store. Notes live in `~/.agents/memory/`, outside any repository, which is what lets a note written in one project be read from another. The graph index is SQLite through `node:sqlite`, so there is no database to install and no package under it — `npm ls -g --depth 0` shows nothing.

**Zero runtime dependencies, zero dev dependencies, and no `postinstall` hook.** The install script was removed in 0.4.0 specifically because a package that writes into other tools' agent directories at install time is indistinguishable from a supply-chain attack; granting the skills is a separate, explicit command. The package publishes from CI with a provenance attestation.

## Two placements

- **Knowledge Management** — the plugin itself.
- **External Marketplaces** — the repo is also a marketplace, so `claude plugin marketplace add vib795/agent-memory` works directly.

Listed in both because they answer different questions, but happy to drop either if only one placement is wanted.

## Checked before submitting

- `claude plugin validate` passes on both the plugin and marketplace manifests
- Both install commands in the table were verified against `claude plugin --help` and `claude plugin marketplace --help`
- `agent-memory@vib795` matches the published `.claude-plugin/marketplace.json` on `main`
- Links resolve; MIT licensed; 93 tests green on Node 22 and 24 across Linux, macOS and Windows (v0.6.1)

The marketplace row notes that the plugin carries the skills while the store needs the CLI, so nobody installs it expecting a working store and finds three prompts with nothing behind them.

