### PR TITLE
Add checkpoint-vivo to Thinking & Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
 
 ### Thinking & Knowledge Management
+- [checkpoint-vivo](https://github.com/Balli-tech/checkpoint-vivo) - Persists where the work stopped and restores it into context at session start, resume, and after compaction. A PreCompact hook captures git log, pending files, and recent requests on its own.
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)
 
 ### Companion Apps & Tools


### PR DESCRIPTION
Adding [checkpoint-vivo](https://github.com/Balli-tech/checkpoint-vivo), a plugin that keeps a session checkpoint on disk and restores it into context automatically.

**What it does**

- `SessionStart` — injects the checkpoint at session start, resume, and after compaction
- `PreCompact` — captures git log, uncommitted files, and the most recent user requests on its own, writing only between HTML markers so hand-written text is never overwritten
- `Stop` — asks the agent to refresh the checkpoint when there is a commit newer than the file
- A `checkpoint` skill teaches the agent to record decisions **and discarded alternatives**, which is the part that is most expensive to rediscover after compaction

**Why the trigger is a commit, not context size:** the agent cannot read how much of the window it has consumed — no tool returns that number. A commit is observable, so it is used as the signal that a block of work closed.

MIT licensed, no external dependencies, Python 3.10+.

Placed under Thinking & Knowledge Management as it deals with retaining working context across sessions.