### PR TITLE
Add ai-study-kit to Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
 
 ### Knowledge Management
+- [ai-study-kit](https://github.com/jerryjiao/ai-study-kit) — Turn any topic into a learning-loop quiz site: courses, Anki-compatible spaced-repetition flashcards, wrong-answer deep dives, and cross-device progress sync. Bundled site snapshot bootstraps with zero clone; the /ai-study-kit skill coaches the full study workflow.
 - [bedrock](./plugins/bedrock)
 
 ## External Marketplaces


### PR DESCRIPTION
Adds [ai-study-kit](https://github.com/jerryjiao/ai-study-kit) — an open-source study kit that turns any topic into a learning-loop quiz site (courses, Anki-compatible spaced-repetition flashcards, wrong-answer deep dives, cross-device progress sync, UI in 4 languages).

Ships as a Claude Code / zcode plugin with a bundled site snapshot: `/plugin marketplace add jerryjiao/ai-study-kit`, then the `/ai-study-kit` skill bootstraps a buildable quiz site with zero clone (v0.7.0, MIT).

中文简介：ai-study-kit——把任意主题变成学习闭环答题站的开源套件（课程 + 间隔重复闪卡 + 错题精讲 + 跨设备进度），以 Claude Code / zcode 插件分发，自带站点快照零 clone 建站。