### PR TITLE
Add where-am-i plugin to Development Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [thermal-fluid-research-workflow](./plugins/thermal-fluid-research-workflow)
 - [trigger-tree](https://github.com/Hedde/trigger_tree)
 
+- [where-am-i](https://github.com/list91/where-am-i) - Skill that answers "where am I in this code right now?" with one picture: 7 shapes, 40 words, your spot in colour.
+
 ### Git Workflow
 - [analyze-issue](./plugins/analyze-issue)
 - [bug-fix](./plugins/bug-fix)


### PR DESCRIPTION
Adds [where-am-i](https://github.com/list91/where-am-i) — a Claude Code skill/plugin: type `/wai` and it shows your spot in agent-written code as one picture (7 shapes, 40 words, your spot in colour, the rest collapsed).

Installable as a plugin: `/plugin marketplace add list91/where-am-i`. License: MIT.