### PR TITLE
Add verdict — a skeptical QA agent with memory (Code Quality Testing)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -2316,6 +2316,38 @@
         "tokens",
         "audit"
       ]
+    },
+    {
+      "name": "verdict",
+      "displayName": "Verdict",
+      "source": {
+        "source": "github",
+        "repo": "ArtJack/verdict"
+      },
+      "description": "A skeptical QA agent with memory: baseline → delta runs (NEW/REGRESSED/RESOLVED), every red test classified, flaky tests quarantined with an expiry, and evidence-cited verdicts you can defend. Read-only on your code; ships a read-only MCP server, a CI release gate, and a scored eval suite with published misses.",
+      "version": "0.80.0",
+      "author": {
+        "name": "ArtJack",
+        "url": "https://github.com/ArtJack"
+      },
+      "category": "Code Quality Testing",
+      "homepage": "https://github.com/ArtJack/verdict",
+      "repository": "https://github.com/ArtJack/verdict",
+      "license": "MIT",
+      "keywords": [
+        "qa",
+        "testing",
+        "release-gate",
+        "regression",
+        "flaky-tests",
+        "mcp"
+      ],
+      "tags": [
+        "qa",
+        "testing",
+        "release-gate",
+        "regression"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [test-results-analyzer](./plugins/test-results-analyzer)
 - [test-writer-fixer](./plugins/test-writer-fixer)
 - [unit-test-generator](./plugins/unit-test-generator)
+- [verdict](https://github.com/ArtJack/verdict)
 - [vibe-guard](https://github.com/ofershap/vibe-guard) - Always-on security guardrails for AI-generated code
 - [think-first](https://github.com/ofershap/think-first) - Plan-before-code behavior modifier for agents
 - [sonmat](https://github.com/jun0-ds/sonmat) — Verification discipline plugin with six reactive axes (guard, inspect, witness, punch, devil's advocate, scribe) for AI-human collaboration.


### PR DESCRIPTION
Adds [verdict](https://github.com/ArtJack/verdict) under **Code Quality Testing**, referenced by GitHub source the same way `tree-ring-memory` and `trigger-tree` are, so the entry tracks the upstream repository rather than a vendored copy.

**What it is.** A Claude Code QA agent that keeps a baseline and reports what broke since the last run: findings with stable IDs and ages (`NEW / STILL_OPEN / RESOLVED / REGRESSED`), every red test classified (real defect / stale expectation / brittle / environment / flaky, quarantined with an expiry), and a verdict of `pass | pass with risks | blocked | fail` that always names what was not tested. Read-only on your code by construction: no Edit tool, write-scope hooks. Also ships a read-only MCP server over its state (`verdict-qa-mcp` on PyPI), an exit-code release gate for CI, and a scored eval suite with the misses published. It audits its own releases nightly.

MIT · Python 3.9+ · stdlib-only plugin · `claude plugin validate` passes. Install: `/plugin marketplace add ArtJack/verdict` then `/plugin install verdict@verdict`.