### PR TITLE
Add mystical-assistant to Companion Apps & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
+- [mystical-assistant](https://github.com/ainurdev/mystical-assistant) — Self-hosted bridge that lists every Claude Code session on a machine, including ones started from a terminal or VS Code, and makes them readable and answerable from a local dashboard, a Telegram bot, or a Telegram Mini App. Parks turns killed by a usage limit and resumes them at reset. Python stdlib only; reuses the `claude` CLI login, no API key.
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)


### PR DESCRIPTION
Adds [mystical-assistant](https://github.com/ainurdev/mystical-assistant) under **Companion Apps & Tools**, alongside Onepilot — same shape of thing: reaching your own machine's Claude Code from elsewhere.

It reads Claude Code's own session registry, so it lists every session on the machine — including ones started from a terminal or VS Code — and makes them readable and answerable from a local dashboard, a Telegram bot, or a Telegram Mini App. When a usage limit kills a turn it parks the session and resumes it at the reset. The server is Python standard library only and needs no API key: it shells out to the `claude` CLI and reuses that login.

MIT licensed, ~400 commits, actively developed. I'm the author — happy to reword or move it if another section fits better.