### PR TITLE
Add Omen

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [Omen](https://github.com/panbanda/omen) — Code-health MCP server and Claude Code plugins (omen-development, omen-reporting): complexity, tech debt, dead code, churn hotspots, clones and a health score across ten languages. `brew install panbanda/brews/omen`
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)


### PR DESCRIPTION
Adds Omen to MCP Servers.

Omen is a Rust CLI and MCP server that measures code health for AI coding agents: cyclomatic and cognitive complexity, self-admitted tech debt, stubs, dead code, git churn and hotspots, clone detection, defect prediction, semantic search and a composite health score across Go, Rust, Python, TypeScript, JavaScript, Java, C, C++, C#, Ruby, PHP and Bash. It ships Claude Code plugins (omen-development, omen-reporting) and a GitHub Action for PR risk comments. Apache-2.0, released weekly, installs with Homebrew or Docker. https://github.com/panbanda/omen