### PR TITLE
Add Worklittle Jobs MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-safety-preflight](./plugins/agent-safety-preflight)
 
 ### MCP Servers
-- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) — Swipe to apply for jobs in your AI app, and search over 4 million jobs with filters like visa status, distance, and salary, and connect your Worklittle account to save jobs you love.. Remote MCP `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`.
+- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) — Swipe to apply for jobs in your AI app, and search over 4 million jobs with filters like visa status, distance, and salary, and connect your Worklittle account to save jobs you love. Remote MCP `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) — Local-first Work Model MCP server and Claude Code/Codex/OpenCode plugin. Tools: `acc_retrieve`, `acc_act`; official registry `io.github.maxbaluev/accint`.
 - [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`

--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-safety-preflight](./plugins/agent-safety-preflight)
 
 ### MCP Servers
-- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) — Search over 4 million jobs with visa, salary, and distance filters. Remote MCP `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`.
+- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) — Swipe to apply for jobs in your AI app, and search over 4 million jobs with filters like visa status, distance, and salary, and connect your Worklittle account to save jobs you love.. Remote MCP `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) — Local-first Work Model MCP server and Claude Code/Codex/OpenCode plugin. Tools: `acc_retrieve`, `acc_act`; official registry `io.github.maxbaluev/accint`.
 - [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-safety-preflight](./plugins/agent-safety-preflight)
 
 ### MCP Servers
+- [Worklittle Jobs](https://github.com/worklittle/jobs-mcp) — Search over 4 million jobs with visa, salary, and distance filters. Remote MCP `https://mcp.worklittle.com/`. Official registry `io.github.worklittle/jobs`.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) — Local-first Work Model MCP server and Claude Code/Codex/OpenCode plugin. Tools: `acc_retrieve`, `acc_act`; official registry `io.github.maxbaluev/accint`.
 - [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`


### PR DESCRIPTION
Add Worklittle Jobs under MCP Servers.

- Remote MCP: https://mcp.worklittle.com/
- Source: https://github.com/worklittle/jobs-mcp
- Official registry: io.github.worklittle/jobs
- Docs: https://docs.worklittle.com/mcp
- Support: support@worklittle.com

Search over 4 million jobs with visa, salary, and distance filters, swipe to apply in your AI app, and save roles to a Worklittle account.


Made with [Cursor](https://cursor.com)