### PR TITLE
Add Azdaja marketplace

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -231,6 +231,7 @@
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — 面向 Claude Code 的 AI 模型定价与推荐 MCP 服务器，帮助为每项任务选择最合适、性价比最高的模型。数据经交叉验证，每 4 小时更新一次。MCP 端点：`https://whichmodel.dev/mcp`
 
 ## 插件市场
+- [Azdaja](https://github.com/kubet/azdaja) —— 面向 Claude Code 的大输入分析插件市场，提供本地评估器、受限模型提示、类型化输出与哈希绑定收据。安装：`claude plugin marketplace add kubet/azdaja`，然后运行 `claude plugin install azdaja@azdaja`。
 - [protonium](https://github.com/protonium-labs/protonium-marketplace) —— AI 智能体与效率工具。包含 **AxiomCore**：项目与日常事务管理智能体，提供强制化结构（编号目录、任务 ID、wiki 记忆）、计划 → 确认 → 执行工作流，支持敏捷或 WBS 方式创建项目.
 
 ## 使用教程

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
+| [kubet/azdaja](https://github.com/kubet/azdaja) | Bounded large-input analysis with a local evaluator, agent skills, typed outputs, and hash-bound receipts | `claude plugin marketplace add kubet/azdaja` then `claude plugin install azdaja@azdaja` |
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
 
 


### PR DESCRIPTION
## Summary

Adds Azdaja to the external marketplace sections in the English and Chinese READMEs.

Azdaja is a Claude Code plugin marketplace for bounded analysis over large inputs with a local evaluator, agent skill, typed outputs, and hash-bound receipts.

## Validation

- Public marketplace install: `claude plugin marketplace add kubet/azdaja`
- Public plugin install: `claude plugin install azdaja@azdaja`
- Release: https://github.com/kubet/azdaja/releases/tag/v0.1.13
- Receipts: https://github.com/kubet/azdaja/blob/main/BENCHMARKS.md