### PR TITLE
Add claude-feedback-loops (Code Quality Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [adamsreview](./plugins/adamsreview)
 - [slicewise](./plugins/slicewise)
 - [bullpen](./plugins/bullpen)
+- [claude-feedback-loops](https://github.com/kirilklein/claude-feedback-loops) - Calibrates `/review` from human PR feedback, logs pipeline gaps in `/ship` and clusters them by root cause, and audits lessons on a confidence ladder. Five slash commands, three markdown files, no runtime.
 
 ### Communication & Integrations
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [adamsreview](./plugins/adamsreview)
 - [slicewise](./plugins/slicewise)
 - [bullpen](./plugins/bullpen)
-- [claude-feedback-loops](https://github.com/kirilklein/claude-feedback-loops) - Calibrates `/review` from human PR feedback, logs pipeline gaps in `/ship` and clusters them by root cause, and audits lessons on a confidence ladder. Five slash commands, three markdown files, no runtime.
+- [claude-feedback-loops](https://github.com/kirilklein/claude-feedback-loops) - Pipeline gap tracking: `/gap` logs one line each time CI, a bot or a human catches what an earlier stage missed, `/gaps` clusters by root cause and closes each at the cheapest layer. Fits any existing workflow via a `CLAUDE.md` snippet. Plus `/review` calibration from PR feedback. Markdown only, no runtime.
 
 ### Communication & Integrations
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.


### PR DESCRIPTION
Adds [claude-feedback-loops](https://github.com/kirilklein/claude-feedback-loops) to Code Quality Testing.

A plugin of five slash commands (`/retro`, `/review`, `/ship`, `/gaps`, `/promote`) that calibrates code review from human PR feedback, logs cases where a later pipeline step catches an earlier step's miss, and audits a lessons file on a confidence ladder. Plain markdown, no runtime. MIT.