### PR TITLE
Add punchcard to Code Quality Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [adamsreview](./plugins/adamsreview)
 - [slicewise](./plugins/slicewise)
 - [bullpen](./plugins/bullpen)
+- [punchcard](https://github.com/Maksim-Burtsev/punchcard) - Architecture-level code review for your working tree, a branch, or a GitHub PR / GitLab MR. Three search subagents plus a judge that verifies findings by executing the code; every finding cites one of 78 principles distilled from 30 classic software books. Never comments on naming or formatting.
 
 ### Communication & Integrations
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.


### PR DESCRIPTION
I'd like to add my plugin, [punchcard](https://github.com/Maksim-Burtsev/punchcard) (MIT, v1.2.0), to the Code Quality Testing section.

It does architecture-level code review — module boundaries, dependency direction, data model, error paths — and deliberately never comments on naming or formatting. Two commands: `/punchcard` reviews the working tree, a branch, or a PR URL, and `/punchcard:pr` reviews a GitHub PR or GitLab MR and posts the review into it, keeping a single review updated in place per PR.

Two things make it different from the usual reviewer plugin:

- Judgement comes from a "constitution" of 78 principles distilled from 30 classic software books, and every finding cites one, so the review argues from a stated rule instead of taste.
- Three independent search subagents find candidates, then a judge verifies them by actually executing main and the PR, which drops most of the noise. I benchmarked it against Claude Code's built-in `/code-review` on real PRs; the runs are in `benchmarks/` in the repo.

Install: `/plugin marketplace add Maksim-Burtsev/punchcard` then `/plugin install punchcard@punchcard`. It's also an Agent Skills-standard skill for other harnesses via `npx skills add Maksim-Burtsev/punchcard`.