### PR TITLE
docs: add requested marketing plugins

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -192,6 +192,9 @@
 
 ### 市场营销与增长
 - [app-store-optimizer](./plugins/app-store-optimizer)
+- [claude-seo](https://github.com/AgriciDaniel/claude-seo) - SEO 套件，涵盖网站审计、技术 SEO、E-E-A-T、GEO、结构化数据和本地 SEO 工作流。
+- [claude-ads](https://github.com/AgriciDaniel/claude-ads) - 面向 Google、Meta、LinkedIn、TikTok 和 Microsoft Ads 的付费广告审计工作流。
+- [claude-blog](https://github.com/AgriciDaniel/claude-blog) - 博客工作流，提供命令、模板、评分和 CMS 集成。
 - [content-creator](./plugins/content-creator)
 - [growth-hacker](./plugins/growth-hacker)
 - [instagram-curator](./plugins/instagram-curator)

--- a/README.md
+++ b/README.md
@@ -302,6 +302,9 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Marketing Growth
 - [app-store-optimizer](./plugins/app-store-optimizer)
 - [claude-rank](https://github.com/Houseofmvps/claude-rank) - SEO/GEO/AEO audit with 170+ rules, auto-fix for robots.txt/sitemap.xml/llms.txt/JSON-LD
+- [claude-seo](https://github.com/AgriciDaniel/claude-seo) - SEO suite with site audits, technical SEO, E-E-A-T, GEO, schema, and local SEO workflows.
+- [claude-ads](https://github.com/AgriciDaniel/claude-ads) - Paid advertising audit workflows for Google, Meta, LinkedIn, TikTok, and Microsoft Ads.
+- [claude-blog](https://github.com/AgriciDaniel/claude-blog) - Blog workflow with commands, templates, scoring, and CMS integration.
 - [content-creator](./plugins/content-creator)
 - [growth-hacker](./plugins/growth-hacker)
 - [Hermes Tweet](https://github.com/Xquik-dev/hermes-tweet) - Native Hermes Agent plugin for X/Twitter research, monitoring, drafting, follower exports, and approval-gated actions.


### PR DESCRIPTION
Resolves #169

## What changed

- Added `claude-seo`, `claude-ads`, and `claude-blog` to the Marketing Growth section in the English README.
- Added the same three external entries to the Chinese README, with concise translated descriptions.
- Verified each upstream repository is public, active, and MIT-licensed, and checked that all three links resolve through the GitHub API.

No in-repository plugin manifest was needed because these entries point to external repositories.

## Validation

- `git diff --check` passes.
- Each new entry appears once in each README.
- Repository and README metadata fetched successfully for all three links.