### PR TITLE
Add requirement-zero plugin (Project & Product Management)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2316,6 +2316,37 @@
         "tokens",
         "audit"
       ]
+    },
+    {
+      "name": "requirement-zero",
+      "displayName": "requirement-zero",
+      "source": {
+        "source": "github",
+        "repo": "Chisanan232/requirement-zero"
+      },
+      "description": "Two scope-discipline skills: challenge whether a requirement should be built before planning, and audit whether existing code still deserves to exist.",
+      "version": "0.2.0",
+      "author": {
+        "name": "Chisanan232",
+        "url": "https://github.com/Chisanan232"
+      },
+      "category": "Project & Product Management",
+      "homepage": "https://github.com/Chisanan232/requirement-zero",
+      "repository": "https://github.com/Chisanan232/requirement-zero",
+      "license": "MIT",
+      "keywords": [
+        "agent-skills",
+        "claude-code",
+        "code-audit",
+        "requirements-engineering",
+        "technical-debt",
+        "yagni"
+      ],
+      "tags": [
+        "requirements",
+        "code-audit",
+        "scope"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -213,7 +213,7 @@
 - [tool-evaluator](./plugins/tool-evaluator)
 - [workflow-optimizer](./plugins/workflow-optimizer)
 - [product-org-os](./plugins/product-org-os)
-- [requirement-zero](https://github.com/Chisanan232/requirement-zero) - 两个范围控制技能：`requirement-zero` 在规划开始前质疑某个需求是否应该被构建，`codebase-zero` 审计既有代码是否仍值得存在。每个技能给出一个明确结论。纯 Markdown，MIT 许可。
+- [requirement-zero](https://github.com/Chisanan232/requirement-zero)
 
 ### 安全、合规与法律
 - [ai-ethics-governance-specialist](./plugins/ai-ethics-governance-specialist)

--- a/README-zh.md
+++ b/README-zh.md
@@ -213,6 +213,7 @@
 - [tool-evaluator](./plugins/tool-evaluator)
 - [workflow-optimizer](./plugins/workflow-optimizer)
 - [product-org-os](./plugins/product-org-os)
+- [requirement-zero](https://github.com/Chisanan232/requirement-zero) - 两个范围控制技能：`requirement-zero` 在规划开始前质疑某个需求是否应该被构建，`codebase-zero` 审计既有代码是否仍值得存在。每个技能给出一个明确结论。纯 Markdown，MIT 许可。
 
 ### 安全、合规与法律
 - [ai-ethics-governance-specialist](./plugins/ai-ethics-governance-specialist)

--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-decision-record](./plugins/agent-decision-record)
 - [product-org-os](./plugins/product-org-os)
 - [governor](https://github.com/0xhimanshu/governor)
+- [requirement-zero](https://github.com/Chisanan232/requirement-zero) - Two scope-discipline skills: `requirement-zero` challenges whether a requirement should be built before planning starts, `codebase-zero` audits whether existing code still deserves to exist. Each reaches one explicit verdict. Markdown only, MIT.
 
 ### Lifestyle & Entertainment
 - [ai-divination-skills](./plugins/ai-divination-skills)

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-decision-record](./plugins/agent-decision-record)
 - [product-org-os](./plugins/product-org-os)
 - [governor](https://github.com/0xhimanshu/governor)
-- [requirement-zero](https://github.com/Chisanan232/requirement-zero) - Two scope-discipline skills: `requirement-zero` challenges whether a requirement should be built before planning starts, `codebase-zero` audits whether existing code still deserves to exist. Each reaches one explicit verdict. Markdown only, MIT.
+- [requirement-zero](https://github.com/Chisanan232/requirement-zero) - Two scope-discipline skills: `requirement-zero` challenges whether a requirement should be built before planning starts, `codebase-zero` audits whether existing code still deserves to exist. Each reaches one explicit verdict. Skills are Markdown, MIT.
 
 ### Lifestyle & Entertainment
 - [ai-divination-skills](./plugins/ai-divination-skills)


### PR DESCRIPTION
Adds [requirement-zero](https://github.com/Chisanan232/requirement-zero) to the **Project & Product
Management** category as an external GitHub source, following the pattern established by merged PR
#313 — no plugin files are copied into this repository.

Two Agent Skills that address the same gap from opposite ends. An agent will readily build what it is
asked for, and readily keep what already exists; neither default gets examined.

- **`requirement-zero`** runs before planning or implementation and reaches one explicit verdict:
  DELETE, REDUCE, DEFER, BUILD, or BUILD HARD. Scoped to requests whose necessity has not been
  established. It explicitly declines to run on already-validated work, bug fixes, or safety,
  security, legal, and compliance requirements.
- **`codebase-zero`** runs on an artifact that already exists and reaches one verdict per artifact:
  DELETE, CONSOLIDATE, SIMPLIFY, DEFER CLEANUP, KEEP, or INVEST. It audits and recommends; it does not
  delete code on its own authority. Already-decided removals are still audited when the target is a
  security, safety, privacy, data-integrity, legal, compliance, or compatibility control.

The skills are Markdown — no package, no server, no runtime, no install script, and no hook. Nothing
runs as part of using a skill. MIT licensed. (For completeness: the repository also contains one
maintainer-run Python evaluation harness, `eval/run_eval.py`, which shells out to the authenticated
`claude` CLI and therefore makes paid API calls when a maintainer runs it. It is standard-library only
and is never invoked by either skill.)

### Changes

- Register `Chisanan232/requirement-zero` as an external GitHub plugin source in
  `.claude-plugin/marketplace.json`
- Add the plugin to the Project & Product Management lists in `README.md` and `README-zh.md` — a
  described entry in `README.md`, and a bare link in `README-zh.md` to match that section, where all
  11 existing entries are bare links (this also matches precedent #313, which described in EN only)
- Include version, author, category, homepage, repository, license, keyword, and tag metadata,
  matching the field set on the two existing external-source entries

**On the category.** The pair genuinely spans two of your categories — `requirement-zero` is a
pre-build scoping decision (Project & Product Management) and `codebase-zero` is an audit of existing
code (Code Quality Testing). I put it in Project & Product Management because the earlier decision is
the one the pair leads with, and because listing one plugin in two categories is not a convention this
README uses (no plugin currently appears twice). Happy to move it to Code Quality Testing instead if
you prefer — say which and I will push the change.

### Validation

- `jq empty .claude-plugin/marketplace.json` — valid JSON
- Normalised before/after comparison (`jq -S` with the new entry filtered out) is **byte-identical**,
  so the edit is an addition only: no reformatting, no reordering, and no change to any of the 151
  existing entries
- Plugin count 151 → 152; all 152 `name` values unique, so `requirement-zero` collides with nothing
- `category` value `"Project & Product Management"` matches the existing vocabulary exactly
- `version: "0.2.0"` matches the latest published release tag `v0.2.0` on the source repository. Two
  things worth stating rather than leaving for you to discover: the source `plugin.json` declares no
  `version` key of its own (its USAGE.md says "no semver exists to depend on"), so this field
  originates here; and since no tag carries the manifest, the entry resolves to the default branch,
  which is 70 commits ahead of `v0.2.0`. Those 70 commits touched only `README.md`, `USAGE.md` and
  `.claude-plugin/` — `git diff v0.2.0 main -- SKILL.md skills/ references/ examples/ eval/` is empty,
  so the installed skill content is byte-identical to `v0.2.0`. If you would rather the field be
  omitted than originate a version the source does not declare, say so and I will drop it
- Trailing newline at end of `marketplace.json` preserved
- `git diff --check` — clean
- Both new README links fetched: HTTP 200
- Upstream repository self-test: `python3 eval/run_eval.py --self-test` exits 0 — 32/32
  verdict-extraction cases across both skills' verdict vocabularies, and 2/2 skill descriptions within
  the 1,536-character listing budget

### Notes, stated plainly

- **Install caveat, so nobody hits it unexpectedly.** Neither published release tag (`v0.1.0`,
  `v0.2.0`) contains the `.claude-plugin/` directory — the manifests landed after both tags were cut.
  So `claude plugin marketplace add Chisanan232/requirement-zero` installs from the default branch
  today; a `@v0.2.0`-pinned install would not find the manifest. This is documented in the source
  repository's README and USAGE.md, and will be resolved by the next release.
- **Tested on Claude Code 2.1.226 only.** No non-Claude host has been tested, so the repository claims
  no cross-agent compatibility. The three install routes and what each one actually loaded are
  recorded in
  [USAGE.md](https://github.com/Chisanan232/requirement-zero/blob/main/USAGE.md).
- **This is a new repository (first commit 2026-08-15) with 0 stars.** No adoption is claimed anywhere
  in this PR or in the entry text.
- Each skill has a published evaluation run in the repository. Reporting both results, including the
  unfavourable one: the `codebase-zero` evaluation (7 cases) showed measurable verdict changes against
  baseline, while the `requirement-zero` evaluation showed **no measurable effect** on the metric it
  was designed to move. That negative result is written up in the repository rather than omitted.
- I am the author.

---

## Correction after self-review

One fresh-context reviewer went over this submission and found claims worth tightening. All were
reproduced before being changed:

- **"Markdown only — no package, no server, no runtime, no install script, and no hook"** was too
  broad: the repository also contains a maintainer-run Python evaluation harness that shells out to the
  authenticated `claude` CLI and makes paid API calls. The opening paragraph now scopes the claim to
  the skills and describes the harness explicitly rather than leaving it to be discovered.
- **The `version` field now carries its own caveat.** `"0.2.0"` does match the latest release tag, but
  the source `plugin.json` declares no version of its own, so the field originates in this entry. That
  is now stated in Validation along with the evidence that the default-branch skill content is
  byte-identical to `v0.2.0`.
- **The `README-zh.md` entry is now a bare link** (commit `0c9a355`). The described form used a hyphen
  separator where that file's other described entries use an em-dash, and more importantly the
  Chinese Project & Product Management section has no descriptions at all — all 11 entries are bare
  links, and precedent #313 described in English only. Matching the section beats importing a
  convention from the English file.
- **The `README.md` entry now says "Skills are Markdown, MIT"** rather than "Markdown only, MIT", for
  the same reason as the first point.
