### PR TITLE
Add handrail (fail-closed deny/ask hooks) to Security, Compliance, & Legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [compliance-automation-specialist](./plugins/compliance-automation-specialist)
 - [data-privacy-engineer](./plugins/data-privacy-engineer)
 - [enterprise-security-reviewer](./plugins/enterprise-security-reviewer)
+- [handrail](https://github.com/trimkeep/claude-plugins) - Fail-closed deny/ask hooks for Claude Code and other agent CLIs; marketplace `trimkeep`, install `handrail@trimkeep`.
 - [security-sweep](https://github.com/Onome-AJ/security-sweep-plugin) - Comprehensive security scanner covering OWASP Top 10 (2025), Mobile Top 10 (2024), and LLM Top 10 (2025). Scans for hardcoded secrets, injection flaws, auth issues, misconfigurations, AI-specific vulnerabilities, mobile security, and data exposure.
 - [legal-advisor](./plugins/legal-advisor)
 - [legal-compliance-checker](./plugins/legal-compliance-checker)


### PR DESCRIPTION
Adds the handrail plugin (marketplace repo trimkeep/claude-plugins; source and tests at trimkeep/handrail-kit) under Security, Compliance, & Legal.

Six deny/ask rules for Claude Code hooks that fail closed on malformed input and only tighten existing permissions. MIT.

Disclosure: I maintain this project. Handrail is not affiliated with, endorsed by, or a product of Anthropic.