### PR TITLE
Add fin-skills marketplace (Marketplaces)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -232,6 +232,7 @@
 
 ## 插件市场
 - [protonium](https://github.com/protonium-labs/protonium-marketplace) —— AI 智能体与效率工具。包含 **AxiomCore**：项目与日常事务管理智能体，提供强制化结构（编号目录、任务 ID、wiki 记忆）、计划 → 确认 → 执行工作流，支持敏捷或 WBS 方式创建项目.
+- [fin-skills](https://github.com/howard-lynn-ye/fin-skills) —— 七个插件、共 53 个 Agent Skills，面向 Python 量化金融：行情数据、回测、期权、加密货币、A 股、LLM 交易智能体；每条结论均注明核验日期，并标记为已验证、二手来源或未验证。安装：`/plugin marketplace add howard-lynn-ye/fin-skills`。MIT。
 
 ## 使用教程
 

--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ Example:
 
 - [AgentStore](https://github.com/techgangboss/agentstore) - Open-source plugin marketplace with gasless USDC payments. Install via `/plugin marketplace add techgangboss/agentstore`. Publishers earn 80% of sales. Agent-first API for zero-auth publishing.
 - [protonium](https://github.com/protonium-labs/protonium-marketplace) — AI agents and productivity tools. Includes **AxiomCore**, a project & routine management agent: enforced structure (numbered folders, task IDs, wiki memory), plan → approve → execute workflow, agile or WBS project creation.
+- [fin-skills](https://github.com/howard-lynn-ye/fin-skills) - Seven plugins with 53 Agent Skills for Python quantitative finance: market data, backtesting, options, crypto, China A-shares, LLM trading agents; every claim is dated and marked verified, secondhand, or unverified. Install via `/plugin marketplace add howard-lynn-ye/fin-skills`. MIT.
 
 ## Contributing
 


### PR DESCRIPTION
Adds the fin-skills marketplace to Marketplaces in README.md and 插件市场 in README-zh.md (both files, as in #318).
Seven plugins / 53 Agent Skills for Python quantitative finance (market data, backtesting, options, crypto, China A-shares, LLM trading agents); every claim is dated and marked verified, secondhand, or unverified. MIT.
Install: `/plugin marketplace add howard-lynn-ye/fin-skills` then `/plugin install fin-core@fin-skills`.
Disclosure: I'm the author.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
