### PR TITLE
Add charter to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [artel](https://github.com/NicolasPrimeau/artel) - Infrastructure for AI teams: shared semantic memory, tasks, agent-to-agent messages, and session handoffs across machines and LLM providers.
 - **[claude-brain](https://github.com/toroleapinc/claude-brain)** — Sync and evolve your Claude Code brain across machines. Auto-syncs memory, skills, agents, rules, and CLAUDE.md via Git with LLM-powered semantic merge.
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
+- [charter](https://github.com/diazoxide/charter) — Control plane for agents working across many repos: one directory of clones per task (each repo on its own branch), durable personas with committed memory, and a credential vault the model never reads from. Runs in Claude Code, opencode and Codex. `claude plugin marketplace add diazoxide/charter`
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks


### PR DESCRIPTION
Adding [charter](https://github.com/diazoxide/charter) under **Workflow Orchestration**, alongside `artel` and `claude-brain` — it solves the same class of problem (state that outlives a session, across machines and repos).

**What it is:** a control plane for coding agents working across many repos.

- **Per-task workspaces** — one directory of clones per task, each repo on its own branch, so parallel work doesn't share a checkout. Worktrees split one clone further, so two sub-agents can hold the same repo on different branches.
- **Durable personas** — named roles (`devops`, `qa`) with their own charter, committed memory and vault, each dispatchable as a real Claude Code sub-agent.
- **A credential vault the model never reads from** — secrets are handed to a *command*, not to the model, and redacted from its output. Providers: plain file, 1Password, reference.
- **State is git.** No database, no server, no daemon. The Python package has zero dependencies.

**Plugin details:** ships as a Claude Code plugin via `claude plugin marketplace add diazoxide/charter`, with hooks, four skills (`charter:secrets`, `charter:persona`, `charter:working-in-a-clone`, `charter:browser`) and generated per-persona sub-agents. Also runs in opencode and Codex, enforcing the same rules in each.

MIT licensed. I'm the author — happy to adjust the wording, the category, or drop it if it's not a fit.