### PR TITLE
Add TranscriptFetch MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [WhichModel](https://github.com/Which-Model/whichmodel-mcp) — AI model pricing & recommendation MCP server for Claude Code. Helps choose the right model for every task at the best price. Cross-verified data updated every 4 hours. MCP endpoint: `https://whichmodel.dev/mcp`
 - [Synder Importer MCP](https://github.com/SynderAccounting/gl-importer-plugin) — Official Synder plugin. Import CSV/XLSX accounting data into QuickBooks Online or Xero via the [Synder Importer API](https://importer.synder.com). 19 MCP tools covering imports, field mapping rules, post-import rules, and entity discovery. Bundles the `gl-importer` agent skill.
 - [AgentIQ / MoltAd](https://github.com/chrisgu/agentiq-mcp) — Publisher MCP: list placements, `deliver_ad`, earn credits. https://moltad.net/publishers · https://moltad.net/mcp
+- [TranscriptFetch](https://github.com/TranscriptFetch/mcp-server) — Video and podcast transcripts for Claude: YouTube, TikTok, Instagram and direct media URLs, with automatic transcription when a video has no captions. Remote MCP `https://transcriptfetch.com/mcp` or `npx -y transcriptfetch-mcp`
 
 ### Thinking & Knowledge Management
 - [thinking-tree](https://github.com/CoralLips/thinking-tree)


### PR DESCRIPTION
Adds TranscriptFetch to the MCP Servers section.

An MCP server that gives Claude Code transcripts for YouTube, TikTok and Instagram videos, podcasts and direct media URLs. Videos without a caption track are transcribed automatically. Runs as a remote server (`claude mcp add --transport http transcriptfetch https://transcriptfetch.com/mcp`) or locally with `npx -y transcriptfetch-mcp`. Five tools: `get_transcript`, `search_videos`, `list_channel_videos`, `list_playlist_videos`, `get_credits`.

Repo: https://github.com/TranscriptFetch/mcp-server (MIT). Disclosure: I maintain it.
