### PR TITLE
Add great-cto to Workflow Orchestration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -44,6 +44,29 @@
       ]
     },
     {
+      "name": "great-cto",
+      "source": {
+        "source": "github",
+        "repo": "avelikiy/great_cto"
+      },
+      "description": "Runs Claude Code as a pipeline of 71 specialist agents — architecture, product, implementation, QA, security, deploy — where an independent model checks each stage before the next begins, and human gates sit on whatever is expensive to undo.",
+      "version": "3.22.0",
+      "author": {
+        "name": "Alexander Velikiy",
+        "url": "https://github.com/avelikiy"
+      },
+      "category": "Workflow Orchestration",
+      "homepage": "https://greatcto.systems",
+      "keywords": [
+        "orchestration",
+        "pipeline",
+        "subagents",
+        "code-review",
+        "gates",
+        "cto"
+      ]
+    },
+    {
       "name": "lyra",
       "source": "./plugins/lyra",
       "description": "Lyra - a master-level AI prompt optimization specialist.",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -49,8 +49,8 @@
         "source": "github",
         "repo": "avelikiy/great_cto"
       },
-      "description": "Runs Claude Code as a pipeline of 71 specialist agents — architecture, product, implementation, QA, security, deploy — where an independent model checks each stage before the next begins, and human gates sit on whatever is expensive to undo.",
-      "version": "3.22.0",
+      "description": "Ships a spec-first pipeline whose report is trustworthy in the negative direction: a skipped stage, a review that never ran and an unmeasured cost each render as themselves and are never counted as a pass. Three approvals stay yours; spending caps refuse rather than warn.",
+      "version": "3.27.4",
       "author": {
         "name": "Alexander Velikiy",
         "url": "https://github.com/avelikiy"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks
-- [great-cto](https://github.com/avelikiy/great_cto) - Runs Claude Code as a pipeline of 71 specialist agents — architecture, product, implementation, QA, security, deploy — where an independent model checks each stage before the next begins, and human gates sit on whatever is expensive to undo.
+- [great-cto](https://github.com/avelikiy/great_cto) - Ships a spec-first pipeline whose report is trustworthy in the negative direction: a skipped stage, a review that never ran and an unmeasured cost each render as themselves and are never counted as a pass. Three approvals stay yours; spending caps refuse rather than warn.
 - [lyra](./plugins/lyra)
 - [magebyte-power](https://github.com/MageByte-Zero/magebyte-power) — Production-incident-distilled Claude Code skill: 7-phase workflow with 4-round AI cross-verification that catches concurrency & idempotency bugs before prod
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [claude-recap](https://github.com/hatawong/claude-recap) — Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local.
 - [claude-desktop-extension](./plugins/claude-desktop-extension)
 - [equilateral-agents](https://github.com/Equilateral-AI/equilateral-agents-open-core) - 22 self-learning agents with memory, security review, code quality, deployment validation, and infrastructure checks
+- [great-cto](https://github.com/avelikiy/great_cto) - Runs Claude Code as a pipeline of 71 specialist agents — architecture, product, implementation, QA, security, deploy — where an independent model checks each stage before the next begins, and human gates sit on whatever is expensive to undo.
 - [lyra](./plugins/lyra)
 - [magebyte-power](https://github.com/MageByte-Zero/magebyte-power) — Production-incident-distilled Claude Code skill: 7-phase workflow with 4-round AI cross-verification that catches concurrency & idempotency bugs before prod
 - [model-context-protocol-mcp-expert](./plugins/model-context-protocol-mcp-expert)


### PR DESCRIPTION
Adds **great-cto** — a Claude Code plugin that runs the tool as a pipeline of specialist agents instead of a single one: architecture, product, implementation, QA, security and deploy, with an independent model reviewing each stage before the next begins and human gates on the steps that are expensive to undo.

- **Repository:** https://github.com/avelikiy/great_cto (MIT)
- **npm:** `great-cto@3.22.0`
- **Docs:** https://greatcto.systems
- 71 agents · 44 commands · 39 skills

### On the `source` field

Listed with an external `source` — the same shape `tree-ring-memory` and `trigger-tree` use — rather than vendoring the plugin into `./plugins`. At 71 agents, 44 commands and 39 skills a copy here would be large, and it would drift from the upstream it was copied from. Happy to vendor it instead if that is preferred.

### Changes

- `README.md` — one row, inserted in the existing order of **Workflow Orchestration** without reordering the neighbouring entries
- `.claude-plugin/marketplace.json` — one entry, category `Workflow Orchestration`