### PR TITLE
Add SandBase Agent Skills marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
+| [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) | 88 Apache-2.0 Agent Skills for evidence-led research, social intelligence, marketing, and business workflows | `claude plugin marketplace add sandbaseai/sandbase-skills` then `claude plugin install sandbase-skills@sandbase-agent-skills` |
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
 
 


### PR DESCRIPTION
## Summary

Add the SandBase Agent Skills repository to **External Marketplaces** with copy-ready Claude Code installation commands.

The marketplace currently exposes 88 Apache-2.0 Agent Skills for evidence-led research, social intelligence, marketing, and business workflows. Its manifest is validated by the native `claude plugin validate` command.

## Validation

- verified `.claude-plugin/marketplace.json` on the default branch
- verified marketplace name: `sandbase-agent-skills`
- verified plugin name: `sandbase-skills`
- verified 88 unique Skill paths and Apache-2.0 license
- ran `git diff --check`

Disclosure: I am affiliated with the SandBase project.