### PR TITLE
Add Market Brief funding and liquidity research plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [dna-claude-analysis](./plugins/dna-claude-analysis)
 - [experiment-tracker](./plugins/experiment-tracker)
 - [feedback-synthesizer](./plugins/feedback-synthesizer)
+- [market-brief](https://github.com/beepboop2025/market-brief) - Source-linked funding, capital-market and liquidity briefs with local change comparison. Free early access; the Python helper needs no API key.
 - [newsmcp](https://github.com/pranciskus/newsmcp) — Real-time world news for AI agents — events clustered from hundreds of sources, classified by 12 topics and 30+ geographic regions, ranked by importance. Free, no API key required.
 - [trend-researcher](./plugins/trend-researcher)
 - [wellnizz](./plugins/wellnizz)


### PR DESCRIPTION
Add [Market Brief](https://github.com/beepboop2025/market-brief) to Data Analytics. The plugin contains a skill and standard-library Python helper that build source-linked funding, capital-market and liquidity briefs and compare a user-supplied previous brief. It preserves observation dates and missing evidence.

The MIT code is public, with free early access and a [browser demo](https://beepboop2025.github.io/market-brief/). Python 3.10+ is required for the helper; no account, API key or broker connection is needed. Coverage does not include ticker news, portfolio recommendations or order execution. The optional Financial Evidence connector uses an existing MCP server.

Validation on release `v0.1.0` (`4b50c6d33f070d7a3db8a049e36cbded66cc55c7`): 31 Python tests, 23 JavaScript tests, strict Claude marketplace validation, and a live helper run passed. The public links return HTTP 200 and `git diff --check` passes. Existing listings and open/closed issues and PRs were checked for duplicates.
