### PR TITLE
Add using-lwc project memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ### Skills & Frameworks
 - [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
+- [using-lwc](https://github.com/JanYork/llm-wiki-cli/tree/main/skills/using-lwc) — Source-grounded project memory skill for Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and other agents. Guides durable recall and maintenance with citations, provenance, full-text retrieval, and optional document/code graphs.
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.


### PR DESCRIPTION
## Summary

Add the `using-lwc` Agent Skill under Skills & Frameworks. It gives Claude Code and other coding agents durable, source-grounded project memory with citations, provenance, full-text retrieval, and optional document/code graphs.

## Verification

- README-only one-line addition
- direct Skill URL resolves
- `npx skills add JanYork/llm-wiki-cli --list` discovers `using-lwc`
- `git diff --check` passes