### PR TITLE
Add 500k.io Skills Bank to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.
+- [500k.io Skills Bank](https://500k.io/skills) - Searchable index of 638+ Claude, Claude Code and MCP skills, with install command and compatibility matrix per entry.
 
 ## Tutorials
 


### PR DESCRIPTION
Adding the 500k.io Skills Bank to Resources — a searchable index of 638+ skills for Claude, Claude Code, Cowork and MCP-compatible agents, refreshed weekly from GitHub, Anthropic and community sources.

Useful companion to a plugin marketplace: each entry ships the install command, a compatibility matrix, and popularity signals. Free, no signup.

Disclosure: I maintain it.