### PR TITLE
Add hivemind to External Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
+| [Hanishchow/hivemind](https://github.com/Hanishchow/hivemind) | hivemind plugin: delegate mechanical work to headless [opencode](https://opencode.ai) worker swarms on free models while Claude Code stays the planner and reviewer. Git-worktree isolation per writing worker, one-JSON-line worker contract so raw agent output never enters the orchestrator's context, and slash commands for parallel review, research sweeps, migrations and test fleets (`/hive`, `/oc`, `/swarm`, `/review-panel`, `/research-sweep`, `/migration`, `/test-fleet`) | `claude plugin marketplace add Hanishchow/hivemind` then `claude plugin install hivemind@hivemind` |
 
 
 ### Skills & Frameworks


### PR DESCRIPTION
Adds **hivemind** to the External Marketplaces table.

## What it is

A Claude Code plugin marketplace for delegating mechanical work to headless [opencode](https://opencode.ai) worker swarms running on free models, while Claude Code stays the planner, reviewer, and merger.

The design constraint is containment rather than parallelism:

- **One-JSON-line worker contract** — every worker returns exactly `{ok, result, tokens, cost_usd, duration_ms}`. Raw agent streams never enter the orchestrator's context, which is the whole point.
- **Git-worktree isolation** — every writing worker gets its own worktree, so concurrent agents can't corrupt each other's diffs.
- **Explicit fallback ladder** — worker fails, retry once; fails again, the orchestrator does that subtask itself; backend down, abandon the swarm and do the task directly. A swarm should never fail a task one agent could have finished.

Ships seven slash commands: `/hive` (auto-router), `/oc`, `/swarm`, `/review-panel`, `/research-sweep`, `/migration`, `/test-fleet`, plus scout / coder / tester worker personas.

## Install

```
claude plugin marketplace add Hanishchow/hivemind
claude plugin install hivemind@hivemind
```

Verified against the repo's `.claude-plugin/marketplace.json` — marketplace `hivemind`, plugin `hivemind`, skill at `./skills/hivemind`.

## Notes

- Apache-2.0.
- It wraps the third-party `opencode` CLI, and the free tier belongs to opencode rather than Anthropic — both stated up front in a Prerequisites section rather than buried, along with a warning not to delegate secrets, since worker traffic leaves for opencode's endpoints.
- The same skill was merged into [alirezarezvani/claude-skills#979](https://github.com/alirezarezvani/claude-skills/pull/979).

One row, matching the existing table format and install-command style. Happy to move it to the `Marketplaces` list or `Skills & Frameworks` instead if that's a better fit.
