### PR TITLE
Add suede-creator-skills; describe ios-app-dev-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
-- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 74 skills, 6 agents. A build DAG researches your repo, fans out disjoint lanes, and refutes its own review before anything lands; a blunt A-F ship grade blocks the bad merge. The same folder designs the page, writes the copy, and ships native iOS and Android. One skill argued Amazon out of $448.31.
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 74 skills, 6 agents. A build DAG researches your repo, fans out disjoint lanes, and refutes its own review before anything lands; a blunt A-F ship grade blocks the bad merge. The same folder designs the page, writes the copy, and ships native iOS and Android builds.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [suede-creator-skills](https://github.com/JasonColapietro/suede-creator-skills) - 74 skills, 6 agents. A build DAG researches your repo, fans out disjoint lanes, and refutes its own review before anything lands; a blunt A-F ship grade blocks the bad merge. The same folder designs the page, writes the copy, and ships native iOS and Android. One skill argued Amazon out of $448.31.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.
@@ -229,7 +230,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [enterprise-integrator-architect](./plugins/enterprise-integrator-architect)
 - [flutter-mobile-app-dev](./plugins/flutter-mobile-app-dev)
 - [frontend-developer](./plugins/frontend-developer)
-- [ios-app-dev-skills](https://github.com/JasonColapietro/ios-app-dev-skills)
+- [ios-app-dev-skills](https://github.com/JasonColapietro/ios-app-dev-skills) - Turn a website into an App Store-ready iOS app: 7 skills and 23 slash commands covering site audit, native SwiftUI or Capacitor shell, ASO and keywords, simulator screenshots, and an App Review release gate.
 - [mobile-app-builder](./plugins/mobile-app-builder)
 - [html-report](https://github.com/panhongwei/html-report)
 - [project-curator](./plugins/project-curator)


### PR DESCRIPTION
Two one-line README changes, no other files touched.

**1. New entry: suede-creator-skills (Workflow Orchestration)**

https://github.com/JasonColapietro/suede-creator-skills - public, 129 stars, 74 skills, 6 agents, v0.16.0. Homepage: https://skills.suedeai.ai/

Open-source agent skills for Claude Code and Codex. The pack's core is a build DAG that researches the repo, fans out disjoint lanes, and refutes its own review before a change lands, plus an A-F ship grade with instant-F triggers that blocks the merge. The same folder covers design, conversion copy, SEO/AEO, native iOS and Android shipping, and creator-rights tooling.

License: MIT AND BSD-3-Clause. Original work is MIT; `skills/suede-graph-flo-xr` adapts ETH Zurich's graph-of-thoughts and retains its BSD-3-Clause notice. Upstream notices are kept in `licenses/`.

Listed in the README only, matching how every other externally hosted repo in this list is handled (pro-workflow, Claude Forge, nexus-agents, dotforge). The repo does ship `.claude-plugin/marketplace.json` and `plugin.json`, so if you would rather have it installable from this marketplace as a `{"source": "github"}` entry the way tree-ring-memory and trigger-tree are, say the word and I will add it.

**2. Description for the existing ios-app-dev-skills entry**

That line went in via #273 with no description while every neighbor in Development Engineering has one. Filled it in from what the repo actually contains: 7 skills and 23 slash commands for site audit, native SwiftUI or Capacitor shell, ASO, simulator screenshots, and an App Review release gate. MIT.

Both edits are in README.md. README-zh.md is not updated, in line with recent external additions there.
