### PR TITLE
Add problem-tree (brainstorming problem tracker)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)
+- [problem-tree](https://github.com/JimmyTsai55/problem-tree) - Keeps a live problem tree during brainstorming: sub-problems marked solved / in progress / needs decision / blocked, rendered as Mermaid in a Markdown handoff file that survives across sessions (install via `/plugin marketplace add JimmyTsai55/problem-tree`)
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone


### PR DESCRIPTION
Adds [problem-tree](https://github.com/JimmyTsai55/problem-tree) under Thinking & Knowledge Management.

A Claude Code plugin (skill + Stop hook) that maintains a Mermaid problem tree in a Markdown handoff file while brainstorming — nodes marked solved / in progress / needs decision / blocked, with a status line (progress, current node, next action). Built as a companion to superpowers' brainstorming skill to stop long sessions from losing the thread. MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)