### PR TITLE
Add Vetto: kernel sandbox companion app

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
+- [Vetto](https://github.com/shleder/vetto) — daemon-less kernel sandbox for Claude Code: `vetto enable claude` wraps the CLI so secret reads and off-allowlist network are denied (Apache-2.0, no Docker)
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)


### PR DESCRIPTION
Adds Vetto to companion apps / tools.

Vetto (https://github.com/shleder/vetto, Apache-2.0) — run Claude Code sandboxed with one command: `vetto enable claude && claude --dangerously-skip-permissions`. Kernel-enforced (Landlock/seccomp on Linux, Seatbelt on macOS): secret files and off-allowlist network are denied, destructive git commands blocked, every session ends with a security recap. Zero daemons, zero Docker.

Disclosure: I am the author/maintainer of Vetto.
