### PR TITLE
Add MainBook Bank Statement Converter (external plugin)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2316,6 +2316,38 @@
         "tokens",
         "audit"
       ]
+    },
+    {
+      "name": "mainbook-bank-statement-converter",
+      "displayName": "MainBook Bank Statement Converter",
+      "source": {
+        "source": "github",
+        "repo": "human-beyond/mainbook-skill"
+      },
+      "description": "Convert PDF bank statements into Excel, CSV, or JSON and review the arithmetic checks and warning evidence before using the numbers.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Human Beyond LLC",
+        "url": "https://mainbook.ai"
+      },
+      "category": "Data Analytics",
+      "homepage": "https://mainbook.ai/mcp",
+      "repository": "https://github.com/human-beyond/mainbook-skill",
+      "license": "MIT",
+      "keywords": [
+        "bank-statements",
+        "pdf",
+        "excel",
+        "csv",
+        "accounting",
+        "document-conversion"
+      ],
+      "tags": [
+        "bank-statements",
+        "documents",
+        "finance",
+        "mcp"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds one external entry to `.claude-plugin/marketplace.json`, following the shape of the two existing external plugins.

- Repository: https://github.com/human-beyond/mainbook-skill (public, MIT)
- Contains a plugin manifest, a marketplace manifest, one agent skill, and one MCP server configuration
- The bundled MCP server is published on PyPI as `mainbook-mcp` and listed in the official MCP registry
- Nothing is copied into this repository; the source stays external

`marketplace.json` parses cleanly after the change.