### PR TITLE
Add CommitLore

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [CommitLore](https://github.com/MongLong0214/commitlore) — Git-native decision memory MCP server for coding agents. Stores constraints and already-ruled-out alternatives as ordinary git trailers and refs/notes; returns only the records still in force for the file being edited. Works with Cursor, Windsurf, Gemini CLI, and opencode.
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)
@@ -394,6 +395,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
+| [commitlore](https://github.com/MongLong0214/commitlore) | Git-native decision memory for coding agents; stores constraints and ruled-out alternatives as git trailers and refs/notes, no hosted backend or vector database | `/plugin marketplace add MongLong0214/commitlore` then `/plugin install commitlore@commitlore` |
 
 
 ### Skills & Frameworks


### PR DESCRIPTION
Adds CommitLore to the MCP Servers list and the External Marketplaces table. CommitLore is a git-native decision memory tool for coding agents that stores constraints and ruled-out alternatives as ordinary git trailers and refs/notes, with no hosted backend.