### PR TITLE
Add qqmail-cli (safety-first QQ Mail CLI skill plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [bullpen](./plugins/bullpen)
 
 ### Communication & Integrations
+- [qqmail-cli](https://github.com/situker/qqmail-cli) — Safety-first, unofficial QQ Mail / Foxmail CLI skill for AI agents; install via `/plugin marketplace add situker/qqmail-cli`. Read-only by default; every mailbox mutation is dry-run + human-gated, with a restore regret window and no permanent-delete command.
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.
 
 ### Data Analytics


### PR DESCRIPTION
Adds **qqmail-cli** under **Communication & Integrations** (alphabetical, before whatsapp). Single-line addition.

[situker/qqmail-cli](https://github.com/situker/qqmail-cli) is an open-source (Apache-2.0), unofficial QQ Mail / Foxmail CLI that ships a Claude skill and installs as a plugin marketplace:

```
/plugin marketplace add situker/qqmail-cli
/plugin install qqmail-cli@qqmail-cli
```

It lets Claude and other AI agents operate a QQ/Foxmail mailbox safely: read, search, triage, back up, and gated-cleanup over a stable JSON contract. Read-only by default; every server mutation is dry-run + human-gated (no bypass flag); no permanent-delete command (cleanup only moves to trash); a `restore` regret window; email content treated as untrusted (prompt-injection aware). Both `.claude-plugin/marketplace.json` and `plugin.json` pass `claude plugin validate --strict`.