### PR TITLE
Add seo-check to Marketing Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [social-vision](./plugins/social-vision)
 - [x-skills](https://github.com/sergebulaev/x-skills)
 - [yaohe](./plugins/yaohe)
+- [seo-check](https://github.com/AnTIdoTe003/claude-seo-check) - Pre-commit SEO audit plugin: static diff check for regressions (noindex, robots.txt, canonicals, redirects, JSON-LD) plus a zero-dependency Googlebot crawl of the affected routes, with a commit verdict
 
 ### Project & Product Management
 - [bleu](https://github.com/Nirvaan05/Bleu-plugin)


### PR DESCRIPTION
Adds **seo-check** — an MIT-licensed pre-commit SEO audit skill/plugin for Claude Code.

- Repo: https://github.com/AnTIdoTe003/claude-seo-check · Homepage: https://antidote003.github.io/claude-seo-check/
- What it does: `/seo-check` scopes `git diff` to SEO-relevant files, checks the diff against a severity-ranked regression checklist (`noindex`, robots.txt `Disallow`, deleted routes without redirects, canonicals, JSON-LD validity, `'use client'` moving content out of the initial HTML…), then crawls the affected routes from the dev server with a Googlebot UA and reports a ✅/⚠️/❌ commit verdict. `--compare <prod-origin>` diffs every signal local vs production.
- More than a SKILL.md: a zero-dependency Node crawler (`crawl.mjs`, usable standalone with exit codes for git hooks/CI), a reference checklist, and a 31-assertion test suite on Node 18/20/22.
- Installs as a plugin (`/plugin marketplace add AnTIdoTe003/claude-seo-check`) or as a personal skill.

Disclosure: I am the author, and this PR was prepared with Claude Code's help. Happy to adjust wording or placement.