### PR TITLE
docs: add capcut-cli to Audio & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Audio & Media
 - [bibigpt-skill](https://github.com/JimmyLv/bibigpt-skill) - AI-powered video, audio & podcast summarization
+- [capcut-cli](https://github.com/renezander030/capcut-cli) - Claude Code plugin and zero-dependency CLI for editing local CapCut/JianYing drafts — subtitles, timing, effects, templates, and long-form-to-shorts
 
 ### Design UX
 - [brand-guardian](./plugins/brand-guardian)


### PR DESCRIPTION
## Summary

Adds [capcut-cli](https://github.com/renezander030/capcut-cli) to **Audio & Media**.

The repository ships a Claude Code marketplace manifest and `capcut-edit` skill for deterministic local editing of CapCut/JianYing projects, including subtitles, timing, effects, templates, and long-form-to-shorts workflows. It uses local project files rather than an MCP or HTTP service.

Disclosure: I maintain capcut-cli.

## Validation

- one README entry only
- repository and plugin manifest verified live
- `git diff --check`