### PR TITLE
Add VASTlint MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [VASTlint](https://github.com/aleksUIX/vastlint) — Validate VAST, VMAP, and DAAST ad tags against IAB specs. Remote MCP `https://vastlint.org/mcp` (auth none) or `cargo install vastlint-mcp`. Registry `io.github.aleksUIX/vastlint`.
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)


### PR DESCRIPTION
## Summary
- Add [VASTlint](https://github.com/aleksUIX/vastlint) to MCP Servers.
- Remote MCP `https://vastlint.org/mcp` (auth none). Local: `cargo install vastlint-mcp`. Registry `io.github.aleksUIX/vastlint`.

## Test plan
- [ ] Repo link works
- [ ] `claude mcp add --transport http vastlint https://vastlint.org/mcp` connects without OAuth