### PR TITLE
Add tokenchit to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Community-maintained plugin marketplaces you can add to access additional plugin
 
 ## Resources
 - [Claudebin](https://claudebin.com) ([GitHub](https://github.com/wunderlabs-dev/claudebin.com/)) - A minimalistic tool for publishing and sharing Claude coding sessions.
+- [tokenchit](https://tokenchit.app) ([GitHub](https://github.com/iyashjayesh/tokenchit)) - Parses local Claude Code, Codex and OpenCode logs and renders a token-usage card you commit to your repo, with an opt-in public leaderboard.
 
 ## Tutorials
 


### PR DESCRIPTION
Adds [tokenchit](https://tokenchit.app) to the Resources section, alongside Claudebin.

tokenchit is a CLI that reads your local Claude Code, Codex and OpenCode logs and renders an SVG stat card you commit into your README — a file in your repo rather than a hosted endpoint, so the card keeps working if the site does not. Parsing happens entirely on your machine; no prompts or code are read or transmitted. Publishing to the public leaderboard is a separate opt-in command.

- Repo: https://github.com/iyashjayesh/tokenchit (MIT)
- Install: `npx -y @tokenchit/cli@latest generate`

Placed under Resources rather than a plugin category because it is a standalone CLI, not a Claude Code plugin — the same shape as the existing Claudebin entry.