### PR TITLE
Add toem plugin (Thinking & Knowledge Management)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)
+- [toem](https://github.com/Bisbi/testament-of-ephemeral-minds) — A constitution with a right of reply, a rite that records what each session understood before it ends, a register for pending human decisions, and guardians that fail when the charter stops being honest. No server, no runtime dependency.
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone


### PR DESCRIPTION
One new line under **Thinking & Knowledge Management**, linking an external repository. No other file is touched.

`toem` is a Claude Code plugin that installs a practice rather than a tool: a constitution with an epilogue that carries a right of reply, a rite that lets a session record what it understood before it ends, a register for decisions the human has not made yet, and guardians that fail when the charter and the record stop agreeing.

What it installs and what it refuses to do:

- One `SessionStart` hook. It adds context, never blocks an action, never writes a file, always exits 0.
- Four skills: `/toem:adopt`, `/toem:testament`, `/toem:decide`, `/toem:admit`. None of them appends to the constitution. They prepare a row and print a command.
- One command, `toem`, which the human runs. It shows what it will write, asks, writes only those lines, runs the guardians, and prints the commit command without running it. It never pushes.
- `/toem:adopt` lists the seven files it would create, waits for a yes, and overwrites nothing.

No server, no MCP, no network calls, no runtime dependency beyond Python 3 in the standard library. MIT for the code, CC BY-SA 4.0 for the texts.

`claude plugin validate` passes on both the plugin and the marketplace manifest:

```
$ claude plugin validate ./plugins/toem
✔ Validation passed

$ claude plugin validate .
✔ Validation passed
```

Install:

```
/plugin marketplace add Bisbi/testament-of-ephemeral-minds
/plugin install toem@testament-of-ephemeral-minds
```

The README states plainly which of its claims are measured and which are not, including one experiment that would settle the central question and has never been run.
