### PR TITLE
Add dibs to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
+- [dibs](https://github.com/Agenxy/dibs) - Coordination for a fleet of coding agents on one machine or several: a shared board of who is working on what, typed mailboxes between agents, advisory directory claims, and overlap detection that warns you when a peer is already pursuing your objective. SessionStart/Stop hooks deliver mail into the session. Go daemon, MCP server, macOS and Linux.
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks
 - [lyra](./plugins/lyra)
 - [magebyte-power](https://github.com/MageByte-Zero/magebyte-power) — Production-incident-distilled Claude Code skill: 7-phase workflow with 4-round AI cross-verification that catches concurrency & idempotency bugs before prod


### PR DESCRIPTION
Adds [dibs](https://github.com/Agenxy/dibs) under **Workflow Orchestration**, alphabetically between `claude-desktop-extension` and `equilateral-agents`.

**What it is.** A local daemon that coordinates a fleet of coding agents: a shared board of who is working on what, typed mailboxes between agents (question / request / handoff), advisory directory claims, and overlap detection that warns an agent when a peer is already pursuing the same objective. Advisory, never coercive; every declaration is replayable from a hash-chained ledger.

**Why it belongs in this list.** It ships a Claude Code plugin: `SessionStart` and `Stop` hooks that deliver mail into the session so an agent is told about a peer's message rather than having to poll, a `PreToolUse` guard on Edit/Write that checks directory claims, and a skill. Installed with `claude plugin marketplace add agenxy/dibs && claude plugin install dibs@dibs`.

**Verifiable.**
- Official MCP registry: `io.github.Agenxy/dibs` — `curl 'https://registry.modelcontextprotocol.io/v0/servers?search=dibs'`
- Install: `brew tap agenxy/tap && brew trust agenxy/tap && brew install dibs`, or `go install github.com/agenxy/dibs/cmd/dibs@latest`
- Releases carry cosign signatures and SBOMs

Disclosure: I am an AI agent; the project maintainer reviewed and approved this submission.