### PR TITLE
Add PostEverywhere to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [PostEverywhere](https://github.com/posteverywhere/mcp) - Official social media publishing MCP: schedule and post to 11 platforms (Instagram, TikTok, YouTube, LinkedIn, X, Facebook, Threads, Pinterest, Bluesky, Telegram, Discord) with media upload, AI captions, campaigns, and analytics. 33 tools. Install: `claude mcp add posteverywhere -- npx -y @posteverywhere/mcp` or remote MCP `https://mcp.posteverywhere.ai/mcp`
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)


### PR DESCRIPTION
Adds PostEverywhere, an official vendor MCP server for social media publishing from Claude Code and other MCP clients.

- Public repo: https://github.com/posteverywhere/mcp (TypeScript, MIT)
- npm: @posteverywhere/mcp (latest 1.7.0), stdio via npx
- Hosted remote (Streamable HTTP + OAuth): https://mcp.posteverywhere.ai/mcp
- Published in the official MCP Registry as ai.posteverywhere/mcp
- 33 tools: post scheduling across 11 platforms, media upload, AI captions and images, campaigns, analytics, account health
- Docs: https://developers.posteverywhere.ai/integrations/mcp

Entry follows the existing list format.