### PR TITLE
Add claude-skills-pro — 15 engineering-workflow skills (7 free/MIT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,8 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ### Skills & Frameworks
 - [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
+- [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) — 15 engineering-workflow skills (7-dimension code review, bug-catching test generation, root-cause debugging, security audit, behavior-preserving refactor; 7 free/MIT) with a Chinese handbook and 15-row scenario lookup table. Install: `npx skills add Hahaknight/claude-skills-pro`
+
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.


### PR DESCRIPTION
Adds [claude-skills-pro](https://github.com/Hahaknight/claude-skills-pro) to **Skills & Frameworks**.

15 engineering-workflow skills — 7-dimension code review, bug-catching test generation, root-cause debugging, security audit, behavior-preserving refactor, API design, zero-downtime DB migration; 7 free/MIT, 8 in the Pro pack (ships with a Chinese handbook + scenario lookup table).

Install path verified end-to-end in 6 agent CLIs (Claude Code / Codex / Gemini CLI / Goose / Crush / Qwen Code):

```
npx skills add Hahaknight/claude-skills-pro
```

Real output samples in [EXAMPLES.md](https://github.com/Hahaknight/claude-skills-pro/blob/main/EXAMPLES.md).