### PR TITLE
Add Sum-Usage-Claude to Companion Apps & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
+- [Sum-Usage-Claude](https://github.com/ArcticFox2029/Sum-Usage-Claude) — offline dashboard for what your Claude Code usage would have cost at API prices, against what you actually paid. Reads the transcripts Claude Code already writes; opens from `file://` with no install and no server. Thai and English, Python stdlib only, MIT
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)


### PR DESCRIPTION
One line added to **Companion Apps & Tools**. Nothing else touched.

[Sum-Usage-Claude](https://github.com/ArcticFox2029/Sum-Usage-Claude) reads the transcripts Claude Code already writes and answers one question: what would this usage have cost at API list prices, against what you actually paid.

It is a companion tool rather than a plugin, which is why it is in this section and not under Plugins.

- **No install, no server.** The build inlines the dataset into the page, so `index.html` opens straight from `file://`. Python 3 standard library only.
- **Real billing cycles, not calendar months** — you enter the invoices you were actually sent, so the multiple is against a real number.
- **Thai and English**, switchable in the page.

Three corrections that change the figures, each measurable: records are deduplicated by `requestId` (48% of them were repeats of an id already counted), cache tokens are priced separately (a cache read bills at 0.1× input and is ~99% of all input here), and days are bucketed locally rather than in UTC (otherwise every late-night session splits across two dates).

MIT, no network calls, no telemetry. Only counts and costs are written out — no prompt text, no replies, no paths beyond the project directory name.

Happy to reword or drop it if it is not a fit.