### PR TITLE
Add Pocket Drives to MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [Pocket Drives](https://github.com/RevList/pocket-drives-mcp) — Search peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Remote MCP `https://pocketdrives.ai/mcp`.
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)


### PR DESCRIPTION
Adds Pocket Drives under MCP Servers, after AgentIQ / MoltAd and before Thinking & Knowledge Management.

Pocket Drives is a remote MCP for searching peer-to-peer luxury, exotic, and EV rentals from independent hosts. Booking finishes in the iOS app. Streamable HTTP at https://pocketdrives.ai/mcp. Listing repo: https://github.com/RevList/pocket-drives-mcp. Official registry: `ai.pocketdrives/pocket-drives`.

Same shape as other remote MCP rows already in this section (e.g. Lobex).

PocketList Inc builds the platform. Hosts are independent operators (not a Pocket-owned fleet).