### PR TITLE
Add claude-code-sdlc plugin (Workflow Orchestration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [claude-code-sdlc](https://github.com/Koroqe/claude-code-sdlc) - Documentation-first SDLC pipeline: 16 role-specialized agents (PRD, use cases, architecture, QA, planning, review), TDD slices executed in parallel waves, and 9 pre-merge quality gates. MIT.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.


### PR DESCRIPTION
Adds [claude-code-sdlc](https://github.com/Koroqe/claude-code-sdlc) to the Workflow Orchestration section.

It is an MIT-licensed Claude Code plugin that turns Claude Code into a documentation-first development pipeline: 16 role-specialized agents (PRD writer, BA analyst, architect, QA planner, tech-lead planner, plan critic, test writer, reviewers, verifier, and others), TDD slices executed in parallel waves, and 9 pre-merge quality gates.

Disclosure: I am the author of the plugin. One line added to README.md; nothing else touched.