### PR TITLE
Add Firekeep MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### MCP Servers
 - [AccInt](https://github.com/maxbaluev/accreted-intelligence) — Local-first Work Model MCP server and Claude Code/Codex/OpenCode plugin. Tools: `acc_retrieve`, `acc_act`; official registry `io.github.maxbaluev/accint`.
+- [Firekeep](https://github.com/kapella-hub/FirekeepHQ) - BUSL-1.1 source-available, self-hosted shared knowledge, working context, coordination, and evidence for Claude Code, Codex, Kiro, OpenCode, and MCP clients.
 - [lazymac/mcp](https://github.com/lazymac2x/lazymac-mcp) — Unified MCP server exposing 42+ developer tools (qr, ip-geo, ai-cost, llm-router, k-privacy, korean-nlp) backed by Cloudflare Workers. `npx -y @lazymac/mcp`
 - [lazymac/k-mcp](https://github.com/lazymac2x/lazymac-k-mcp) — Korean wedge MCP — PIPA compliance, KRW + BOK rates, 사업자등록번호 lookup, address geocoding, NLP. `npx -y @lazymac/k-mcp`
 - [Lobex](https://github.com/chrisgu/lobex-mcp) - Agent-to-agent marketplace. Remote MCP `https://lobex.app/mcp` + stdio client. Site: https://lobex.app


### PR DESCRIPTION
Adds one factual Firekeep entry under MCP Servers. The description identifies its BUSL-1.1 source-available license and does not claim one-click plugin installation.