### PR TITLE
Add Portable Handoff to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - **[claude-brain](https://github.com/toroleapinc/claude-brain)** — Sync and evolve your Claude Code brain across machines. Auto-syncs memory, skills, agents, rules, and CLAUDE.md via Git with LLM-powered semantic merge.
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
+- [Portable Handoff](https://github.com/legoambarish/portable-handoff) — Local-first CLI and Markdown/JSON capsule format for carrying coding-agent session context between chats and tools. No API key, no server, standard-library-only Python.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks
 - [lyra](./plugins/lyra)


### PR DESCRIPTION
Adds Portable Handoff next to claude-recap and tree-ring-memory: a local-first CLI and Markdown/JSON capsule format for carrying coding-agent session context (goal, decisions, corrections, next action) between chats and tools \u2014 Claude Code, Codex, Cursor. Standard-library-only Python, no server, no account, no API key.