### PR TITLE
Add x-research skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ### Skills & Frameworks
 - [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
+- [x-research](https://github.com/agentbody/skills/tree/main/skills/x-research) — Read-only X/Twitter research skill: public post search, trends, post details, profiles, profile posts/media, and replies via a bundled Python client.
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.


### PR DESCRIPTION
Adds AgentBody's X Research skill to Skills & Frameworks.

**Skill:** [x-research](https://github.com/agentbody/skills/tree/main/skills/x-research)
**Description:** Read-only X/Twitter research: public post search, trends, post details, profiles, profile posts/media, and replies via a bundled Python client.
**License:** MIT