### PR TITLE
Add pit-stop to Code Quality Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [adamsreview](./plugins/adamsreview)
 - [slicewise](./plugins/slicewise)
 - [bullpen](./plugins/bullpen)
+- [pit-stop](https://github.com/Finn763/pit-stop) - One instruction runs a full codebase improvement loop: find → fix → verify → report, every finding with path:line evidence.
 
 ### Communication & Integrations
 - [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) — WhatsApp channel plugin for Claude Code. Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control.


### PR DESCRIPTION
Add [Finn763/pit-stop](https://github.com/Finn763/pit-stop): one-line instruction runs a full codebase improvement loop (read → find → fix → verify → report) with evidence-before-claims reporting. Cross-runtime (Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Hermes, Pi). Install: `npx skills add Finn763/pit-stop`.