### PR TITLE
Add claudenews to Development Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [skill-auto-installer](./plugins/skill-auto-installer)
 - [tldr](./plugins/tldr)
 - [Imagine](https://github.com/freestyler-arb/imagine-gemini-for-claude-codex) - Brings Google Gemini into Claude Code & Codex: delegate reasoning, independent code review, deep research, and automatic prompt-engineering. Runs on your Google AI Pro subscription, not your agent's tokens.
+- [claudenews](https://github.com/bhpark1013/claudenews) - Developer news in the Claude Code status line while the agent works: Hacker News, GitHub Trending, and per-language sources, with optional translation and short summaries.
 
 ### Documentation
 - [analyze-codebase](./plugins/analyze-codebase)


### PR DESCRIPTION
Adds [claudenews](https://github.com/bhpark1013/claudenews) to **Development Engineering**, alongside the other status line entries such as `cc-hud`.

Developer news in the Claude Code status line while the agent works — Hacker News, GitHub Trending, and per-language sources, with optional translation and short summaries.

- MIT licensed
- Actively maintained since April 2026 (currently v0.24.1)
- Uses the official `statusLine` API; patches nothing in Claude Code

Entry follows the existing external-repo format used in this section. Single line added, no other changes.

https://claude.ai/code/session_013ZS4io8TJKUivqTbBpTPdy