### PR TITLE
Add aeoptimize to Marketing Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [update-branch-name](./plugins/update-branch-name)
 
 ### Marketing Growth
+- [aeoptimize](https://github.com/cucuwang/aeoptimize) - Deterministic content-readiness lint and Claude Code skills for static sites and documentation, without ranking or citation predictions.
 - [app-store-optimizer](./plugins/app-store-optimizer)
 - [claude-rank](https://github.com/Houseofmvps/claude-rank) - SEO/GEO/AEO audit with 170+ rules, auto-fix for robots.txt/sitemap.xml/llms.txt/JSON-LD
 - [content-creator](./plugins/content-creator)


### PR DESCRIPTION
## Summary

Add aeoptimize to the Marketing Growth section as an external Claude Code plugin.

## Why it fits

- provides three Claude Code skills for scanning, proposing discovery artifacts, and evidence-bounded content edits
- runs deterministic content-readiness checks for static sites and documentation
- explicitly avoids ranking, indexing, and citation predictions
- open source under the MIT license

## Verification

- repository is public
- Claude plugin validation passes
- npx skills add cucuwang/aeoptimize --list detects all three skills