### PR TITLE
Add awesome-claude-code-hooks link

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 - [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
 
 ## Resources
+- [awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) - A curated list of hooks for Claude Code.
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.
 
 ## Tutorials


### PR DESCRIPTION
Adds a link to https://github.com/loqimean/awesome-claude-code-hooks in the Resources section, a curated list of hooks for Claude Code.