### PR TITLE
Add kindle-highlights to Thinking & Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
 
 ### Thinking & Knowledge Management
+- [kindle-highlights](https://github.com/l3a0/claude-plugins) — Export every Kindle highlight for a book to one verbatim, location-cited Markdown file, recovering the highlights Amazon's export limit truncates or hides (macOS).
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)
 
 ### Companion Apps & Tools


### PR DESCRIPTION
Adds [l3a0/claude-plugins](https://github.com/l3a0/claude-plugins) — a plugin whose kindle-highlights skill exports every Kindle highlight for a book into one verbatim, location-cited Markdown file, including the highlights Amazon's export limit truncates or hides (recovered from the Mac Kindle app's synced annotation positions plus the Cloud Reader's rendered pages).

- MIT licensed, macOS only (stated up front in the README)
- Proven on four real books: 2,432 highlights, 815 export-blocked, all recovered
- Install: `claude plugin marketplace add l3a0/claude-plugins` then `claude plugin install l3a0@l3a0`

Entry follows the section's existing format and is placed alphabetically.