### PR TITLE
docs: add cue-omni-reader under Skills & Frameworks

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -23,6 +23,8 @@
     - [安全、合规与法律](#安全、合规与法律)
     - [MCP 服务器](#mcp-服务器)
 * [插件市场](#插件市场)
+* [外部市场](#外部市场)
+    - [Skills 与框架](#skills-与框架)
 * [使用教程](#使用教程)
 * [如何贡献](#如何贡献)
 
@@ -232,6 +234,14 @@
 
 ## 插件市场
 - [protonium](https://github.com/protonium-labs/protonium-marketplace) —— AI 智能体与效率工具。包含 **AxiomCore**：项目与日常事务管理智能体，提供强制化结构（编号目录、任务 ID、wiki 记忆）、计划 → 确认 → 执行工作流，支持敏捷或 WBS 方式创建项目.
+
+## 外部市场
+
+社区维护的插件市场，可自行添加以获取更多插件。
+
+### Skills 与框架
+- [aurakit](https://github.com/smorky850612/Aurakit) — 一体化 Claude Code skill：46 种模式、23 个子智能体、6 层 OWASP 安全、10 个生命周期钩子，约 55% token 节省。跨平台（Codex、Cursor、Manus、Windsurf）。安装：`npx @smorky85/aurakit`
+- [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) — 把网页、PDF、录音或本地视频收成 Markdown，再进入后续 agent 流程。MIT。`npx skills add sensedeal/cue-skills --skill cue-omni-reader`
 
 ## 使用教程
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ### Skills & Frameworks
 - [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
-- [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) — Instruction-only agent skill that plugs into any AI agent (Claude Code, Codex CLI, Gemini CLI, WorkBuddy, etc.) to drive the official Cue Omni Reader MCP to parse an HTTP(S) URL or an authorized local document, audio, or video source into Markdown. Native loading on WorkBuddy is still marked unverified upstream (see `references/compatibility.md`). MIT. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader`
+- [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) — Turn a web page, PDF, recording, or local video into Markdown before the rest of the agent workflow. MIT. `npx skills add sensedeal/cue-skills --skill cue-omni-reader`
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ### Skills & Frameworks
 - [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
+- [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) — Instruction-only agent skill that drives the official Cue Omni Reader MCP to parse an HTTP(S) URL or an authorized local document, audio, or video source into Markdown. Works across Claude Code, Codex CLI, Gemini CLI, WorkBuddy and other agents. MIT. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader`
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ### Skills & Frameworks
 - [aurakit](https://github.com/smorky850612/Aurakit) — All-in-one Claude Code skill: 46 modes, 23 sub-agents, 6-layer OWASP security, 10 lifecycle hooks, ~55% token savings. Cross-platform (Codex, Cursor, Manus, Windsurf). Install: `npx @smorky85/aurakit`
-- [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) — Instruction-only agent skill that drives the official Cue Omni Reader MCP to parse an HTTP(S) URL or an authorized local document, audio, or video source into Markdown. Works across Claude Code, Codex CLI, Gemini CLI, WorkBuddy and other agents. MIT. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader`
+- [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) — Instruction-only agent skill that plugs into any AI agent (Claude Code, Codex CLI, Gemini CLI, WorkBuddy, etc.) to drive the official Cue Omni Reader MCP to parse an HTTP(S) URL or an authorized local document, audio, or video source into Markdown. Native loading on WorkBuddy is still marked unverified upstream (see `references/compatibility.md`). MIT. Install: `npx skills add sensedeal/cue-skills --skill cue-omni-reader`
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.


### PR DESCRIPTION
> **Disclosure:** I'm a maintainer of [sensedeal/cue-skills](https://github.com/sensedeal/cue-skills) (MIT). This PR adds a note pointing to cue-omni-reader, which I help maintain.

Skills & Frameworks currently lists orchestration kits. A very common Claude Code job is still missing: **get a page / PDF / recording / local video into Markdown** before the rest of the workflow.

Same list item in `README.md` and `README-zh.md` (外部市场 / Skills 与框架), same shape as `aurakit`, MIT:

```
npx skills add sensedeal/cue-skills --skill cue-omni-reader
```
