### PR TITLE
Add Screenpipe MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-safety-preflight](./plugins/agent-safety-preflight)
 
 ### MCP Servers
+- [Screenpipe MCP](https://github.com/screenpipe/screenpipe/tree/main/packages/screenpipe-mcp) — Gives Claude Code searchable access to locally recorded screen, audio, meetings, and UI context.
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) — Local-first Work Model MCP server and Claude Code/Codex/OpenCode plugin. Tools: `acc_retrieve`, `acc_act`; official registry `io.github.maxbaluev/accint`.
 - [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`


### PR DESCRIPTION
Adds Screenpipe MCP to the existing MCP Servers section. It gives Claude Code searchable access to locally recorded screen, audio, meeting, and UI context.

Disclosure: I maintain Screenpipe. I linked the implementation directly and kept the description factual. Thank you for considering it; I am happy to adjust or close the PR if it is not a fit.