### PR TITLE
Add chamnan — repository-local context so an agent stops rediscovering the same work

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [skill-auto-installer](./plugins/skill-auto-installer)
 - [tldr](./plugins/tldr)
 - [Imagine](https://github.com/freestyler-arb/imagine-gemini-for-claude-codex) - Brings Google Gemini into Claude Code & Codex: delegate reasoning, independent code review, deep research, and automatic prompt-engineering. Runs on your Google AI Pro subscription, not your agent's tokens.
+- [chamnan](https://github.com/ArcticFox2029/chamnan) — keeps a repository's engineering context on disk so a session reads instead of rediscovering: an architecture index, an impact map, session handoffs and recorded decisions, as markdown committed beside the code. Repository-local, no network, Python stdlib, MIT
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)


### PR DESCRIPTION
Adding [chamnan](https://github.com/ArcticFox2029/chamnan) to **Development Engineering**. One line, appended at the end of the section.

### What it does

An agent working in a repository keeps arriving at the same conclusions: a new session starts with nothing, a long session compacts, and the reasoning behind a fix is not in the diff. chamnan writes what gets discovered into repository-local markdown, so the next session reads instead of rediscovering.

- **Understand** — an architecture index, plus an impact section for who depends on a file and which tests cover it
- **Remember** — work state, session records, and decisions/lessons/rules
- **Reuse** — procedures, tools, and detection of the same commands run in the same order on separate days
- **Evolve** — milestones: the changes that reshaped the repository, and why

Everything lives in `.chamnan/`, committed beside the code. No service, no account, no database.

### Details

- MIT, standard library only — nothing to install
- 378 tests, no pytest
- Measured on a 2,365-file polyglot corpus: **507 tokens** reach a session with every store populated
- Secrets are redacted at one choke point; the README states plainly that it is **not** a sandbox, because a hook cannot filter what the `Read` tool returns

Honest scope: it is an amortising tool. On a four-file repository it costs more than it saves, and the README says so before the install instructions.

Happy to move it to a different category or shorten the description.