### PR TITLE
Add Mobile SSH to Companion Apps & Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
+- [Mobile SSH](https://mobile-ssh.github.io) — Android and iOS SSH client for running Claude Code on remote servers, with a tmux session manager and alerts when an agent needs input
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)


### PR DESCRIPTION
Adds **Mobile SSH** to `### Companion Apps & Tools`, directly after Onepilot — the same category of tool.

Mobile SSH is an Android and iOS SSH/SFTP/terminal client for running terminal coding agents (Claude Code, Codex) on remote servers from a phone. The Claude Code-specific part is **agent alerts**: when a remote agent is waiting on input, the app raises a phone notification (haptic/sound/notification), so a blocked agent doesn't sit idle unnoticed. It also ships a multi-server tmux session/window/pane manager, so you can attach to the session your agent is running in and answer it directly.

It integrates with Claude Code's documented Notification hooks (`agent_needs_input`, `agent_completed`) rather than scraping the terminal for a prompt string.

Website: https://mobile-ssh.github.io

Disclosure: I am the author. The app is free — no account, no cloud sync, no ads, no paid tier. Android is currently a Google Play closed test and iOS is a public TestFlight beta; both install links are on the site.

Single line added, matching the em-dash format and no-trailing-period style of the existing entry in that section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
