### PR TITLE
Add deja-vu to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)
+- [deja-vu](https://github.com/vshulcz/deja-vu) — Local memory over the session files 20 coding agents already write to disk, including the months before you installed it. Search, auto-recall on every prompt, MCP tools, no network calls. Install: `/plugin marketplace add vshulcz/deja-vu`
 
 ## External Marketplaces
 


### PR DESCRIPTION
deja-vu indexes the session files that 20 coding agents already write to disk, so a new session can search what you did before — including the months before you installed it. Ships hooks, MCP tools and a skill; one Go binary, no network calls, MIT.

Installs as a marketplace: /plugin marketplace add vshulcz/deja-vu