### PR TITLE
Add breather

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [angelos-symbo](./plugins/angelos-symbo)
 - [artel](https://github.com/NicolasPrimeau/artel) - Infrastructure for AI teams: shared semantic memory, tasks, agent-to-agent messages, and session handoffs across machines and LLM providers.
 - **[claude-brain](https://github.com/toroleapinc/claude-brain)** — Sync and evolve your Claude Code brain across machines. Auto-syncs memory, skills, agents, rules, and CLAUDE.md via Git with LLM-powered semantic merge.
+- [breather](https://github.com/ilandahan/breather) - Presence tracking across every session, a rest countdown in the status line, and a written handoff at safe stopping points. Node stdlib only, no dependencies.
 - [ceo-quality-controller-agent](./plugins/ceo-quality-controller-agent)
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)


### PR DESCRIPTION
Adds [breather](https://github.com/ilandahan/breather).

**What it does:** tracks how long the user has actually been present across every Claude Code session on the machine, with idle gaps over 20 minutes removed, and at safe boundaries — tests green, a commit, a question resolved — offers a stopping point with a written handoff, so the context does not die with the session.

**Why it fits this list:** it improves the experience of Claude Code itself and requires no external service — no API to call, no account, no server of mine in the path. One file, Node stdlib only, nothing fetched at runtime.

**Checklist**
- MIT licensed
- `SKILL.md` with `name` and `description` frontmatter at `skills/breather/SKILL.md`
- Installable as a Claude Code plugin; `claude plugin validate` passes
- No dependencies, no telemetry, no network calls at runtime
- Installer behaviour covered by tests against a throwaway home; CI on Linux, macOS and Windows
- One entry added, existing section formatting and alphabetical order followed