### PR TITLE
Add swarmery to External Marketplaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 | Marketplace | Description | Install |
 |-------------|-------------|---------|
 | [ykdojo/claude-code-tips](https://github.com/ykdojo/claude-code-tips?tab=readme-ov-file#install-the-dx-plugin) | dx plugin: GitHub Actions analysis (`/gha`), conversation cloning (`/clone`, `/half-clone`), context handoffs (`/handoff`), Reddit fetching (`/reddit-fetch`) | `claude plugin marketplace add ykdojo/claude-code-tips` then `claude plugin install dx@ykdojo` |
+| [atretyak1985/swarmery](https://github.com/atretyak1985/swarmery) | swarmery: vendor-neutral agent framework — `core` (13 agents, 36 skills, 8 commands, hooks, project-aware workspace CLI) plus 11 opt-in domain packs (web, infra, IoT, UAV, Jira, architecture, design, LSP, knowledge graph, multi-account, Claude engineering). Pairs with a local-first control plane (single Go binary, dashboard on `:7777`) that indexes sessions, shows live tool calls and cost, queues permission prompts, and dispatches board tasks to headless agents in git worktrees | `claude plugin marketplace add atretyak1985/swarmery` then `claude plugin install core@swarmery` |
 
 
 ### Skills & Frameworks


### PR DESCRIPTION
Adds **swarmery** to the External Marketplaces table.

## What it is

A Claude Code plugin marketplace that ships one vendor-neutral agent framework to every project: `core` (13 agents, 36 skills, 8 commands, hooks, and a project-aware workspace CLI) plus 11 opt-in domain packs — web, infra, IoT, UAV, Jira, architecture, design, LSP, knowledge graph, multi-account, Claude engineering. Per-project flavor comes from the consumer's `.claude/project.json`; nothing project-specific is baked into the plugins.

The same repo carries a local-first control plane for Claude Code: a single Go binary that indexes the transcripts Claude Code already writes, shows live tool calls, cost and diffs, routes permission prompts to one approvals queue, and dispatches board tasks to headless agents in git worktrees. No cloud, no account, no telemetry.

Framework Apache-2.0; control plane PolyForm Noncommercial. `claude plugin validate .` passes.

## Install

```
claude plugin marketplace add atretyak1985/swarmery
claude plugin install core@swarmery
```

Demo (40 s): https://github.com/atretyak1985/swarmery/raw/main/docs/screenshots/demo.gif
