### PR TITLE
Add kettle (Audio & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Audio & Media
 - [bibigpt-skill](https://github.com/JimmyLv/bibigpt-skill) - AI-powered video, audio & podcast summarization
+- [kettle](https://github.com/ChiHanLu/kettle) - Put the kettle on and walk away. Sound cues for Claude Code hook events: it finished, it needs permission, it's been waiting on you — and when the turn **died** on an API error (rate limit / overload), which from across the room looks exactly like still working. 11 events each independently on/off, random pools, speech, quiet hours, custom audio. macOS/Windows/Linux, zero dependencies.
 
 ### Design UX
 - [brand-guardian](./plugins/brand-guardian)
@@ -217,7 +218,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [claude-bionify](./plugins/claude-bionify)
 
 ### Development Engineering
-- [claude-sounds](https://github.com/culminationAI/claude-sounds)
+- [kettle](https://github.com/ChiHanLu/kettle) - Put the kettle on and walk away. Sound cues for Claude Code hook events: it finished, it needs permission, it's been waiting on you — and when the turn **died** on an API error (rate limit / overload), which from across the room looks exactly like still working. 11 events each independently on/off, random pools, speech, quiet hours, custom audio. macOS/Windows/Linux, zero dependencies.
 - [ai-engineer](./plugins/ai-engineer)
 - [claw-army/claude-node](https://github.com/claw-army/claude-node) - Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json.
 - [api-integration-specialist](./plugins/api-integration-specialist)


### PR DESCRIPTION
Adds [kettle](https://github.com/ChiHanLu/kettle) under **Audio & Media**.

> Renamed from `claude-sounds` mid-review — the name was already taken in the official community directory. Same PR, one line, updated.

**Why another notification plugin:** I checked the `hooks.json` of all eleven sound/notification plugins currently in the community directory. Every one of them covers `Stop`; ten cover `Notification`. **Not one covers `StopFailure`** — the turn ending because the API rate-limited or overloaded you. A dead terminal looks exactly like a working one, which is the failure mode that actually costs you time.

- 11 hook events, each independently on/off: `Stop`, `Notification:permission_prompt`, `Notification:idle_prompt`, `SubagentStop`, `StopFailure`, `PostToolUseFailure`, `PermissionDenied`, `PreCompact`, `SessionStart`, `SessionEnd`, `TaskCompleted`
- macOS / Windows / Linux, **zero dependencies** — only the audio player the OS already ships
- Portable sound aliases so one config works on any machine; drop your own files in `~/.claude/kettle/sounds/`
- Random pools, per-event volume, speech, quiet hours
- Installs **silent** — nothing plays until `/kettle on`
- Playback is detached, hot path ~30 ms, so blocking hooks like `Stop` never stall a turn
- MIT · `claude plugin validate` clean · CI selftests on ubuntu/macos/windows · README in English / 繁體中文 / 简体中文
- Demo video with actual sound in the README

One line added, nothing else touched.