### PR TITLE
Add qualflare (Code Quality Testing)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2316,6 +2316,36 @@
         "tokens",
         "audit"
       ]
+    },
+    {
+      "name": "qualflare",
+      "displayName": "Qualflare",
+      "source": {
+        "source": "github",
+        "repo": "Qualflare/qualflare-claude-code"
+      },
+      "description": "Generates tests for the code Claude just changed, runs the suite, fixes what breaks, and reports results to Qualflare without leaving Claude Code.",
+      "version": "0.18.0",
+      "author": {
+        "name": "Qualflare",
+        "url": "https://github.com/Qualflare"
+      },
+      "category": "Code Quality Testing",
+      "homepage": "https://qualflare.com",
+      "repository": "https://github.com/Qualflare/qualflare-claude-code",
+      "license": "Apache-2.0",
+      "keywords": [
+        "testing",
+        "test-coverage",
+        "test-reporting",
+        "flaky-tests",
+        "ci"
+      ],
+      "tags": [
+        "testing",
+        "code-quality",
+        "ci"
+      ]
     }
   ]
 }

--- a/README-zh.md
+++ b/README-zh.md
@@ -116,6 +116,7 @@
 - [test-writer-fixer](./plugins/test-writer-fixer)
 - [unit-test-generator](./plugins/unit-test-generator)
 - [sonmat](https://github.com/jun0-ds/sonmat) — 验证纪律插件，六个反应轴（guard、inspect、witness、punch、devil's advocate、scribe）用于AI-人类协作。
+- [qualflare](https://github.com/Qualflare/qualflare-claude-code) — 为 Claude 刚修改的代码生成测试、运行测试套件、修复失败项，并将结果报告到 Qualflare，全程无需离开 Claude Code。
 
 ### 数据分析
 - [analytics-reporter](./plugins/analytics-reporter)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [adamsreview](./plugins/adamsreview)
 - [slicewise](./plugins/slicewise)
 - [bullpen](./plugins/bullpen)
+- [qualflare](https://github.com/Qualflare/qualflare-claude-code) - Generates tests for the code Claude just changed, runs the suite, fixes what breaks, and reports results to Qualflare without leaving Claude Code.
 
 ### Communication & Integrations
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.


### PR DESCRIPTION
Adds [qualflare](https://github.com/Qualflare/qualflare-claude-code) — a Claude Code plugin that generates tests for the code Claude just changed, runs the suite, fixes what breaks, and reports results to Qualflare.

Registered with an external `{"source": "github", "repo": ...}` entry rather than a vendored copy under `plugins/`, following `tree-ring-memory` and `trigger-tree`. That keeps this repo free of a duplicate that would drift as the plugin is updated, and users always install the current version.

Apache-2.0. Entry added to `marketplace.json`, `README.md` and `README-zh.md`; nothing under `plugins/` is touched.