### PR TITLE
Add me-review: M&E document reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [agent-decision-record](./plugins/agent-decision-record)
 - [product-org-os](./plugins/product-org-os)
 - [governor](https://github.com/0xhimanshu/governor)
+- [me-review](https://github.com/monitoringevaluationstudio/me-review) - Twelve structured monitoring and evaluation document reviews: logframes, theories of change, indicators, evaluation TORs, M&E plans, proposals, sampling plans, surveys, baseline and progress reports, data quality assessments, and evaluation reports. Each returns section-by-section PASS/PARTIAL/FAIL ratings, a verdict, and prioritized recommendations. Pure Markdown, MIT.
 
 ### Lifestyle & Entertainment
 - [ai-divination-skills](./plugins/ai-divination-skills)


### PR DESCRIPTION
Adds [me-review](https://github.com/monitoringevaluationstudio/me-review) under **Project & Product Management**.

**What it does.** Twelve structured document reviews for monitoring and evaluation work: logframes, theories of change, indicators, evaluation TORs, M&E plans, proposal M&E sections, sampling plans, survey instruments, baseline reports, progress reports, data quality assessments, and final evaluation reports. Paste a document, get section-by-section PASS/PARTIAL/FAIL ratings, a summary verdict, and prioritized recommendations.

**Why it might interest this list.** It is the only monitoring and evaluation plugin in the ecosystem. The audience is people working in international development, foundations and nonprofits, which is not otherwise represented here.

**Safety surface.** No hooks, no MCP servers, no executables, no `bin/` directory. Pure Markdown skills and commands plus a manifest. MIT licensed. `claude plugin validate` passes.

I maintain the plugin under the `monitoringevaluationstudio` org; this PR is from my other account.

Happy to move it to a different section if Project & Product Management is not the right fit.