### PR TITLE
Add claude-rem (Workflow Orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - **[claude-brain](https://github.com/toroleapinc/claude-brain)** — Sync and evolve your Claude Code brain across machines. Auto-syncs memory, skills, agents, rules, and CLAUDE.md via Git with LLM-powered semantic merge.
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
+- [claude-rem](https://github.com/jatingargiitk/claude-rem) — Session memory for Claude Code, Cursor & Codex: compiles every session into a current-truth briefing, verifies it against git, and injects it at session start. Blind self-eval harness included.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks
 - [lyra](./plugins/lyra)


### PR DESCRIPTION
Adds [claude-rem](https://github.com/jatingargiitk/claude-rem): session memory for Claude Code, Cursor & Codex. After each session it compiles a current-truth briefing (verified against git status, not transcript claims) and injects it at the next session start. Installable as a Claude Code plugin (`/plugin marketplace add jatingargiitk/claude-rem`) or via `npx claude-rem init`. Apache-2.0, ships its own blind eval harness. Placed under Workflow Orchestration alongside the other memory tools.