### PR TITLE
Add claude-in-chrome to Automation DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [notify](https://github.com/ApurvBazari/claude-plugins)
 - [retro-daily](./plugins/retro-daily)
 
+- [claude-in-chrome](https://github.com/hamzahamidi/claude-in-chrome-cli) - Drives your real, logged-in Chrome through the Claude in Chrome extension, so pages behind SSO or a cookie wall work without a fresh profile or a re-login. Bundles a skill on when a real session matters, plus `cic.sh` for shell and cron use. `/plugin marketplace add hamzahamidi/claude-in-chrome-cli`
+
 ### Business Sales
 - [Drevon](https://drevon.dev) - Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel.
 - [b2b-project-shipper](./plugins/b2b-project-shipper)


### PR DESCRIPTION
Adds `claude-in-chrome` under Automation DevOps.

It registers Claude Code's own extension bridge (`claude --claude-in-chrome-mcp`) as an MCP server, so the browser tools drive the real, logged-in Chrome instead of a fresh profile. That covers pages behind SSO or a cookie wall, which sessionless browser tools cannot reach without a re-login.

Repo: https://github.com/hamzahamidi/claude-in-chrome-cli (MIT, v0.2.1)
Listed on ClaudePluginHub: https://www.claudepluginhub.com/plugins/hamzahamidi-claude-in-chrome

One entry, matching the existing format in that section.