### PR TITLE
Add cc-agents-kit (guard hooks for silently-failing shell mistakes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Security, Compliance, & Legal
 - [ai-ethics-governance-specialist](./plugins/ai-ethics-governance-specialist)
 - [audit](./plugins/audit)
+- [cc-agents-kit](https://github.com/AndrewDongminYoo/cc-agents-kit) - Seven defensive hooks: blocks recursive rm aimed at $HOME or /, download-and-execute pipelines, live secrets-file access, formatters invoked with no path argument, credentials in the staged diff, and the two zsh quoting mistakes that fail silently. Every hook fails open with an individual opt-out. 184 regression cases, 74 of which fail when the logic they cover is deleted.
 - [compliance-automation-specialist](./plugins/compliance-automation-specialist)
 - [data-privacy-engineer](./plugins/data-privacy-engineer)
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)


### PR DESCRIPTION
Adds `cc-agents-kit` under **Security, Compliance, & Legal** — one line, placed alphabetically, matching the surrounding entry format.

It is a marketplace of three plugins; the entry describes `guard-hooks`, the one that fits this section. Seven hooks, five of which block a tool call before it runs:

- a recursive `rm` aimed at the home directory or a filesystem root
- download-and-execute pipelines
- reads of live secrets files (dotenv and friends), while template variants stay readable
- a formatter or rewriter invoked with no path argument, where its no-path default is everything reachable
- credentials in the added lines of a staged diff, checked before `git commit` runs
- the two zsh quoting mistakes that fail *silently*: a backtick inside a double-quoted commit message, which runs as command substitution and deletes that word before git sees it, and an unquoted glob in an option value, which zsh expands against the working directory so the command either aborts or searches the wrong thing while looking clean

Two more warn without ever blocking: a lockfile left older than the manifest just edited, and shellcheck findings on an edited script.

Things a curated list may want to know:

- **Fails open, never closed.** Empty or malformed hook input exits 0 silently. A broken guard degrades to no guard rather than to a blocked tool call, and each hook has its own `CC_GUARD_DISABLE_*` switch.
- **The tests are mutation-checked.** 184 cases; delete the logic they cover and 74 fail. That is not decoration — it caught one guard that was scanning nothing at all on stock macOS, because an empty array expansion aborts under `set -u` in bash 3.2 and an adjacent `|| true` swallowed it. CI runs on Linux and macOS for that reason.
- **Apache-2.0.** Three skills in the other two plugins derive from MIT-licensed upstream work; each names its source in a `metadata.origin` key, and `CREDITS.md` records the licence plus how much of each shipped file is verbatim, measured line-wise rather than asserted.

Happy to move it to a different section, shorten the description, or split it if you would rather list the marketplace than one plugin.
