### PR TITLE
Add why-isnt-it-selling to Marketing Growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ Install or disable them dynamically with the `/plugin` command — enabling you 
 - [tiktok-strategist](./plugins/tiktok-strategist)
 - [toprank](./plugins/toprank)
 - [twitter-engager](./plugins/twitter-engager)
+- [why-isnt-it-selling](https://github.com/maxxthemate-png/why-isnt-it-selling) - Diagnose why a shipped product is not selling; five triage questions to one failure mode, ranked moves with a source URL each, plus the graveyard of 11 growth tactics that failed adversarial refutation
 - [wondelai-skills](https://github.com/wondelai/skills)
 - [agentkits-marketing](./plugins/agentkits-marketing)
 - [claude-code-marketing-skills](https://github.com/cognyai/claude-code-marketing-skills) - AI marketing skills: SEO Audit, Landing Page Review, Competitor Analysis, Ad Copy Writer, Lead Qualification. 5 free + premium via Cogny MCP


### PR DESCRIPTION
Adds [why-isnt-it-selling](https://github.com/maxxthemate-png/why-isnt-it-selling) to **Marketing Growth**, placed alphabetically as an external link.

An MIT-licensed plugin for the moment after the build works and nobody is buying. It asks five questions the repo cannot answer (paying customers, real traffic, whether a stranger ever completed the core action, what distribution was actually sent, whether anyone can pay today), names one failure mode, and returns ranked moves with a source URL on every claim.

What makes it different from general growth advice: it is generated from 3,549 evidence clusters distilled from YouTube, podcasts, GitHub, Reddit, Indie Hackers and dev.to, and it ships the negative result. Twenty candidate patterns went through adversarial refutation and eleven died. All eleven are included with what killed them, so it is as clear about what not to do as what to do. One of them is app-store optimization, which is also in this section, and the plugin says so rather than quietly agreeing with the list it is joining.

No shell access and no network tools: the skill declares `allowed-tools: Read, Glob, Grep, AskUserQuestion`, so nothing phones home. `claude plugin validate . --strict` passes clean, and it installs and runs end to end via `/plugin marketplace add maxxthemate-png/why-isnt-it-selling`.