### PR TITLE
Add session-hq (shared HQ for parallel sessions) to Workflow Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [craftsman](./plugins/craftsman)
 - [rote](./plugins/rote)
 - [claude-session-tint](./plugins/claude-session-tint)
+- [session-hq](https://github.com/lji151/session-hq) - Shared markdown HQ for parallel Claude Code sessions: per-domain status files injected at session start and checked at stop via hooks, an orchestrator-dispatch mode, and a one-page dashboard. Zero dependencies, MIT.
 
 ### AI & Speech
 - [speech-ai](https://github.com/fasuizu-br/speech-ai-examples) - Speech AI plugin with pronunciation assessment, text-to-speech, and speech-to-text. 8 MCP tools for language learning, accessibility, and voice applications.


### PR DESCRIPTION
Adds **session-hq** to Workflow Orchestration.

- Repo: https://github.com/lji151/session-hq (MIT, v0.3.0)
- What it is: a shared, file-based headquarters for people who run several Claude Code sessions in parallel — one markdown status file per domain, injected at session start and checked at session end by hooks; an orchestrator session can dispatch work to domain sessions and review results; a one-page dashboard shows what is stale, blocked, or untouched.
- Also usable from other agent CLIs through a `wrap` command (agent-neutral Node CLI, no dependencies).
- Install: `claude plugin marketplace add lji151/session-hq` then `claude plugin install session-hq@session-hq`.

Entry follows the existing `- [name](url) - description` format. Thanks for maintaining the list.