### PR TITLE
Add Synapse to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)
+- [Synapse](https://github.com/smaurier/claude-synapse) - Links Claude Code memory across machines through a single git-hosted hub referenced by filesystem junction/symlink, instead of syncing or copying files between them.
 
 ## External Marketplaces
 


### PR DESCRIPTION
Adds [Synapse](https://github.com/smaurier/claude-synapse), a Claude Code plugin that links memory across machines through a single git-hosted hub (referenced by filesystem junction/symlink from every machine and project) instead of syncing or copying files. MIT licensed, 222 tests, CI passing.