### PR TITLE
Add godmode to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [godmode](https://github.com/arbazkhan971/godmode) - Discipline layer for Claude Code: 135 skills and 7 subagents in a measure → modify → verify → keep/revert loop - every change is tested, kept only if it improves, reverted automatically otherwise. Also runs on Codex, Cursor, Gemini CLI, OpenCode, Amp, and pi.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.


### PR DESCRIPTION
Adds `godmode` to the **Workflow Orchestration** section.

godmode is a discipline-layer skill plugin for Claude Code that ships 135 skills and 7 subagents. Its core loop is measure → modify → verify → keep/revert, so every change is backed by evidence and failed experiments are reverted. It also runs on Codex, Cursor, Gemini CLI, OpenCode, Amp, and pi via adapters.

- Repo: https://github.com/arbazkhan971/godmode
- Release: https://github.com/arbazkhan971/godmode/releases/tag/v2.0.0
- License: MIT

I am the author. Entry follows the existing section format - happy to adjust placement or wording.
