### PR TITLE
Add competitive-intel to Business Sales

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 ### Business Sales
 - [Drevon](https://drevon.dev) - Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel.
 - [b2b-project-shipper](./plugins/b2b-project-shipper)
+- [competitive-intel](https://github.com/kaordones/competitive-intel-plugin) - Turns research on one competitor into three linked sales documents: a sourced deep-dive, a 2–3 page battlecard, and a one-page PDF for live calls. The one-pager is generated from the battlecard, so the two can't drift apart. Industry-agnostic; the build flags unhedged claims about competitors and undated review quotes.
 - [customer-success-manager](./plugins/customer-success-manager)
 - [enterprise-onboarding-specialist](./plugins/enterprise-onboarding-specialist)
 - [finance-tracker](./plugins/finance-tracker)


### PR DESCRIPTION
Adds [competitive-intel](https://github.com/kaordones/competitive-intel-plugin) to Business Sales, in alphabetical position within the section. One line added, no other changes.

It turns one research pass on a competitor into three linked sales documents: a sourced deep-dive, a 2-3 page battlecard, and a one-page PDF for live calls. The one-pager is generated from the battlecard's own content file, so the two can't drift apart and contradict each other in front of a customer.

MIT licensed, four skills, tested in both Claude Code and Cowork. Industry-agnostic: a one-time setup interview captures your own company, so nothing in the format assumes a category. The build also reviews what you wrote and flags unhedged denials about a competitor, judgement words, and undated review quotes.