### PR TITLE
Add earshot and waypoint plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.
+- [earshot](https://github.com/absep98/earshot) - Narrates Claude Code responses so you don't have to read every diff. Silent by default, speaks up only on questions, failures, and blockers — designed against auditory-overload feedback from blind and low-vision developers.
 
 ### Automation DevOps
 - [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) - Auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types, selects from 28+ hooks, scores quality (0-100, A-F). `npm i -g puiux-pilot`
@@ -335,6 +336,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [plannotator](https://github.com/backnotprop/plannotator) - Interactive plan review UI with visual annotation (install via `/plugin marketplace add backnotprop/plannotator`)
 - [prd-specialist](./plugins/prd-specialist)
 - [product-manager-skills](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 30+ frameworks, 32 SaaS metrics with exact formulas, 12 templates, and anti-pattern detection. Pure Markdown, MIT-0 license.
+- [waypoint](https://github.com/absep98/waypoint) - Keeps one session goal front of mind. `/goal-set` stores it, and a `UserPromptSubmit` hook silently re-injects a one-line reminder before every prompt until you close it out with `/goal-done`.
 - [project-shipper](./plugins/project-shipper)
 - [sprint-prioritizer](./plugins/sprint-prioritizer)
 - [studio-producer](./plugins/studio-producer)


### PR DESCRIPTION
Adding two of my own Claude Code plugins:

- **[earshot](https://github.com/absep98/earshot)** (AI & Speech) — narrates Claude Code responses via TTS so you don't have to read every diff. Silent by default, speaks up only on questions, failures, and blockers.
- **[waypoint](https://github.com/absep98/waypoint)** (Project & Product Management) — keeps one session goal front of mind. `/goal-set` stores it, and a `UserPromptSubmit` hook silently re-injects a one-line reminder before every prompt until `/goal-done`.

Both are zero-dependency Node, MIT licensed, and install via `/plugin marketplace add`.