### PR TITLE
Add ballitech to External Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
+| [Balli-tech/ballitech-claude-plugins](https://github.com/Balli-tech/ballitech-claude-plugins) | checkpoint-vivo: persists where the work stopped and restores it into context at session start, resume, and after compaction | `claude plugin marketplace add Balli-tech/ballitech-claude-plugins` then `claude plugin install checkpoint-vivo@ballitech` |
 
 
 ### Skills & Frameworks


### PR DESCRIPTION
Adds the [ballitech](https://github.com/Balli-tech/ballitech-claude-plugins) marketplace to the External Marketplaces table, following the same format as the existing entry.

It currently serves one plugin, [checkpoint-vivo](https://github.com/Balli-tech/checkpoint-vivo) — three hooks and a skill that keep a session checkpoint on disk and restore it into context at session start, resume, and after compaction.

Install:

```bash
claude plugin marketplace add Balli-tech/ballitech-claude-plugins
claude plugin install checkpoint-vivo@ballitech
```

Both repositories are public and MIT licensed. Related to #354, which lists the plugin itself; this one is about the marketplace entry, and either can be merged without the other.