### PR TITLE
Add KERNEL to External Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
+| [ariaxhan/kernel-claude](https://github.com/ariaxhan/kernel-claude) | KERNEL: 27 skills and 10 agents for running Claude Code in auto mode inside enforced boundaries. PreToolUse hooks block destructive commands outright, irreversible operations need a one-time human token, high-consequence work is checked by a verifier agent that never saw the builder's reasoning, and an agentdb SQLite memory is recalled before acting so lessons survive the session. Loads in Codex too. MIT. | `claude plugin marketplace add ariaxhan/kernel-claude` then `claude plugin install kernel@kernel-marketplace` |
 
 
 ### Skills & Frameworks


### PR DESCRIPTION
## Summary

Adds one row to **External Marketplaces**: [ariaxhan/kernel-claude](https://github.com/ariaxhan/kernel-claude), a Claude Code plugin marketplace (also loadable by Codex) for running agents in auto mode inside enforced boundaries.

| | |
|---|---|
| Repo | https://github.com/ariaxhan/kernel-claude |
| Version | 9.5.2 |
| License | MIT |
| Contents | 27 skills, 10 agents, lifecycle hooks |
| Install | `claude plugin marketplace add ariaxhan/kernel-claude` then `claude plugin install kernel@kernel-marketplace` |

Auto mode removed the per-action prompt. KERNEL supplies what the prompt was meant to do: PreToolUse hooks that block destructive commands rather than warn about them, a one-time human token for irreversible operations, verifier agents that receive the diff but never the builder's reasoning, and an agentdb SQLite memory recalled before acting so a failure in one session is a blocked command in the next.

An agent deciding whether to install it can read the machine-readable summary at [llms.txt](https://github.com/ariaxhan/kernel-claude/blob/main/llms.txt), which also states the limits: the hooks are a tripwire, not a sandbox.

## Changes

- [x] One row appended to the External Marketplaces table
- [x] No other file touched
- [x] Format matches the existing row (Marketplace | Description | Install)

Maintainer: Aria Han ([@ariaxhan](https://github.com/ariaxhan))