### PR TITLE
Add YYLO to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [YYLO](https://github.com/yylo-dev/yylo) — Command-line orchestrator that runs coding agents (Claude Code, Codex, Gemini CLI) in parallel across isolated git worktrees, tracked on a Kanban board with review gates and typed merge/release flows. Install via npm (`@yylo/cli`).
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.


### PR DESCRIPTION
Adds **YYLO** to the Workflow Orchestration section — a command-line orchestrator that runs coding agents (Claude Code, Codex, Gemini CLI) in parallel across isolated git worktrees, tracked on a Kanban board with review gates and typed merge/release flows.

It sits alongside the other external orchestrator entries in that section (e.g. [nexus-agents](https://github.com/williamzujkowski/nexus-agents), [devforge-ai](https://github.com/saitarrun/devforge-ai)) with the same one-line README format, appended at the bottom of the section.

- Repo: https://github.com/yylo-dev/yylo (MIT, actively maintained)
- Install: `npm install -g @yylo/cli` (Node 20.10+)

Full disclosure: I maintain this project.