### PR TITLE
Add config-drift-checker to Code Quality Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [code-review](./plugins/code-review)
 - [code-review-assistant](./plugins/code-review-assistant)
 - [code-reviewer](./plugins/code-reviewer)
+- [config-drift-checker](https://github.com/jameskomo/config-drift-checker) - CI for your Claude Code setup: turns CLAUDE.md, skills and hooks into eval cases, re-runs them on every Claude Code release and PR, and diffs against a pinned baseline with noise-aware verdicts.
 - [database-performance-optimizer](./plugins/database-performance-optimizer)
 - [debug-session](./plugins/debug-session)
 - [debugger](./plugins/debugger)


### PR DESCRIPTION
Adding my project, config-drift-checker: CI for a repo's Claude Code setup. It turns CLAUDE.md, skills and hooks into eval cases, re-runs them on every Claude Code release and on PRs that touch the config, and diffs against a pinned baseline with noise-aware verdicts so judge flakiness doesn't cause false alarms.

To show it catches real breakage there is a published self-sabotage demo: a deliberately broken skill trigger takes the suite from 1.00 to 0.36 with the tripwire case at 0.00 (https://jameskomo.github.io/config-drift-checker/example-break/report.html).

Placed under Code Quality Testing in alphabetical order. Happy to adjust format or section if you prefer.