### PR TITLE
Add Meanwhile plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [Meanwhile](https://github.com/vaddisrinivas/meanwhile) - Offers one optional, bounded focus, recovery, learning, play, or reality-check quest while Claude Code continues substantial work. No account, telemetry, or completion tracking.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.


### PR DESCRIPTION
Adds [Meanwhile](https://github.com/vaddisrinivas/meanwhile), an MIT-licensed Claude Code plugin and Agent Skill for one optional, bounded side quest while substantial agent work continues.

Install:
```sh
claude plugin marketplace add vaddisrinivas/meanwhile
claude plugin install meanwhile@meanwhile
```

Validation:
- `claude plugin validate . --strict` passed
- Clean-profile marketplace add and plugin install succeeded
- No account, telemetry, callback, cookies, or completion tracking
- `git diff --check` passed