### PR TITLE
Add Sillage

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 
 ### Companion Apps & Tools
 - [Onepilot](https://onepilotapp.com) — iOS app to SSH into remote servers and run Claude Code from your phone
+- [Sillage](https://github.com/MarlBurroW/sillage) - Self-hosted, mobile-first web UI that drives the Claude Code and Codex CLIs on your own machine, with sessions that outlive the client, full-text search, an IDE panel, and an installable PWA. Single Docker container.
 
 ### Knowledge Management
 - [bedrock](./plugins/bedrock)


### PR DESCRIPTION
Adds Sillage to the Companion Apps & Tools section, right next to Onepilot.

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs running on your own machine (it replaces the terminal, not the agent). Sessions that outlive the client, full-text search over every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.

Repo: https://github.com/MarlBurroW/sillage

Disclosure: I am the author of Sillage.