### PR TITLE
Add ClawMetry to Companion Apps & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
-- [ClawMetry](https://github.com/vivekchand/clawmetry) — Open-source local dashboard that auto-detects Claude Code sessions and shows live transcripts, token costs, and tool calls across 20+ agent runtimes
+- [ClawMetry](https://github.com/vivekchand/clawmetry) — Open-source local dashboard that auto-detects Claude Code sessions and shows live transcripts, token costs, and tool calls across 20+ agent runtimes [Website](https://clawmetry.com)
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
+- [ClawMetry](https://github.com/vivekchand/clawmetry) — Open-source local dashboard that auto-detects Claude Code sessions and shows live transcripts, token costs, and tool calls across 20+ agent runtimes
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)


### PR DESCRIPTION
Adds ClawMetry (https://github.com/vivekchand/clawmetry) to the Companion Apps & Tools section. It is an open-source local dashboard that auto-detects Claude Code sessions and shows live transcripts, token costs, and tool calls across 20+ agent runtimes. Entry matches the existing format in the section.

Website: https://clawmetry.com
