### PR TITLE
Add SpecLock constraint enforcement plugin

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -223,6 +223,7 @@
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)
 - [shellgate](./plugins/shellgate)
+- [SpecLock](https://github.com/sgroy10/speclock) — AI 约束引擎，通过语义检查、Claude Code 钩子、Git 钩子和 51 个 MCP 工具，强制执行 CLAUDE.md、AGENTS.md 等 AI 指令文件中的项目规则。
 - [web-security-guard](./plugins/web-security-guard)
 - [agent-safety-preflight](./plugins/agent-safety-preflight)
 

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [privacy-mask](https://github.com/fullstackcrew-alpha/privacy-mask) - Detect and redact PII, API keys, and secrets in screenshots via OCR + regex before images reach Claude. 47 detection rules, Tesseract/RapidOCR support, UserPromptSubmit hook integration. 100% offline.
 - [skillfortify](https://github.com/qualixar/skillfortify) - External: Formal verification scanner for AI agent skills (including Claude Code skills + MCP servers). 100% precision on 540-skill benchmark. ASBOM generation. arXiv:2603.00195.
 - [shellgate](./plugins/shellgate)
+- [SpecLock](https://github.com/sgroy10/speclock) - AI constraint engine that enforces project rules from CLAUDE.md, AGENTS.md, and other AI instruction files with semantic checks, Claude Code hooks, Git hooks, and 51 MCP tools.
 - [huiyu-safe-ai](https://github.com/huiyu9144/huiyu-safe-ai) - Lightweight AI security guard for install/download commands. Blocks 68+ malicious packages, verifies identity, scans code in <1s. Built from a real supply chain attack.
 - [web-security-guard](./plugins/web-security-guard)
 - [supply-chain-gate](./plugins/supply-chain-gate)


### PR DESCRIPTION
Adds SpecLock to the English and Chinese plugin directories. SpecLock 5.7.1 is live on npm with native Claude Code plugin support.