### PR TITLE
Add trailhead to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [trailhead](https://github.com/ToRvaLDz/trailhead) - Run a large project as a map of decision tickets on GitHub Issues, resolved one at a time by a discuss → plan → execute → verify engine with atomic commits, subagent techniques, and cross-session handoffs. Self-contained, runs on Claude Code and Codex CLI.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.


### PR DESCRIPTION
Adds **trailhead** to the Workflow Orchestration section.

[trailhead](https://github.com/ToRvaLDz/trailhead) runs a large project as a map of decision tickets on GitHub Issues, resolved one at a time by a discuss → plan → execute → verify engine with atomic commits. Plans get an optional cross-AI review (the PLAN is sent to other AI CLIs on your PATH, excluding the host's own model), and UI tickets start from a throwaway prototype before UI code. It is self-contained (no external-plugin dependencies) and runs on both Claude Code (as a plugin) and Codex CLI from a single source.

- Repo: https://github.com/ToRvaLDz/trailhead
- License: MIT
- Single one-line entry, appended to the Workflow Orchestration list, matching the existing entry format (no emoji).