### PR TITLE
Add FoundRole MCP server (job search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [FoundRole](https://github.com/foundrole/jobs-mcp-proxy) - Job search MCP server. Live job listings with salary, H-1B sponsorship, and ghost-job signals; resume ATS check; Kanban application tracker. Remote MCP `https://www.foundrole.com/mcp` + open-source stdio bridge. Site: https://www.foundrole.com/ai-search-mcp
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)


### PR DESCRIPTION
## What is FoundRole?

FoundRole is a free job search platform with built-in market analytics — live job listings pulled directly from company applicant tracking systems, with salary benchmarks, H-1B sponsorship history, E-Verify status, and a ghost-job trust grade on every posting.

## What makes it different

- Every listing carries data most boards don't expose: salary range, visa sponsorship history, and a ghost-job trust grade.
- Resume ATS check — see how a resume actually parses before a human sees it.
- Kanban application tracker with follow-up reminders and job alerts.
- Works from Claude, ChatGPT, Cursor, or any MCP client via a hosted remote MCP server (`https://www.foundrole.com/mcp`, OAuth 2.1 + PKCE, free account) or the open-source stdio bridge (`@foundrole/ai-job-search-mcp`, also in the official MCP Registry).

## Why MCP Servers

FoundRole ships a hosted remote MCP endpoint plus an open-source stdio bridge repo, matching the shape of the other hosted MCP entries in this section (e.g. Lobex, AgentIQ). It's a job-search data source an agent can query directly rather than a Claude Code plugin package.