### PR TITLE
Add craftsman plugin (Code Quality Testing) + craftsman-marketplace

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -75,7 +75,7 @@
 - [bobusang](https://github.com/jun0-ds/bobusang) — Claude Code多设备记忆系统，通过git自动同步在Windows、WSL2和Linux之间同步上下文。
 - [magic-cc-codex-worker](./plugins/magic-cc-codex-worker)
 - [ai-meeting](./plugins/ai-meeting)
-- [craftsman](./plugins/craftsman)
+- [craftsman](https://github.com/gul-labs/craftsman-marketplace) — 面向 AI 生成应用的工程就绪度审计，覆盖十个领域（UX、前端、后端、数据库、安全、基础设施、可观测性、测试、Lint、AI 集成）。问题以通俗语言呈现并按实际后果排序，审计工作区支持中断续跑，配套修复技能无法自行将修复标记为已验证。安装：`claude plugin marketplace add gul-labs/craftsman-marketplace`
 - [rote](./plugins/rote)
 
 ### 自动化运维
@@ -116,6 +116,7 @@
 - [test-writer-fixer](./plugins/test-writer-fixer)
 - [unit-test-generator](./plugins/unit-test-generator)
 - [sonmat](https://github.com/jun0-ds/sonmat) — 验证纪律插件，六个反应轴（guard、inspect、witness、punch、devil's advocate、scribe）用于AI-人类协作。
+- [craftsman](https://github.com/gul-labs/craftsman-marketplace) - External: Engineering-readiness audit for AI-built apps across ten domains (UX, frontend, backend, database, security, infrastructure, observability, testing, lint, AI integrations). Plain-language findings ranked by consequence, a resumable audit workspace, and a companion fix skill that cannot mark its own repairs verified. Install: `claude plugin marketplace add gul-labs/craftsman-marketplace`
 
 ### 数据分析
 - [analytics-reporter](./plugins/analytics-reporter)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [adamsreview](./plugins/adamsreview)
 - [slicewise](./plugins/slicewise)
 - [bullpen](./plugins/bullpen)
+- [craftsman](https://github.com/gul-labs/craftsman-marketplace) - External: Engineering-readiness audit for AI-built apps across ten domains (UX, frontend, backend, database, security, infrastructure, observability, testing, lint, AI integrations). Plain-language findings ranked by consequence, a resumable audit workspace, and a companion fix skill that cannot mark its own repairs verified. Install: `claude plugin marketplace add gul-labs/craftsman-marketplace`
 
 ### Communication & Integrations
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.
@@ -394,6 +395,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
+| [gul-labs/craftsman-marketplace](https://github.com/gul-labs/craftsman-marketplace) | craftsman plugin: engineering-readiness audits for AI-built apps across ten domains, with plain-language findings ranked by consequence and a resumable audit workspace | `claude plugin marketplace add gul-labs/craftsman-marketplace` then `claude plugin install craftsman@craftsman-marketplace` |
 
 
 ### Skills & Frameworks


### PR DESCRIPTION
Adds `craftsman` to **Code Quality Testing** in both READMEs, and `gul-labs/craftsman-marketplace` to the **External Marketplaces** table.

**What it is:** an engineering-readiness audit for apps built with Lovable, Replit, Bolt, v0, Claude Code, or Codex. `craft-audit` reviews a whole project across ten domains (UX, frontend, backend, database, security, infrastructure, observability, testing, lint, AI integrations), writes plain-language findings ranked by real consequence into a resumable `.craftsman/` workspace, and the companion `craft-fix` skill is not permitted to mark its own repairs verified -- only a fresh audit pass can.

**Why README-only, no `marketplace.json` entry:** the plugin lives at `plugins/craftsman` inside a marketplace repo, and the `github` plugin source has no subdirectory option, so a `marketplace.json` entry could not resolve. It installs via its own marketplace instead, so I followed the existing external-entry pattern (`vibe-guard`, `think-first`, `sonmat`, `tailtest`, `sdlc-wizard`) rather than adding an entry that would break.

- 12 skills, MIT, no telemetry or network calls
- Install: `claude plugin marketplace add gul-labs/craftsman-marketplace` then `claude plugin install craftsman@craftsman-marketplace`

Happy to adjust the category, wording, or drop either placement.