### PR TITLE
Add Cadence Code to AI & Speech

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.
+- [Cadence Code](https://github.com/michael-L-i/cadence-code) - Fully local voice conversations on Apple Silicon. Selectable MLX text-to-speech and transcription models run on-device, so speech never reaches a cloud service. 8 MCP tools. `/plugin marketplace add michael-L-i/cadence-code`
 
 ### Automation DevOps
 - [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) - Auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types, selects from 28+ hooks, scores quality (0-100, A-F). `npm i -g puiux-pilot`


### PR DESCRIPTION
Adds [Cadence Code](https://github.com/michael-L-i/cadence-code) under **AI & Speech**.

## What it is

A Claude Code plugin that provides fully local voice conversations on Apple
Silicon. Its stdio MCP server owns the selected text-to-speech and
speech-to-text models directly through MLX Audio, so speech never reaches a
cloud service and no second language model rewrites Claude's responses. Users
pick their own speech and transcription models.

The plugin ships slash commands (`/cadence-code:start-talking`,
`/cadence-code:jump-in`, `/cadence-code:wrap-up`) plus 8 MCP tools:
`voice_start`, `voice_speak`, `voice_listen`, `voice_interrupt`, `voice_stop`,
`voice_models`, `voice_configure`, `voice_status`.

## Install

```
/plugin marketplace add michael-L-i/cadence-code
/plugin install cadence-code@cadence-code-marketplace
```

## Notes

- Searched the repo for the project name and URL; no existing entry.
- MIT licensed, public, actively maintained; latest release 0.6.0.
- Also supports Codex, Cursor, and Antigravity, but it is a first-class Claude
  Code plugin with its own marketplace manifest.