### PR TITLE
Add Lians Agent Memory MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-safety-preflight](./plugins/agent-safety-preflight)
 
 ### MCP Servers
+- [Lians Agent Memory](https://github.com/Lians-ai/Lians) — Local-first MCP memory for Claude Code and other agents, with SQLite-backed cross-session recall, user-controlled inspection/correction/deletion, and point-in-time memory receipts. Official registry: `io.github.ebeirne/lians`.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) — Local-first Work Model MCP server and Claude Code/Codex/OpenCode plugin. Tools: `acc_retrieve`, `acc_act`; official registry `io.github.maxbaluev/accint`.
 - [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`


### PR DESCRIPTION
## What changed

Adds one Lians entry to the MCP Servers section.

## Why it fits

Lians exposes local, SQLite-backed agent memory through MCP and documents a Claude Code integration. The entry links to the Apache-2.0 repository and identifies the official MCP Registry name.

## Validation

- Confirmed there is no existing Lians entry or prior Lians PR
- Kept the change to one README line
- Cross-checked every capability against the linked repository README
- Ran `git diff --check`

## Disclosure

I am affiliated with Lians. This submission was drafted with AI assistance and manually checked against the repository's current section format and the linked source.