### PR TITLE
Add craft plugin (Workflow Orchestration)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2324,8 +2324,8 @@
         "source": "github",
         "repo": "drobins25/craft"
       },
-      "description": "A Claude Code plugin whose workshop of expert agents learns as it builds: repeated fixes become permanent rules, loved tweaks become taste it remembers - and every change waits behind a write gate you control.",
-      "version": "2.4.2",
+      "description": "A Claude Code plugin that acts as an intelligent harness for your development workflow: your codebase is read-only by default, every change passes through a Write Gate as planned and approved work, and craft tracks your project's history, design tokens, and decisions locally so Claude learns your taste and architectural preferences over time.",
+      "version": "2.6.1",
       "author": {
         "name": "Darin Drobinski",
         "url": "https://github.com/drobins25"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2316,6 +2316,37 @@
         "tokens",
         "audit"
       ]
+    },
+    {
+      "name": "craft",
+      "displayName": "craft",
+      "source": {
+        "source": "github",
+        "repo": "drobins25/craft"
+      },
+      "description": "A Claude Code plugin whose workshop of expert agents learns as it builds: repeated fixes become permanent rules, loved tweaks become taste it remembers - and every change waits behind a write gate you control.",
+      "version": "2.4.2",
+      "author": {
+        "name": "Darin Drobinski",
+        "url": "https://github.com/drobins25"
+      },
+      "category": "Workflow Orchestration",
+      "homepage": "https://github.com/drobins25/craft",
+      "repository": "https://github.com/drobins25/craft",
+      "license": "MIT",
+      "keywords": [
+        "claude-code",
+        "development",
+        "workflow",
+        "creative",
+        "harness",
+        "agents",
+        "multi-agent",
+        "orchestration",
+        "write-gate",
+        "quality-gates",
+        "taste"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -61,6 +61,7 @@
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — 基于话题的会话记忆插件，使用 Shell hooks 将每个对话话题归档为独立的 Markdown 摘要。两个 hooks，bash + Node.js，100% 本地运行。
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [craft](https://github.com/drobins25/craft)
 - [lyra](./plugins/lyra)
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)
 - [problem-solver-specialist](./plugins/problem-solver-specialist)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
-- [craft](https://github.com/drobins25/craft) - A Claude Code plugin whose workshop of expert agents learns as it builds: repeated fixes become permanent rules, loved tweaks become taste it remembers - and every change waits behind a write gate you control.
+- [craft](https://github.com/drobins25/craft) - A Claude Code plugin that acts as an intelligent harness for your development workflow: your codebase is read-only by default, every change passes through a Write Gate as planned and approved work, and craft tracks your project's history, design tokens, and decisions locally so Claude learns your taste and architectural preferences over time.
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks
 - [lyra](./plugins/lyra)
 - [magebyte-power](https://github.com/MageByte-Zero/magebyte-power) — Production-incident-distilled Claude Code skill: 7-phase workflow with 4-round AI cross-verification that catches concurrency & idempotency bugs before prod

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [craft](https://github.com/drobins25/craft) - A Claude Code plugin whose workshop of expert agents learns as it builds: repeated fixes become permanent rules, loved tweaks become taste it remembers - and every change waits behind a write gate you control.
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks
 - [lyra](./plugins/lyra)
 - [magebyte-power](https://github.com/MageByte-Zero/magebyte-power) — Production-incident-distilled Claude Code skill: 7-phase workflow with 4-round AI cross-verification that catches concurrency & idempotency bugs before prod


### PR DESCRIPTION
Adds craft as a Claude Code plugin marketplace entry under Workflow Orchestration, using the external GitHub source form (same as tree-ring-memory and trigger-tree).

craft is a Claude Code plugin whose workshop of expert agents learns as it builds: repeated fixes become permanent rules, loved tweaks become taste it remembers - and every change waits behind a write gate you control. Source repo: https://github.com/drobins25/craft

Validation performed:
- `claude plugin validate` on drobins25/craft's own manifests: passed
- `claude plugin validate` in this repo with the craft entry added: passed (one pre-existing warning on an unrelated vendored plugin, none on this entry)
- Duplicate plugin-name check: no existing "craft" entry among the 151 plugins (closest is "craftsman", a different plugin)
- README and README-zh entries added in the Workflow Orchestration section, matching the existing external-plugin format

🤖 Generated with [Claude Code](https://claude.com/claude-code)