### PR TITLE
Update Claude Code SDLC Harness entry: fix URL, move to Workflow Orchestration

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -77,6 +77,7 @@
 - [ai-meeting](./plugins/ai-meeting)
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
+- [Claude Code SDLC Harness](https://github.com/BaseInfinity/claude-sdlc-harness) — 面向代码库的 SDLC 编排系统：为每个代码库定制设置和更新，强制执行规划与 TDD，并通过独立的跨模型审查把关交付。安装：`npx agentic-sdlc-wizard init`。
 
 ### 自动化运维
 - [deployment-engineer](./plugins/deployment-engineer)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [Claude Code SDLC Harness](https://github.com/BaseInfinity/claude-sdlc-harness) - Codebase-aware SDLC orchestration that tailors setup and updates to each repository, enforces planning and TDD, and gates delivery on independent cross-model review. Installs via `npx agentic-sdlc-wizard init`.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.
@@ -162,7 +163,6 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [optimize](./plugins/optimize)
 - [performance-benchmarker](./plugins/performance-benchmarker)
 - [refractor](./plugins/refractor)
-- [sdlc-wizard](https://github.com/BaseInfinity/agentic-ai-sdlc-wizard) - SDLC enforcement plugin with hooks for TDD gates, planning workflow, confidence levels, and cross-model review. Installs via `npx agentic-sdlc-wizard init`.
 - [test-file](./plugins/test-file)
 - [test-results-analyzer](./plugins/test-results-analyzer)
 - [test-writer-fixer](./plugins/test-writer-fixer)


### PR DESCRIPTION
Thanks for merging #159 — genuinely appreciated.

Two things went stale since. The repo moved to `BaseInfinity/claude-sdlc-harness` (the old link still 301s, but a rename redirect dies the moment the old name is reused), and the plugin outgrew *Code Quality Testing* — its defining behavior is coordinating plan → build → independent cross-model review with artifact-gated enforcement, which puts it alongside `devforge-ai` and `magebyte-power` in Workflow Orchestration.

This PR:
- moves the entry to **Workflow Orchestration** with a corrected URL and description
- renames the entry to its canonical product title, `Claude Code SDLC Harness` (install command unchanged)
- adds the missing `README-zh.md` entry under `### 工作流编排`

Two files, +2/−1. Happy to trim any part of it if you'd rather keep the change minimal.
