### PR TITLE
Add agentguard under Security, Compliance, & Legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [ai-divination-skills](./plugins/ai-divination-skills)
 
 ### Security, Compliance, & Legal
+- [agentguard](https://github.com/tainguyen091994/agentguard) - Scans agent extensions before install: skills, plugins, hooks, and MCP server configs. Detects prompt injection planted in SKILL.md, hardcoded credentials, curl-pipe-shell hooks, unpinned marketplace sources, and plaintext transport. 19 rules written as plain YAML with fixtures; runs as a CLI or a GitHub Action with SARIF output.
 - [ai-ethics-governance-specialist](./plugins/ai-ethics-governance-specialist)
 - [audit](./plugins/audit)
 - [compliance-automation-specialist](./plugins/compliance-automation-specialist)


### PR DESCRIPTION
Adds [agentguard](https://github.com/tainguyen091994/agentguard) to the **Security, Compliance, & Legal** section.

It scans agent extensions before you install them rather than scanning your application code. Targets are `SKILL.md` files, `plugin.json` and `marketplace.json` manifests, hook scripts, `settings.json`, and `.mcp.json`.

What the 19 rules catch, in short: prompt injection planted in a skill for the installing agent, credentials hardcoded into an MCP config, `curl | bash` inside a hook, hooks that read `~/.ssh` or `.env` and post them somewhere, marketplace sources with no pinned commit SHA, and plaintext transport.

It complements the scanners already listed here rather than overlapping them. `security-sweep` and `openclaw-security` look at workspaces and application code; agentguard reads the extension manifests themselves and is meant to run before install or in CI on a plugin repo.

- License: Apache-2.0
- Rules are plain YAML with a good and a bad fixture each, so the rule set is auditable without reading the TypeScript
- Output is human-readable or SARIF, so GitHub code scanning picks it up
- `npx @hachiman94/agentguard scan .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
